### PR TITLE
Fix issue #476

### DIFF
--- a/lib/MetaCPAN/Document/File.pm
+++ b/lib/MetaCPAN/Document/File.pm
@@ -369,6 +369,16 @@ sub _build_abstract {
     my $text = ${ $self->content };
     my ( $documentation, $abstract );
     my $section = MetaCPAN::Util::extract_section( $text, 'NAME' );
+
+    # if it's a POD file without a name section, let's try to generate
+    # an abstract and name based on filename
+    if( !$section && $self->path =~ /\.pod$/ ) {
+        $section = $self->path;
+        $section =~ s{^lib/}{};
+        $section =~ s{\.pod$}{};
+        $section =~ s{/}{::}g;
+    }
+
     return undef unless ($section);
     $section =~ s/^=\w+.*$//mg;
     $section =~ s/X<.*?>//mg;


### PR DESCRIPTION
If we don't have a NAME section in the POD and it's a .pod file
we can autogenerate a name based on the file path. So that
something like My/Project/Tutorial.pod becomes My::Project::Tutorial.
This fixes issue #476
