### PR TITLE
Ignore metacpan_server_local.conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /var/log/metacpan.*
 /t/var/tmp/
 /etc/metacpan_local.pl
+metacpan_server_local.conf


### PR DESCRIPTION
The docs for installation (https://github.com/CPAN-API/cpan-api/wiki/Installation) talk about creating your own  metacpan_server_local.conf file. This just makes git ignore that file if you have one.
