### PR TITLE
Fix Gravatar URL: use only pauseid@cpan.org address

### DIFF
--- a/lib/MetaCPAN/Document/Author.pm
+++ b/lib/MetaCPAN/Document/Author.pm
@@ -128,18 +128,18 @@ sub _build_dir {
 
 sub _build_gravatar_url {
     my $self = shift;
-    my $email = ref $self->email ? $self->email->[0] : $self->email;
+    # We do not use the author personal address ($self->email[0])
+    # because we want to show the author's CPAN identity.
+    # Using another e-mail than the CPAN one removes flexibility for
+    # the author and ultimately could be a privacy leak.
+    # The author can manage this identity both on his gravatar account
+    # (by assigning an image to his author@cpan.org)
+    # and now by changing this URL from metacpa.org
     return Gravatar::URL::gravatar_url(
-        email   => $email,
+        email   => $self->{pauseid} . '@cpan.org',
         size    => 130,
-        default => Gravatar::URL::gravatar_url(
-
-            # Fallback to the CPAN address, as used by s.c.o, which will in
-            # turn fallback to a generated image.
-            email   => $self->{pauseid} . '@cpan.org',
-            size    => 130,
-            default => 'identicon',
-        )
+        # Fallback to a generated image
+        default => 'identicon',
     );
 }
 


### PR DESCRIPTION
Only use the CPAN e-mail address (pauseid@cpan.org) because we are using the gravatar URL to show the author's CPAN identity. Using only the pauseid@cpan.org allows the author to use his Gravatar account to assign his own image for his CPAN identity.

The previous code used the first email in the profile (which usually is the final
destination of the @cpan.org address) but the author may want to use it for
others purpose. By using only the @cpan.org address, the author has to explicitely assign an image to this account so this protect his privacy better.

(By the way, this could make initial Gravatar slightly display faster as we
drop a Gravatar fallback.)
