### PR TITLE
script/mapping: use the provided --delete flag

### DIFF
--- a/lib/MetaCPAN/Script/Mapping.pm
+++ b/lib/MetaCPAN/Script/Mapping.pm
@@ -21,6 +21,13 @@ has delete => (
 
 sub run {
     my $self = shift;
+    $self->delete_mapping;
+}
+
+sub delete_mapping {
+    my $self = shift;
+    return unless $self->delete;
+
     if (is_interactive) {
         print colored(
             ['bold red'],


### PR DESCRIPTION
we currently ignore this flag which is bad if we want to add new functionality to the script without destroying the mapping.