### PR TITLE
try to tidy up diffs by disabling copy+rename detection.

### DIFF
--- a/lib/MetaCPAN/Server/Diff.pm
+++ b/lib/MetaCPAN/Server/Diff.pm
@@ -13,7 +13,7 @@ has relative => ( is => 'ro', required => 1 );
 sub _build_raw {
     my $self = shift;
     my $raw = "";
-    run3([$self->git, qw(diff -C -z --no-index -u --no-color --numstat), "--relative=" . $self->relative, $self->source, $self->target], undef, \$raw);
+    run3([$self->git, qw(diff --no-renames -z --no-index -u --no-color --numstat), "--relative=" . $self->relative, $self->source, $self->target], undef, \$raw);
     (my $stats = $raw ) =~ s/^([^\n]*\0).*$/$1/s;
     $self->numstat($stats);
     $raw = substr($raw, length($stats));


### PR DESCRIPTION
When I was browsing the diff for Geo-Coder-Google [1], I noticed it seemed odd in spots. For example, the diff for t/01_v2_live.t is blank.

By disabling copy and rename detection, the diffs for renames become full deletes and a new file. This should look a little cleaner on the site.

[1] https://metacpan.org/diff/release/MIYAGAWA/Geo-Coder-Google-0.06/ARCANEZ/Geo-Coder-Google-0.07
