### PR TITLE
render POD parse errors section on request

### DIFF
--- a/lib/MetaCPAN/Pod/XHTML.pm
+++ b/lib/MetaCPAN/Pod/XHTML.pm
@@ -31,6 +31,58 @@ sub end_item_text   {
     $_[0]->emit;
 }
 
+# Custom handling of errata section
+
+sub _gen_errata {
+    return;   # override the default errata formatting
+}
+
+sub end_Document {
+    my $self = shift;
+    $self->_emit_custom_errata() if $self->{errata};
+    $self->SUPER::end_Document(@_);
+}
+
+sub _emit_custom_errata {
+    my $self = shift;
+
+    my $tag = sub {
+        my $name = shift;
+        my $attributes = '';
+        if(ref($_[0])) {
+            my $attr = shift;
+            while(my($k, $v) = each %$attr) {
+                $attributes .= qq{ $k="} . $self->encode_entities($v) . '"';
+            }
+        }
+        my @body = map { /^</ ? $_ : $self->encode_entities($_) } @_;
+        return join('', "<$name$attributes>", @body, "</$name>");
+    };
+
+    my @errors = map {
+        my $line = $_;
+        my $error = $self->{'errata'}->{$line};
+        (
+            $tag->('dt', "Around line $line:"),
+            $tag->('dd', map { $tag->('p', $_) } @$error),
+        );
+    } sort {$a <=> $b} keys %{$self->{'errata'}};
+
+    my $error_count = keys %{$self->{'errata'}};
+    my $s = $error_count == 1 ? '' : 's';
+
+    $self->{'scratch'} = $tag->('div',
+        { id => "pod-errors" },
+        $tag->('p', { class => 'title' }, "$error_count POD Error$s"),
+        $tag->('div',
+            { id => "pod-error-detail" },
+            $tag->('p', 'The following errors were encountered while parsing the POD:'),
+            $tag->('dl', @errors),
+        ),
+    );
+    $self->emit;
+}
+
 1;
 
 =pod

--- a/lib/MetaCPAN/Server/View/Pod.pm
+++ b/lib/MetaCPAN/Server/View/Pod.pm
@@ -15,6 +15,7 @@ sub process {
     $content = eval { join("", $content->getlines) };
     my ($body, $content_type);
     my $accept = eval { $c->req->preferred_content_type } || 'text/html';
+    my $show_errors = $c->req->params->{show_errors};
     if($accept eq 'text/plain') {
       $body = $self->build_pod_txt( $content );
       $content_type = 'text/plain';
@@ -25,7 +26,7 @@ sub process {
       $body = $self->build_pod_markdown( $content );
       $content_type = 'text/plain';
     } else {
-      $body = $self->build_pod_html( $content );
+      $body = $self->build_pod_html( $content, $show_errors );
       $content_type = 'text/html';
     }
     $c->res->content_type($content_type);
@@ -40,13 +41,13 @@ sub build_pod_markdown {
 }
 
 sub build_pod_html {
-    my ( $self, $source ) = @_;
+    my ( $self, $source, $show_errors ) = @_;
     my $parser = MetaCPAN::Pod::XHTML->new();
     $parser->index(1);
     $parser->html_header('');
     $parser->html_footer('');
     $parser->perldoc_url_prefix('');
-    $parser->no_errata_section(1);
+    $parser->no_errata_section( !$show_errors );
     my $html = "";
     $parser->output_string( \$html );
     $parser->parse_string_document($source);

--- a/t/server/controller/pod.t
+++ b/t/server/controller/pod.t
@@ -67,4 +67,23 @@ test_psgi app, sub {
     }
 };
 
+test_psgi app, sub {
+    my $cb = shift;
+
+    my $path = '/pod/BadPod';
+    ok( my $res = $cb->( GET $path), "GET $path" );
+    is( $res->code, 200, "code 200" );
+    unlike( $res->content, qr/<div[^>]*id="pod-errors"/, 'no POD errors section' );
+
+    $path = '/pod/BadPod?show_errors=1';
+    ok( my $res = $cb->( GET $path), "GET $path" );
+    is( $res->code, 200, "code 200" );
+    like( $res->content, qr/<div[^>]*id="pod-errors"/, 'got POD errors section' );
+
+    my @err = $res->content =~ m{<dd.*?>(.*?)</dd>}sg;
+    is( scalar(@err), 2, "two parse errors listed ");
+    like( $err[0], qr/=head\b/, "first error mentions =head" );
+    like( $err[1], qr/C&lt;/, "first error mentions C< ... >" );
+};
+
 done_testing;

--- a/t/var/fakecpan/configs/badpod.json
+++ b/t/var/fakecpan/configs/badpod.json
@@ -1,0 +1,11 @@
+{
+  "name": "BadPod",
+  "abstract": "Distribution with malformed POD",
+  "X_Module_Faker": {
+    "cpan_author": "MO",
+    "append": [ {
+        "file": "lib/BadPod.pm",
+        "content": "\n\n=head1 NAME\n\nBadPod - Malformed POD\n\n=head SYNOPSIS\n\nThere is no C<more."
+    } ]
+  }
+}


### PR DESCRIPTION
This patchset provides the backend support for displaying POD parse errors. The errors will not be included unless the API request includes the `show_errors=1` querystring parameter.

For a mockup of the intended result see: http://www.mclean.net.nz/pod-parsing-errors/
