### PR TITLE
Fix JSONP handling of /source URLs

### DIFF
--- a/lib/MetaCPAN/Server/View/JSONP.pm
+++ b/lib/MetaCPAN/Server/View/JSONP.pm
@@ -7,7 +7,12 @@ extends 'Catalyst::View';
 sub process {
     my ($self, $c) = @_;
     return 1 unless(my $cb = $c->req->params->{callback});
-    my $body = decode_utf8($c->res->body);
+    my $body = $c->res->body;
+    if( ref($body) ) {
+        local($/);
+        $body = <$body>;
+    }
+    $body = decode_utf8($body);
     my $content_type = $c->res->content_type;
     return 1 if($content_type eq 'text/javascript');
     if($content_type ne 'application/json') {

--- a/t/server/controller/source.t
+++ b/t/server/controller/source.t
@@ -7,6 +7,8 @@ use MetaCPAN::Server::Test;
 my %tests = (
     '/source/DOESNEXIST'      => 404,
     '/source/DOY/Moose-0.01/' => 200,
+    '/source/DOY/Moose-0.01/MANIFEST'              => 200,
+    '/source/DOY/Moose-0.01/MANIFEST?callback=foo' => 200,
     '/source/Moose'           => 200,
 );
 
@@ -21,6 +23,26 @@ test_psgi app, sub {
                 'text/plain; charset=UTF-8',
                 'Content-type'
             );
+        }
+        elsif ( $k =~ /MANIFEST/ ) {
+            my $manifest = "MANIFEST\nlib/Moose.pm\nMakefile.PL\n"
+                         . "META.yml\nt/00-nop.t";
+            if( $k =~ /callback=foo/ ) {
+                ok( my( $function_args ) = $res->content =~ /^foo\((.*)\)/s, 'JSONP wrapper');
+                ok( my $jsdata = JSON->new->allow_nonref->decode( $function_args ), 'decode json' );
+                is( $jsdata, $manifest, 'JSONP-wrapped manifest' );
+                is( $res->header('content-type'),
+                    'text/javascript; charset=UTF-8',
+                    'Content-type'
+                );
+            }
+            else {
+                is( $res->content, $manifest, 'Plain text manifest' );
+                is( $res->header('content-type'),
+                    'text/plain; charset=UTF-8',
+                    'Content-type'
+                );
+            }
         }
         elsif ( $v eq 200 ) {
             like( $res->content, qr/Index of/, 'Index of' );


### PR DESCRIPTION
The JSONP view handler is failing for /source URLs due to the response body being an IO::File object when the code assumed it was a string.

So for example, this URL:

```
http://api.metacpan.org/source/DOY/Moose-2.0402/MANIFEST?callback=foo
```

Yields a response body like this:

```
foo("IO::File=GLOB(0x5e84828)");
```

The fix in this patch simply slurps the filehandle before adding the JSONP function wrapper.  I guess that could potentially be a problem for delivering huge files (although my interest is primarily in using the API to get the MANIFEST and the change log).
