### PR TITLE
script/latest: support queueing + code reuse

### DIFF
--- a/lib/MetaCPAN/Role/Script.pm
+++ b/lib/MetaCPAN/Role/Script.pm
@@ -9,6 +9,7 @@ use Git::Helpers qw( checkout_root );
 use Log::Contextual qw( :log :dlog );
 use MetaCPAN::Model;
 use MetaCPAN::Types qw(:all);
+use MetaCPAN::Queue ();
 use Moose::Role;
 use Carp ();
 
@@ -65,6 +66,21 @@ has home => (
     lazy    => 1,
     coerce  => 1,
     default => sub { checkout_root() },
+);
+
+has _minion => (
+    is      => 'ro',
+    isa     => 'Minion',
+    lazy    => 1,
+    handles => { _add_to_queue => 'enqueue', stats => 'stats', },
+    default => sub { MetaCPAN::Queue->new->minion },
+);
+
+has queue => (
+    is            => 'ro',
+    isa           => Bool,
+    default       => 0,
+    documentation => 'add indexing jobs to the minion queue',
 );
 
 with 'MetaCPAN::Role::Fastly', 'MetaCPAN::Role::HasConfig',

--- a/lib/MetaCPAN/Script/Queue.pm
+++ b/lib/MetaCPAN/Script/Queue.pm
@@ -3,7 +3,6 @@ package MetaCPAN::Script::Queue;
 use strict;
 use warnings;
 
-use MetaCPAN::Queue ();
 use MetaCPAN::Types qw( Dir File );
 use Moose;
 use Path::Iterator::Rule ();
@@ -20,14 +19,6 @@ has file => (
     isa       => File,
     predicate => '_has_file',
     coerce    => 1,
-);
-
-has _minion => (
-    is      => 'ro',
-    isa     => 'Minion',
-    lazy    => 1,
-    handles => { _add_to_queue => 'enqueue', stats => 'stats', },
-    default => sub { MetaCPAN::Queue->new->minion },
 );
 
 with 'MetaCPAN::Role::Script', 'MooseX::Getopt';

--- a/lib/MetaCPAN/Script/Release.pm
+++ b/lib/MetaCPAN/Script/Release.pm
@@ -16,7 +16,6 @@ use MetaCPAN::Util;
 use MetaCPAN::Model::Release;
 use MetaCPAN::Script::Runner;
 use MetaCPAN::Types qw( Bool Dir HashRef Int Str );
-use MetaCPAN::Queue ();
 use Moose;
 use PerlIO::gzip;
 use Try::Tiny qw( catch try );
@@ -41,13 +40,6 @@ has skip => (
     isa           => Bool,
     default       => 0,
     documentation => 'skip already indexed modules (0)',
-);
-
-has queue => (
-    is            => 'ro',
-    isa           => Bool,
-    default       => 0,
-    documentation => 'add indexing jobs to the  minion queue',
 );
 
 has status => (
@@ -83,14 +75,6 @@ has _bulk_size => (
     isa      => Int,
     init_arg => 'bulk_size',
     default  => 10,
-);
-
-has _minion => (
-    is      => 'ro',
-    isa     => 'Minion',
-    lazy    => 1,
-    handles => { _add_to_queue => 'enqueue', stats => 'stats', },
-    default => sub { MetaCPAN::Queue->new->minion },
 );
 
 sub run {


### PR DESCRIPTION
1. Moved queueing infra. to Role::Script for reuse.
2. Added support for queueing in Script::Latest
   (will be useful for later features)

This is part of creating a 'missing latest release' checker, but will also allow extending the use of the queue and make it easily available from all scripts.