### PR TITLE
removing timestamp references (not supported in ES2.x)

### DIFF
--- a/lib/MetaCPAN/Document/Favorite.pm
+++ b/lib/MetaCPAN/Document/Favorite.pm
@@ -33,15 +33,5 @@ has date => (
     default  => sub { DateTime->now },
 );
 
-=head2 timestamp
-
-Sets the C<_timestamp> field to the value of L</date>.
-
-=cut
-
-has timestamp => (
-    is        => 'ro',
-    timestamp => {},     # { path => 'date', store => 1 },
-);
-
 __PACKAGE__->meta->make_immutable;
+1;

--- a/lib/MetaCPAN/Model/User/Account.pm
+++ b/lib/MetaCPAN/Model/User/Account.pm
@@ -103,17 +103,6 @@ sub _build_looks_human {
     return $self->has_identity('pause') || ( $self->passed_captcha ? 1 : 0 );
 }
 
-=head2 timestamp
-
-Sets the C<_timestamp> field.
-
-=cut
-
-has timestamp => (
-    is        => 'ro',
-    timestamp => {},
-);
-
 =head1 METHODS
 
 =head2 add_identity

--- a/lib/MetaCPAN/Model/User/Session.pm
+++ b/lib/MetaCPAN/Model/User/Session.pm
@@ -6,16 +6,5 @@ use warnings;
 use Moose;
 use ElasticSearchX::Model::Document;
 
-=head2 timestamp
-
-Sets the C<_timestamp> field.
-
-=cut
-
-has timestamp => (
-    is        => 'ro',
-    timestamp => {},     # { store => 1 },
-);
-
 __PACKAGE__->meta->make_immutable;
 1;

--- a/lib/MetaCPAN/Script/Session.pm
+++ b/lib/MetaCPAN/Script/Session.pm
@@ -45,8 +45,7 @@ __PACKAGE__->meta->make_immutable;
 
 =pod
 
-Purges user sessions.  The timestamp field doesn't appear to get populated in
-the session type, so we just iterate over the sessions for the time being and
+Purges user sessions. we iterate over the sessions for the time being and
 perform bulk delete.
 
 =cut


### PR DESCRIPTION
per #446 