### PR TITLE
Ignore metacpan_server_local.conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /var/log/metacpan.*
 /t/var/tmp/
 /etc/metacpan_local.pl
+metacpan_server_local.conf


### PR DESCRIPTION
The installation docs (https://github.com/CPAN-API/cpan-api/wiki/Installation) recommend creating a metacpan_server_local.conf file. So we should ignore it by default if the user does create it.
