### PR TITLE
Set 'first' to true if no releases *before* this one

### DIFF
--- a/lib/MetaCPAN/Document/Release.pm
+++ b/lib/MetaCPAN/Document/Release.pm
@@ -153,7 +153,12 @@ sub _build_first {
     my $self = shift;
     $self->index->type('release')
         ->filter(
-        { term => { 'release.distribution' => $self->distribution } } )->count
+        {
+            and => [
+                { term => { 'release.distribution' => $self->distribution } },
+                { range => { 'release.date' => { 'lt' => $self->date . '.000Z' } } }
+            ]
+        } )->count
         ? 0
         : 1;
 }


### PR DESCRIPTION
When indexing a release, the boolean value for 'first' is set to true if there's no other release with the same name. However if we re-index a release, this test will fail - i.e.: there will be a release with the same name in the index - unfortunately it's the one we're about to replace. So any release which is re-indexed will always get its 'first' field set to false.

This patch refines the search filter to only look for releases with an earlier date.  I wasn't sure of the approved way to format a date for ES so that part of the patch might need tweaking by someone more familiar with the code-base.
