### PR TITLE
Support content-type of application/x-perl for /pod/* URLs

### DIFF
--- a/lib/MetaCPAN/Plack/Pod.pm
+++ b/lib/MetaCPAN/Plack/Pod.pm
@@ -56,6 +56,9 @@ sub handle {
     } elsif($accept eq 'text/x-markdown') {
       $body = $self->build_pod_markdown( $content );
       $content_type = 'text/plain';
+    } elsif($accept eq 'application/x-perl') {
+      $body = $content;
+      $content_type = 'application/x-perl';
     } else {
       $body = $self->build_pod_html( $content );
       $content_type = 'text/html';


### PR DESCRIPTION
 I want this for http://beta.metacpan.org/module/Pod::Cpandoc

The alternative is two requests, the first to figure out the right author/dist-version string, and the second to use it.
