### PR TITLE
Allow non-JSON content (e.g.: POD) to be delivered via JSONP

### DIFF
--- a/lib/MetaCPAN/Server/View/JSONP.pm
+++ b/lib/MetaCPAN/Server/View/JSONP.pm
@@ -1,14 +1,20 @@
 package MetaCPAN::Server::View::JSONP;
 use Moose;
 use Encode qw(decode_utf8);
+use JSON::XS qw();
 extends 'Catalyst::View';
 
 sub process {
     my ($self, $c) = @_;
     return 1 unless(my $cb = $c->req->params->{callback});
-    $c->res->body(
-        "$cb(" . decode_utf8($c->res->body) . ");"
-    );
+    my $body = decode_utf8($c->res->body);
+    my $content_type = $c->res->content_type;
+    if($content_type ne 'application/json') {
+        if(my($key) = $content_type =~ m{^text/(.*)$}) {
+            $body = JSON::XS->new->utf8->encode({ $key => $body });
+        }
+    }
+    $c->res->body( "$cb($body);" );
     return 1;
 }
 


### PR DESCRIPTION
Without this patch, a JSONP request like http://api.metacpan.org/pod/Acme::Orange?callback=my_func would result in the Javascript function wrapper being applied to the text/plain or text/html body.

This patch takes the text body and encodes it as a string in a JSON object before adding the JSONP callback function wrapper.  The object key name is determined from the original content type.
