### PR TITLE
Update numify/fix version tests for latest version.pm

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -169,7 +169,7 @@ my %WriteMakefileArgs = (
     "strict" => 0,
     "strictures" => 1,
     "utf8" => 0,
-    "version" => 0,
+    "version" => '0.9901',
     "warnings" => 0,
   },
 

--- a/t/util.t
+++ b/t/util.t
@@ -9,7 +9,9 @@ is( MetaCPAN::Util::numify_version('010'),    10.000 );
 is( MetaCPAN::Util::numify_version('v2.1.1'), 2.001001 );
 is( MetaCPAN::Util::numify_version(undef),    0.000 );
 is( MetaCPAN::Util::numify_version('LATEST'), 0.000 );
-is( MetaCPAN::Util::numify_version('0.20_8'), 0.20008 );
+is( MetaCPAN::Util::numify_version('0.20_8'), 0.208 );
+is( MetaCPAN::Util::numify_version('0.20_88'), 0.200088 );
+is( MetaCPAN::Util::numify_version('0.208_8'), 0.208008 );
 is( MetaCPAN::Util::numify_version('0.20_108'), 0.2000108 );
 
 lives_ok { is(version("2a"), 2) };


### PR DESCRIPTION
Previously passing test for x.xx_x started failing
due to bugfix in latest version.pm release (rt-79259).

Does this look ok?
I didn't update the lib at all, just the failing test.

Do we need to update the lib or reindex or anything?
I'm not sure if this would really affect anything or not.
