### PR TITLE
Prepend 404 messages with a "Not found: " string, fill in an error (or t...

### DIFF
--- a/lib/MetaCPAN/Server/Controller/Root.pm
+++ b/lib/MetaCPAN/Server/Controller/Root.pm
@@ -12,7 +12,7 @@ sub default : Path {
 sub not_found : Private {
     my ( $self, $c, $message ) = @_;
     $c->clear_stash;
-    $c->stash( { message => $message || 'Not found' } );
+    $c->stash( { message => "Not found: " . ($message || "No error...") } );
     $c->response->status(404);
     $c->forward($c->view('JSON'));
 }

--- a/t/server/controller/pod.t
+++ b/t/server/controller/pod.t
@@ -11,7 +11,7 @@ $fh->close;
 my %tests = (
 
     # TODO
-    #'/pod'                             => 404,
+    #'/pod'                            => 404,
     '/pod/DOESNEXIST'                  => 404,
     '/pod/Moose'                       => 200,
     '/pod/DOY/Moose-0.01/lib/Moose.pm' => 200,
@@ -32,7 +32,7 @@ test_psgi app, sub {
         );
         if($k eq '/pod/Pod::Pm') {
             like( $res->content, qr/Pod::Pm - abstract/, 'NAME section' );
-        } elsif ( $v eq 200 ) {
+        } elsif ( $v == 200 ) {
             like( $res->content, qr/Moose - abstract/, 'NAME section' );
             ok( $res = $cb->( GET "$k?content-type=text/plain" ),
                 "GET plain" );
@@ -40,6 +40,8 @@ test_psgi app, sub {
                 'text/plain; charset=UTF-8',
                 'Content-type'
             );
+        } elsif ( $v == 404 ) {
+            like( $res->content, qr/Not found: (\w+)/, "404 correct error");
         }
         
         my $ct = $k =~ /Moose[.]pm$/ ? '&content-type=text/x-pod' : '';


### PR DESCRIPTION
...he class name) if present.
