### PR TITLE
[WIP]skip broken files at indexing

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -55,6 +55,7 @@ requires 'File::Basename';
 requires 'File::Find';
 requires 'File::Find::Rule';
 requires 'File::Find::Rule::Perl';
+requires 'File::pushd';
 requires 'File::Spec';
 requires 'File::Spec::Functions';
 requires 'File::Temp';
@@ -134,6 +135,7 @@ requires 'Regexp::Common';
 requires 'Regexp::Common::time';
 requires 'Safe', '2.35'; # bug fixes (used by Parse::PMFile)
 requires 'Starman';
+requires 'Test::RequiresInternet';
 requires 'Time::Local';
 requires 'Throwable::Error';
 requires 'Try::Tiny';

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -3367,6 +3367,21 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 6.59
       Test::More 0.96
       perl 5.008008
+  File-pushd-1.009
+    pathname: D/DA/DAGOLDEN/File-pushd-1.009.tar.gz
+    provides:
+      File::pushd 1.009
+    requirements:
+      Carp 0
+      Cwd 0
+      Exporter 0
+      ExtUtils::MakeMaker 6.17
+      File::Path 0
+      File::Spec 0
+      File::Temp 0
+      overload 0
+      strict 0
+      warnings 0
   Filesys-Notify-Simple-0.12
     pathname: M/MI/MIYAGAWA/Filesys-Notify-Simple-0.12.tar.gz
     provides:
@@ -7174,6 +7189,15 @@ DISTRIBUTIONS
       Test::Builder::Module 0
       Test::More 0.61
       perl 5.008_001
+  Test-RequiresInternet-0.04
+    pathname: M/MA/MALLEN/Test-RequiresInternet-0.04.tar.gz
+    provides:
+      Test::RequiresInternet 0.04
+    requirements:
+      ExtUtils::MakeMaker 0
+      Socket 0
+      strict 0
+      warnings 0
   Test-Routine-0.018
     pathname: R/RJ/RJBS/Test-Routine-0.018.tar.gz
     provides:

--- a/t/script/release/skip_broken_files.t
+++ b/t/script/release/skip_broken_files.t
@@ -1,0 +1,57 @@
+use strict;
+use warnings;
+
+use Archive::Tar;
+use File::pushd;
+use FindBin;
+use HTTP::Request;
+use LWP::UserAgent;
+use MetaCPAN::Script::Release;
+use MetaCPAN::Script::Runner;
+use Test::More;
+use Test::RequiresInternet ( 'metacpan.org' => 443 );
+
+my $dir = tempd();
+
+my $ua = LWP::UserAgent->new(
+    agent      => 'metacpan',
+    env_proxy  => 1,
+    parse_head => 0,
+    timeout    => 30,
+);
+
+my $url
+    = 'https://cpan.metacpan.org/authors/id/S/SH/SHULL/karma-0.7.0.tar.gz';
+my $tarball = 'tarball.tar.gz';
+
+my $req = HTTP::Request->new( GET => $url );
+$req->header( Accept => '*/*' );
+my $res = $ua->request( $req, $tarball );
+
+my $arch = Archive::Tar->new;
+$arch->read($tarball);
+
+my $config = do {
+
+    # build_config expects test to be t/*.t
+    local $FindBin::RealBin = "$FindBin::RealBin/../..";
+    MetaCPAN::Script::Runner->build_config;
+};
+
+my $release = MetaCPAN::Script::Release->new($config);
+
+my $next = Archive::Tar->iter($tarball);
+while ( my $file = $next->() ) {
+    if ( $file->is_fifo ) {
+        ok(
+            $release->_is_broken_file($file),
+            $file->full_path . ' is a broken pipe'
+        );
+    }
+    elsif ( $file->is_symlink ) {
+        ok( $release->_is_broken_file($file),
+            $file->full_path . ' is a  broken symlink' );
+    }
+}
+
+done_testing();


### PR DESCRIPTION
Some tarballs contain broken symlinks or pipes that block the indexing process and by skipping those files, the indexer can run until completion. 
