### PR TITLE
server: use to_app

### DIFF
--- a/app.psgi
+++ b/app.psgi
@@ -4,6 +4,7 @@ use warnings;
 use FindBin;
 use lib "$FindBin::RealBin/lib";
 use Catalyst::Middleware::Stash 'stash';
+use MetaCPAN::Server;
 
 if ( $ENV{PLACK_ENV} eq 'development' ) {
 
@@ -14,5 +15,5 @@ if ( $ENV{PLACK_ENV} eq 'development' ) {
     }
 }
 
-# The class has the Plack initialization and returns the app.
-require MetaCPAN::Server;
+MetaCPAN::Server->to_app;
+

--- a/lib/MetaCPAN/Server.pm
+++ b/lib/MetaCPAN/Server.pm
@@ -117,5 +117,6 @@ sub to_app {
     return $app;
 }
 
-# Let's be explicit because implicit returns can be confusing
-return $app;
+1;
+
+__END__

--- a/t/lib/MetaCPAN/Server/Test.pm
+++ b/t/lib/MetaCPAN/Server/Test.pm
@@ -6,6 +6,7 @@ use warnings;
 use HTTP::Request::Common qw(POST GET DELETE);
 use Plack::Test;
 use Test::More;
+use MetaCPAN::Server;
 
 use base 'Exporter';
 our @EXPORT = qw(
@@ -21,7 +22,7 @@ my $app;
 sub _load_app {
 
     # Delay loading.
-    $app ||= require MetaCPAN::Server;
+    $app ||= MetaCPAN::Server->to_app;
 }
 
 sub prepare_user_test_data {


### PR DESCRIPTION
any reason this added function wasn't used?
the current code relying on the returned value of `require` is not explicit and not as clear.