### PR TITLE
Add author links to author handler response

### DIFF
--- a/lib/MetaCPAN/Server/Controller/Author.pm
+++ b/lib/MetaCPAN/Server/Controller/Author.pm
@@ -35,6 +35,19 @@ sub get : Path('') : Args(1) {
         $st->{release_count}
             = $c->model('CPAN::Release')
             ->aggregate_status_by_author( $st->{pauseid} );
+
+        my ( $id_2, $id_1 ) = $id =~ /^((\w)\w)/;
+        $st->{links} = {
+            cpan_directory => "http://cpan.org/authors/id/$id_1/$id_2/$id",
+            backpan_directory =>
+                "https://cpan.metacpan.org/authors/id/$id_1/$id_2/$id",
+            cpants => "http://cpants.cpanauthors.org/author/$id",
+            cpantesters_reports =>
+                "http://cpantesters.org/author/$id_1/$id.html",
+            cpantesters_matrix => "http://matrix.cpantesters.org/?author=$id",
+            metacpan_explorer =>
+                "https://explorer.metacpan.org/?url=/author/$id",
+        };
     }
     $c->stash($st)
         || $c->detach( '/not_found',

--- a/t/server/controller/author.t
+++ b/t/server/controller/author.t
@@ -119,6 +119,15 @@ test_psgi app, sub {
         'release_count has the correct keys'
     );
 
+    my $links = delete $doy->{links};
+    is_deeply(
+        [ sort keys %{$links} ],
+        [
+            qw< backpan_directory cpan_directory cpantesters_matrix cpantesters_reports cpants metacpan_explorer >
+        ],
+        'links has the correct keys'
+    );
+
     my $source = $json->{hits}->{hits}->[0]->{_source};
     is_deeply( $doy, $source, 'same result as direct get' );
 


### PR DESCRIPTION
This will allow us:
1. Serve the links as extra info from the API as well as the WEB.
2. Not concatenate those links using code within the WEB templates.
3. Reuse the links in templates.

Moving functionality from WEB to API.
This was done to allow cleaning up some template code and reuse links.