### PR TITLE
GET controller for Author, add release count info

### DIFF
--- a/lib/MetaCPAN/Server/Controller/Author.pm
+++ b/lib/MetaCPAN/Server/Controller/Author.pm
@@ -24,4 +24,38 @@ __PACKAGE__->config(
     }
 );
 
+sub get : Path('') : Args(1) {
+    my ( $self, $c, $id ) = @_;
+    my $file = $self->model($c)->raw->get($id);
+    if ( !defined $file ) {
+        $c->detach( '/not_found', ['Not found'] );
+    }
+    my $st = $file->{_source} || $file->{fields};
+    if ( $st and $st->{pauseid} ) {
+        $st->{release_count}
+            = $self->_get_author_release_status_counts( $c, $st->{pauseid} );
+    }
+    $c->stash($st)
+        || $c->detach( '/not_found',
+        ['The requested field(s) could not be found'] );
+}
+
+sub _get_author_release_status_counts {
+    my ( $self, $c, $pauseid ) = @_;
+    my %ret;
+    for my $status (qw< cpan backpan latest >) {
+        $ret{$status} = $c->model('CPAN::Release')->filter(
+            {
+                and => [
+                    { term => { author => $pauseid } },
+                    { term => { status => $status } }
+                ]
+            }
+            )->count
+            || 0;
+    }
+    $ret{'backpan-only'} = delete $ret{'backpan'};
+    return \%ret;
+}
+
 1;

--- a/t/server/controller/author.t
+++ b/t/server/controller/author.t
@@ -112,6 +112,16 @@ test_psgi app, sub {
 
     is( @{ $json->{hits}->{hits} }, 1, '1 hit' );
 
+    my $release_count = delete $doy->{release_count};
+    is_deeply(
+        [ sort keys %{$release_count} ],
+        [qw< backpan-only cpan latest >],
+        'release_count has the correct keys'
+    );
+
+    my $source = $json->{hits}->{hits}->[0]->{_source};
+    is_deeply( $doy, $source, 'same result as direct get' );
+
     {
         ok( my $res = $cb->( GET '/author/_search?q=*&size=99999' ),
             'GET size=99999' );

--- a/t/server/controller/author.t
+++ b/t/server/controller/author.t
@@ -111,8 +111,6 @@ test_psgi app, sub {
     $json = decode_json_ok($res);
 
     is( @{ $json->{hits}->{hits} }, 1, '1 hit' );
-    is_deeply( $json->{hits}->{hits}->[0]->{_source},
-        $doy, 'same result as direct get' );
 
     {
         ok( my $res = $cb->( GET '/author/_search?q=*&size=99999' ),


### PR DESCRIPTION
Per @neilb's request #502 

This is done in the controller.

After playing with this solution *and* with adding the data to the index, I think this is the better one as it will show data in sync with the release index (no need for the Author script to update the numbers) and won't require remapping of the index.

Still, open for comments / suggestions.
