### PR TITLE
Add RENEEB to author.json

### DIFF
--- a/conf/author.json
+++ b/conf/author.json
@@ -27,5 +27,19 @@
     "twitter_username": "wundercounter",
     "blog_url": "http://blogs.perl.org/users/olaf_alders/",
     "blog_feed": "http://blogs.perl.org/users/olaf_alders/atom.xml"
+  },
+  "RENEEB": {
+    "blog_feed": "http://reneeb-perlblog.blogspot.com/feeds/posts/default",
+    "blog_url": "http://reneeb-perlblog.blogspot.com",
+    "github_username": "reneeb",
+    "website": "http://perl-magazin.de",
+    "linkedin_public_profile": "http://de.linkedin.com/in/reneebaecker",
+    "perlmongers" : "Frankfurt.pm",
+    "perlmongers_url" : "http://frankfurt.perlmongers.de",
+    "twitter_username" : "reneeb_perl",
+    "slideshare_username" : "reneebperl",
+    "irc_nick" : "reneeb",
+    "perlmonks_username" : "reneeb",
+    "country": "Germany"
   }
 }


### PR DESCRIPTION
Hi,

I added some info about RENEEB to author.json. I also added the new fields "perlmongers", "perlmongers_url" and "slideshare_username" to the datastructure.

I think these fields can be useful, too.
- Renée
