### PR TITLE
Adding "metacpan check" command

### DIFF
--- a/lib/MetaCPAN/Script/Check.pm
+++ b/lib/MetaCPAN/Script/Check.pm
@@ -36,6 +36,13 @@ has max_errors => (
     documentation => 'the maximum number of errors to encounter before stopping',
 );
 
+has errors_only => (
+    is            => 'ro',
+    isa           => 'Bool',
+    default       => 0,
+    documentation => 'just show errors',
+);
+
 has error_count => (
     is      => 'rw',
     isa     => 'Int',
@@ -135,7 +142,8 @@ sub check_modules {
                 # if we found the releases tell them about it
                 if (@releases) {
                     if (@releases == 1 && $releases[0]->{fields}->{status} eq 'latest') {
-                        log_info { "Found latest release $releases[0]->{fields}->{name} for $pkg" };
+                        log_info { "Found latest release $releases[0]->{fields}->{name} for $pkg" }
+                        unless $self->errors_only;
                     } else {
                         log_error { "Could not find latest release for $pkg" };
                         foreach my $rel (@releases) {


### PR DESCRIPTION
This is a basic first draft to make it easier to see what info we have
in the elasticsearch index for modules. Can be extended later to
include releases, authors, files, etc. 

This developed out of a conversation I had with Olaf at #perlqa2012

You can test it out with commands like this:

```
# check on HTML::Template
metacpan check --modules --module HTML::Template

# check on all the modules in 02packages to see if they are in elasticsearch
metacpan check --modules

# just look for the first 10 missing modules
metacpan check --modules --max_errors 10 --errors_only 
```
