### PR TITLE
[WIP] distribution: bugs -> rt + github

### DIFF
--- a/lib/MetaCPAN/Script/Tickets.pm
+++ b/lib/MetaCPAN/Script/Tickets.pm
@@ -17,7 +17,7 @@ use Moose;
 use Parse::CSV;
 use Pithub;
 use URI::Escape qw(uri_escape);
-use MetaCPAN::Types qw( ArrayRef Str );
+use MetaCPAN::Types qw( HashRef );
 
 with 'MetaCPAN::Role::Script', 'MooseX::Getopt';
 
@@ -53,6 +53,12 @@ has pithub => (
     builder => '_build_pithub',
 );
 
+has _bugs => (
+    is      => 'ro',
+    isa     => HashRef,
+    default => sub { +{} },
+);
+
 sub _build_github_token {
     my $self = shift;
     exists $self->config->{github_token}
@@ -71,37 +77,21 @@ sub _build_pithub {
 
 sub run {
     my $self = shift;
-    my $bugs = {};
-
-# NOTE: Order is important here.
-# Hash keys are distribution names.
-# rt issues are counted for all dists (the download tsv contains everything).
-# gh issues are counted for any dist with a github url in `resources.bugtracker.web`.
-# Any dists in the second will overwrite the first.
-    foreach my $source ( @{ $self->source } ) {
-        if ( $source eq 'github' ) {
-            log_debug {'Fetching GitHub issues'};
-            $bugs = { %$bugs, %{ $self->retrieve_github_bugs } };
-        }
-        elsif ( $source eq 'rt' ) {
-            log_debug {'Fetching RT bugs'};
-            $bugs = { %$bugs, %{ $self->retrieve_rt_bugs } };
-        }
-    }
-    $self->index_bug_summary($bugs);
-
+    $self->retrieve_rt_bugs();
+    $self->retrieve_github_bugs();
+    $self->index_bug_summary();
     return 1;
 }
 
 sub index_bug_summary {
-    my ( $self, $bugs ) = @_;
+    my $self = shift;
     $self->index->refresh;
     my $dists = $self->index->type('distribution');
     my $bulk = $self->index->bulk( size => 300 );
-    for my $dist ( keys %$bugs ) {
+    for my $dist ( keys %{ $self->_bugs } ) {
         my $doc = $dists->get($dist);
         $doc ||= $dists->new_document( { name => $dist } );
-        $doc->_set_bugs( $bugs->{ $doc->name } );
+        $doc->_set_bugs( $self->_bugs->{ $doc->name } );
         $bulk->put($doc);
     }
     $bulk->commit;
@@ -109,6 +99,8 @@ sub index_bug_summary {
 
 sub retrieve_github_bugs {
     my $self = shift;
+    log_info {'Fetching GitHub issues'};
+
     my $scroll
         = $self->index->type('release')->find_github_based->scroll('5m');
     log_debug { sprintf( "Found %s repos", $scroll->total ) };
@@ -132,7 +124,7 @@ sub retrieve_github_bugs {
         );
         next unless ( $closed->success );
         $summary->{ $release->{distribution} }
-            = { open => 0, closed => 0, source => $source, type => 'github' };
+            = { open => 0, closed => 0, source => $source };
         $summary->{ $release->{distribution} }->{open}++
             while ( $open->next );
         $summary->{ $release->{distribution} }->{closed}++
@@ -141,7 +133,8 @@ sub retrieve_github_bugs {
             = $summary->{ $release->{distribution} }->{open};
 
     }
-    return $summary;
+
+    $self->_bugs->{$_}{github} = $summary->{$_} for keys %{$summary};
 }
 
 # Try (recursively) to find a github url in the resources hash.
@@ -165,14 +158,17 @@ sub github_user_repo_from_resources {
 }
 
 sub retrieve_rt_bugs {
-    my ($self) = @_;
+    my $self = shift;
+    log_info {'Fetching RT issues'};
 
     my $resp = $self->ua->request( GET $self->rt_summary_url );
 
     log_error { $resp->status_line } unless $resp->is_success;
 
     # NOTE: This is sending a byte string.
-    return $self->parse_tsv( $resp->content );
+    my $rt = $self->parse_tsv( $resp->content );
+
+    $self->_bugs->{$_}{rt} = $rt->{$_} for keys %{$rt};
 }
 
 sub parse_tsv {
@@ -190,7 +186,6 @@ sub parse_tsv {
     my %summary;
     while ( my $row = $tsv_parser->fetch ) {
         $summary{ $row->{dist} } = {
-            type   => 'rt',
             source => $self->rt_dist_url( $row->{dist} ),
             active => $row->{active},
             closed => $row->{inactive},

--- a/lib/MetaCPAN/Types/Internal.pm
+++ b/lib/MetaCPAN/Types/Internal.pm
@@ -25,6 +25,8 @@ use MooseX::Types -declare => [
         Blog
         PerlMongers
         Tests
+        RTIssueStatus
+        GitHubIssueStatus
         BugSummary
         RiverSummary
         )
@@ -93,14 +95,25 @@ coerce Profile, from HashRef,
 subtype Tests,
     as Dict [ fail => Int, na => Int, pass => Int, unknown => Int ];
 
-subtype BugSummary,
+subtype RTIssueStatus,
     as Dict [
     (
         map { $_ => Optional [Int] }
-            qw(new open stalled patched resolved rejected active closed)
+            qw( active closed new open patched rejected resolved stalled )
     ),
-    type   => Str,
     source => Str
+    ];
+
+subtype GitHubIssueStatus,
+    as Dict [
+    ( map { $_ => Optional [Int] } qw( active closed open ) ),
+    source => Str,
+    ];
+
+subtype BugSummary,
+    as Dict [
+    rt     => Optional [RTIssueStatus],
+    github => Optional [GitHubIssueStatus],
     ];
 
 subtype RiverSummary,

--- a/t/release/bugs.t
+++ b/t/release/bugs.t
@@ -9,17 +9,18 @@ test_distribution(
     'Moose',
     {
         bugs => {
-            type => 'rt',
-            source =>
-                'https://rt.cpan.org/Public/Dist/Display.html?Name=Moose',
-            new      => 15,
-            open     => 20,
-            stalled  => 4,
-            patched  => 0,
-            resolved => 122,
-            rejected => 23,
-            active   => 39,
-            closed   => 145,
+            rt => {
+                source =>
+                    'https://rt.cpan.org/Public/Dist/Display.html?Name=Moose',
+                new      => 15,
+                open     => 20,
+                stalled  => 4,
+                patched  => 0,
+                resolved => 122,
+                rejected => 23,
+                active   => 39,
+                closed   => 145,
+            },
         },
     },
     'Test bug data for Moose dist',

--- a/t/release/text-tabs-wrap.t
+++ b/t/release/text-tabs-wrap.t
@@ -9,18 +9,19 @@ test_distribution(
     'Text-Tabs+Wrap',
     {
         bugs => {
-            type => 'rt',
-            source =>
-                'https://rt.cpan.org/Public/Dist/Display.html?Name=Text-Tabs%2BWrap',
-            new      => 2,
-            open     => 0,
-            stalled  => 0,
-            patched  => 0,
-            resolved => 15,
-            rejected => 1,
-            active   => 2,
-            closed   => 16,
-        },
+            rt => {
+                source =>
+                    'https://rt.cpan.org/Public/Dist/Display.html?Name=Text-Tabs%2BWrap',
+                new      => 2,
+                open     => 0,
+                stalled  => 0,
+                patched  => 0,
+                resolved => 15,
+                rejected => 1,
+                active   => 2,
+                closed   => 16,
+            },
+        }
     },
     'rt url is uri escaped',
 );


### PR DESCRIPTION
example entry:

``` json
      {
        "_type": "distribution",
        "_source": {
          "bugs": {
            "github": {
              "active": 10,
              "source": "https://github.com/ranguard/text-vcard",
              "open": 10,
              "closed": 30
            },
            "rt": {
              "closed": "6",
              "patched": 0,
              "active": "2",
              "resolved": 6,
              "rejected": 0,
              "open": 0,
              "new": 2,
              "source": "https://rt.cpan.org/Public/Dist/Display.html?Name=Text-vCard",
              "stalled": 0
            }
          },
          "name": "Text-vCard"
        },
        "_score": 1,
        "_index": "cpan_v1",
        "_id": "Text-vCard"
      }
```

WIP since after agreeing on this we will need to reindex the `distribution` type - which means deleting it, remapping and rebuilding using the tickets and river scripts.
