### PR TITLE
Alter download url for backpan status

### DIFF
--- a/lib/MetaCPAN/Document/Release.pm
+++ b/lib/MetaCPAN/Document/Release.pm
@@ -111,7 +111,9 @@ sub _build_version_numified {
 
 sub _build_download_url {
     my $self = shift;
-    'http://cpan.cpantesters.org/authors/'
+    ($self->status eq 'backpan'
+        ? 'http://backpan.perl.org/authors/'
+        : 'http://cpan.cpantesters.org/authors/')
         . MetaCPAN::Document::Author::_build_dir( $self->author ) . '/'
         . $self->archive;
 }


### PR DESCRIPTION
cpan.cpantesters.org doesn't mirror backpan releases.

The "Download" link on metacpan-web is broken when looking at a backpan release.

I think this url change is accurate (are there other backpan mirrors?)
but I don't know if this change is appropriate/sufficient/etc.
I still have much to learn of the overall workings of metacpan.
