### PR TITLE
Google authentication for MetaCPAN

### DIFF
--- a/lib/MetaCPAN/Server/Controller/Login/Google.pm
+++ b/lib/MetaCPAN/Server/Controller/Login/Google.pm
@@ -25,7 +25,6 @@ sub index : Path {
             ]
         );
 
-        warn $token_res->as_string;
         my $token_info = eval { decode_json($token_res->content) } || {};
 
         $c->controller('OAuth2')->redirect($c, error => $token_info->{error})
@@ -37,7 +36,6 @@ sub index : Path {
 
         my $user_res = $ua->request(
             GET "https://www.googleapis.com/oauth2/v1/userinfo?access_token=$token");
-        warn $user_res->as_string;
         my $user = eval { decode_json($user_res->content) } || {};
         $self->update_user($c, google => $user->{id}, $user);
     }


### PR DESCRIPTION
I believe this is pretty close to done. This is most, if not all, the changes required to implement issue #241. The only part I have not fully tested is the complete end-to-end integration with metacpan-web as there something in my sandbox setup that's keeping that from working at the moment. However, this will successfully authenticate against google and fetch a unique user ID for the user via the Google APIs.

For reference, you may want to read:
- https://developers.google.com/accounts/docs/OAuth2Login
- https://developers.google.com/accounts/docs/OAuth2WebServer

These are the relevant docs on how to implement Google's flavor of OAuth2. I tested using the "https://www.googleapis.com/auth/userinfo.profile" scope, which provides a unique user ID. It also grants access to the basic details of the user's Google+ profile. The other suggested scope is "https://www.googleapis.com/auth/userinfo.email" which might be preferred. Based on the information shared from Facebook with MetaCPAN, though, I suspect userinfo.profile is probably the way to go.

You will need to register MetaCPAN on the Google APIs Console:
- https://code.google.com/apis/console/

You'll need to setup the redirect URI as:
- https://api.metacpan.org/login/google

Other than that, I think the other settings are up to you. I think that's about it. Please send me an email (sterling at [my-last-name] .com) if you have questions. You can try to ping me on IRC as well, but I'm not on there or always paying attention.
