### PR TITLE
mickey/2 birds

### DIFF
--- a/lib/MetaCPAN/Script/Release.pm
+++ b/lib/MetaCPAN/Script/Release.pm
@@ -16,6 +16,7 @@ use MetaCPAN::Util;
 use MetaCPAN::Model::Release;
 use MetaCPAN::Script::Runner;
 use MetaCPAN::Types qw( Bool Dir HashRef Int Str );
+use MetaCPAN::Queue ();
 use Moose;
 use PerlIO::gzip;
 use Try::Tiny qw( catch try );
@@ -82,6 +83,14 @@ has _bulk_size => (
     isa      => Int,
     init_arg => 'bulk_size',
     default  => 10,
+);
+
+has _minion => (
+    is      => 'ro',
+    isa     => 'Minion',
+    lazy    => 1,
+    handles => { _add_to_queue => 'enqueue', stats => 'stats', },
+    default => sub { MetaCPAN::Queue->new->minion },
 );
 
 sub run {
@@ -178,11 +187,8 @@ sub run {
         }
 
         if ( $self->queue ) {
-            local @ARGV = (
-                qw{ queue --file },
-                $file, ( $self->latest ? '--latest' : () )
-            );
-            MetaCPAN::Script::Runner->run;
+            $self->_add_to_queue( index_release =>
+                    [ ( $self->latest ? '--latest' : () ), $file ] );
         }
         else {
             try { $self->import_archive($file) }

--- a/lib/MetaCPAN/Script/Release.pm
+++ b/lib/MetaCPAN/Script/Release.pm
@@ -290,14 +290,15 @@ sub import_archive {
         $document->put;
     }
 
+    # update 'first' value
+    $document->set_first;
+    $document->put;
+
+    # update 'latest' (must be done _after_ last update of the document)
     if ( $self->latest ) {
         local @ARGV = ( qw(latest --distribution), $document->distribution );
         MetaCPAN::Script::Runner->run;
     }
-
-    # update 'first' value
-    $document->set_first;
-    $document->put;
 }
 
 sub _build_cpan_files_list {


### PR DESCRIPTION
this PR fixes 2 issues (that are very much related):

1. corrects the way --queue is handled by `Script::Release` so `--latest` is not ignored
2. fixes the `latest` bit overrun by the last `document->put` in Script::Release which screws up so much in the data - we got `latest` to be applied to the `file` index only without `release` being updated (the reason for many Web issues)