### PR TITLE
[WIP] created new endpoints to remove web ES awareness

### DIFF
--- a/lib/MetaCPAN/Document/Author.pm
+++ b/lib/MetaCPAN/Document/Author.pm
@@ -143,7 +143,6 @@ sub validate {
 
 __PACKAGE__->meta->make_immutable;
 
-
 package MetaCPAN::Document::Author::Set;
 
 use MetaCPAN::Moose;

--- a/lib/MetaCPAN/Document/Author.pm
+++ b/lib/MetaCPAN/Document/Author.pm
@@ -145,8 +145,8 @@ sub by_id {
     my ( $self, $req, $ids ) = @_;
     my @ids = map {uc} ( $ids ? $ids : $req->read_param('id') );
     return $self->es_by_terms_vals(
-        req    => $req,
-        should => {
+        req => $req,
+        -or => {
             pauseid => \@ids,
         },
     );
@@ -169,8 +169,8 @@ sub by_user {
     my ( $self, $req ) = @_;
     my @users = $req->read_param('user');
     return $self->es_by_terms_vals(
-        req    => $req,
-        should => {
+        req => $req,
+        -or => {
             user => \@users,
         },
     );

--- a/lib/MetaCPAN/Document/Author.pm
+++ b/lib/MetaCPAN/Document/Author.pm
@@ -154,6 +154,7 @@ with 'MetaCPAN::Role::ES::Query';
 sub by_id {
     my ( $self, $req, $ids ) = @_;
     my @ids = map {uc} ( $ids ? $ids : $req->read_param('id') );
+    return unless @ids;
     return $self->es_by_terms_vals(
         req => $req,
         -or => {
@@ -165,6 +166,7 @@ sub by_id {
 sub by_id_for_top_uploaders {
     my ( $self, $req, $counts ) = @_;
     my $authors = $self->by_id( $req, [ keys %$counts ] );
+    return unless $authors;
     return [
         sort { $b->{releases} <=> $a->{releases} } map {
             {
@@ -178,6 +180,7 @@ sub by_id_for_top_uploaders {
 sub by_user {
     my ( $self, $req ) = @_;
     my @users = $req->read_param('user');
+    return unless @users;
     return $self->es_by_terms_vals(
         req => $req,
         -or => {
@@ -224,6 +227,16 @@ sub by_key {
     };
 
     $self->es_by_filter( req => $req, filter => $filter, cb => $cb );
+}
+
+sub plusser_by_user {
+    my ( $self, $req ) = @_;
+    my @users = $req->read_param('user');
+    return unless @users;
+    return $self->es_by_terms_vals(
+        req => $req,
+        -or => +{ user => \@users }
+    );
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MetaCPAN/Document/Author.pm
+++ b/lib/MetaCPAN/Document/Author.pm
@@ -192,7 +192,7 @@ sub by_user {
 sub by_key {
     my ( $self, $req ) = @_;
     my $key = $req->parameters->{key};
-    $key or return;
+    return unless $key;
 
     my $filter = +{
         bool => {

--- a/lib/MetaCPAN/Document/Author.pm
+++ b/lib/MetaCPAN/Document/Author.pm
@@ -12,8 +12,6 @@ use MetaCPAN::Types qw(:all);
 use MooseX::Types::Structured qw(Dict Tuple Optional);
 use MetaCPAN::Util;
 
-with 'MetaCPAN::Role::ES::Query';
-
 has name => (
     is       => 'ro',
     required => 1,

--- a/lib/MetaCPAN/Document/Author.pm
+++ b/lib/MetaCPAN/Document/Author.pm
@@ -141,6 +141,16 @@ sub validate {
     return @result;
 }
 
+__PACKAGE__->meta->make_immutable;
+
+
+package MetaCPAN::Document::Author::Set;
+
+use MetaCPAN::Moose;
+extends 'ElasticSearchX::Model::Document::Set';
+
+with 'MetaCPAN::Role::ES::Query';
+
 sub by_id {
     my ( $self, $req, $ids ) = @_;
     my @ids = map {uc} ( $ids ? $ids : $req->read_param('id') );

--- a/lib/MetaCPAN/Document/Favorite.pm
+++ b/lib/MetaCPAN/Document/Favorite.pm
@@ -39,8 +39,8 @@ sub by_user {
     my ( $self, $req ) = @_;
     my @users = $req->read_param('user');
     return $self->es_by_terms_vals(
-        req    => $req,
-        should => +{ user => \@users }
+        req => $req,
+        -or => +{ user => \@users }
     );
 }
 
@@ -49,7 +49,7 @@ sub by_distribution {
     my $distribution = $req->read_param('distribution');
     return $self->es_by_terms_vals(
         req  => $req,
-        must => +{ distribution => $distribution }
+        -and => +{ distribution => $distribution }
     );
 }
 

--- a/lib/MetaCPAN/Document/Favorite.pm
+++ b/lib/MetaCPAN/Document/Favorite.pm
@@ -44,5 +44,14 @@ sub by_user {
     );
 }
 
+sub by_distribution {
+    my ( $self, $req ) = @_;
+    my $distribution = $req->read_param('distribution');
+    return $self->es_by_terms_vals(
+        req  => $req,
+        must => +{ distribution => $distribution }
+    );
+}
+
 __PACKAGE__->meta->make_immutable;
 1;

--- a/lib/MetaCPAN/Document/Favorite.pm
+++ b/lib/MetaCPAN/Document/Favorite.pm
@@ -1,16 +1,12 @@
 package MetaCPAN::Document::Favorite;
 
-use strict;
-use warnings;
+use MetaCPAN::Moose;
 
-use Moose;
 use ElasticSearchX::Model::Document;
 
 use DateTime;
 use MetaCPAN::Types qw(:all);
 use MetaCPAN::Util;
-
-with 'MetaCPAN::Role::ES::Query';
 
 has id => (
     is => 'ro',
@@ -34,6 +30,16 @@ has date => (
     isa      => 'DateTime',
     default  => sub { DateTime->now },
 );
+
+__PACKAGE__->meta->make_immutable;
+
+
+package MetaCPAN::Document::Favorite::Set;
+
+use MetaCPAN::Moose;
+extends 'ElasticSearchX::Model::Document::Set';
+
+with 'MetaCPAN::Role::ES::Query';
 
 sub by_user {
     my ( $self, $req ) = @_;

--- a/lib/MetaCPAN/Document/Favorite.pm
+++ b/lib/MetaCPAN/Document/Favorite.pm
@@ -44,6 +44,7 @@ with 'MetaCPAN::Role::ES::Query';
 sub by_user {
     my ( $self, $req ) = @_;
     my @users = $req->read_param('user');
+    return unless @users;
     return $self->es_by_terms_vals(
         req => $req,
         -or => +{ user => \@users }
@@ -53,6 +54,7 @@ sub by_user {
 sub by_distribution {
     my ( $self, $req ) = @_;
     my $distribution = $req->read_param('distribution');
+    return unless $distribution;
     return $self->es_by_terms_vals(
         req  => $req,
         -and => +{ distribution => $distribution }

--- a/lib/MetaCPAN/Document/Favorite.pm
+++ b/lib/MetaCPAN/Document/Favorite.pm
@@ -33,7 +33,6 @@ has date => (
 
 __PACKAGE__->meta->make_immutable;
 
-
 package MetaCPAN::Document::Favorite::Set;
 
 use MetaCPAN::Moose;
@@ -58,6 +57,23 @@ sub by_distribution {
     return $self->es_by_terms_vals(
         req  => $req,
         -and => +{ distribution => $distribution }
+    );
+}
+
+sub recent {
+    my ( $self, $req )  = @_;
+    my ( $size, $page ) = @{ $req->parameters }{qw< size page >};
+    $size ||= 20;
+    $page ||= 1;
+    return $self->es->search(
+        index => $self->index->name,
+        type  => 'favorite',
+        body  => {
+            query => { match_all => {} },
+            size  => $size,
+            from  => ( $page - 1 ) * $size,
+            sort => [ { 'date' => { order => 'desc' } } ],
+        }
     );
 }
 

--- a/lib/MetaCPAN/Document/Favorite.pm
+++ b/lib/MetaCPAN/Document/Favorite.pm
@@ -10,6 +10,8 @@ use DateTime;
 use MetaCPAN::Types qw(:all);
 use MetaCPAN::Util;
 
+with 'MetaCPAN::Role::ES::Query';
+
 has id => (
     is => 'ro',
     id => [qw(user distribution)],
@@ -32,6 +34,15 @@ has date => (
     isa      => 'DateTime',
     default  => sub { DateTime->now },
 );
+
+sub by_user {
+    my ( $self, $req ) = @_;
+    my @users = $req->read_param('user');
+    return $self->es_by_terms_vals(
+        req    => $req,
+        should => +{ user => \@users }
+    );
+}
 
 __PACKAGE__->meta->make_immutable;
 1;

--- a/lib/MetaCPAN/Document/File.pm
+++ b/lib/MetaCPAN/Document/File.pm
@@ -940,5 +940,24 @@ sub full_path {
     return join( '/', $self->author, $self->release, $self->path );
 }
 
+sub dir {
+    my ( $self, $req ) = @_;
+    my ( $author, $release, $dir )
+        = @{ $req->parameters }{qw< author release >};
+    my @path = split m{/}, $dir;
+    return $self->es_by_terms_vals(
+        req  => $req,
+        must => +{
+            author  => $author,
+            release => $release,
+            level   => scalar @path,
+            prefix  => {
+                path => $dir
+            }
+        }
+    );
+
+}
+
 __PACKAGE__->meta->make_immutable;
 1;

--- a/lib/MetaCPAN/Document/File.pm
+++ b/lib/MetaCPAN/Document/File.pm
@@ -947,7 +947,7 @@ sub dir {
     my @path = split m{/}, $dir;
     return $self->es_by_terms_vals(
         req  => $req,
-        must => +{
+        -and => +{
             author  => $author,
             release => $release,
             level   => scalar @path,

--- a/lib/MetaCPAN/Document/File.pm
+++ b/lib/MetaCPAN/Document/File.pm
@@ -1,10 +1,6 @@
 package MetaCPAN::Document::File;
 
-use strict;
-use warnings;
-use utf8;
-
-use Moose;
+use MetaCPAN::Moose;
 use ElasticSearchX::Model::Document;
 
 use Encode;
@@ -939,6 +935,16 @@ sub full_path {
     my $self = shift;
     return join( '/', $self->author, $self->release, $self->path );
 }
+
+__PACKAGE__->meta->make_immutable;
+
+
+package MetaCPAN::Document::File::Set;
+
+use MetaCPAN::Moose;
+extends 'ElasticSearchX::Model::Document::Set';
+
+with 'MetaCPAN::Role::ES::Query';
 
 sub dir {
     my ( $self, $req ) = @_;

--- a/lib/MetaCPAN/Document/Release.pm
+++ b/lib/MetaCPAN/Document/Release.pm
@@ -372,7 +372,7 @@ sub latest_by_author {
     my $author = $req->parameters->{'author'};
     return $self->es_by_terms_vals(
         req  => $req,
-        must => {
+        -and => {
             author => uc($author),
             status => 'latest'
         },
@@ -384,7 +384,7 @@ sub all_by_author {
     my $author = $req->parameters->{'author'};
     return $self->es_by_terms_vals(
         req  => $req,
-        must => {
+        -and => {
             author => uc($author),
         },
     );
@@ -444,7 +444,7 @@ sub by_name_and_author {
     my ( $name, $author ) = @{ $req->parameters }{qw< name author >};
     return $self->es_by_terms_vals(
         req  => $req,
-        must => {
+        -and => {
             name   => $name,
             author => $author,
         },
@@ -455,8 +455,8 @@ sub versions {
     my ( $self, $req ) = @_;
     my @dists = $req->read_param('distribution');
     return $self->es_by_terms_vals(
-        req    => $req,
-        should => {
+        req => $req,
+        -or => {
             distribution => \@dists,
         },
     );

--- a/lib/MetaCPAN/Document/Release.pm
+++ b/lib/MetaCPAN/Document/Release.pm
@@ -365,6 +365,26 @@ sub find_github_based {
         { and => [ { term => { status => 'latest' } }, { or => $or } ] } );
 }
 
+sub latest_by_author {
+    my ( $self, $author ) = @_;
+
+    my $filter = {
+        and => [
+            { term => { author => uc($author) } },
+            { term => { status => 'latest' } }
+        ]
+    };
+
+    my $file
+        = $self->filter($filter)
+        ->sort(
+        [ 'distribution', { 'version_numified' => { reverse => 1 } } ] )
+        ->fields( [qw< author distribution name status abstract date >] )
+        ->size(1000)->all;
+
+    return $file;
+}
+
 sub top_uploaders {
     my ( $self, $range ) = @_;
 

--- a/lib/MetaCPAN/Document/Release.pm
+++ b/lib/MetaCPAN/Document/Release.pm
@@ -276,7 +276,6 @@ sub set_first {
 
 __PACKAGE__->meta->make_immutable;
 
-
 package MetaCPAN::Document::Release::Set;
 
 use MetaCPAN::Moose;

--- a/lib/MetaCPAN/Document/Release.pm
+++ b/lib/MetaCPAN/Document/Release.pm
@@ -1,9 +1,7 @@
 package MetaCPAN::Document::Release;
 
-use strict;
-use warnings;
+use MetaCPAN::Moose;
 
-use Moose;
 use ElasticSearchX::Model::Document;
 use DateTime;
 
@@ -278,12 +276,10 @@ sub set_first {
 
 __PACKAGE__->meta->make_immutable;
 
+
 package MetaCPAN::Document::Release::Set;
 
-use strict;
-use warnings;
-
-use Moose;
+use MetaCPAN::Moose;
 extends 'ElasticSearchX::Model::Document::Set';
 
 with 'MetaCPAN::Role::ES::Query';

--- a/lib/MetaCPAN/Document/Release.pm
+++ b/lib/MetaCPAN/Document/Release.pm
@@ -366,6 +366,7 @@ sub find_github_based {
 sub latest_by_author {
     my ( $self, $req ) = @_;
     my $author = $req->parameters->{'author'};
+    return unless $author;
     return $self->es_by_terms_vals(
         req  => $req,
         -and => {
@@ -378,6 +379,7 @@ sub latest_by_author {
 sub all_by_author {
     my ( $self, $req ) = @_;
     my $author = $req->parameters->{'author'};
+    return unless $author;
     return $self->es_by_terms_vals(
         req  => $req,
         -and => {
@@ -388,6 +390,7 @@ sub all_by_author {
 
 sub top_uploaders {
     my ( $self, $range ) = @_;
+    return unless $range;
 
     my $range_filter = {
         range => {
@@ -438,6 +441,7 @@ sub top_uploaders {
 sub by_name_and_author {
     my ( $self, $req )    = @_;
     my ( $name, $author ) = @{ $req->parameters }{qw< name author >};
+    return unless $name and $author;
     return $self->es_by_terms_vals(
         req  => $req,
         -and => {
@@ -450,6 +454,7 @@ sub by_name_and_author {
 sub versions {
     my ( $self, $req ) = @_;
     my @dists = $req->read_param('distribution');
+    return unless @dists;
     return $self->es_by_terms_vals(
         req => $req,
         -or => {
@@ -500,6 +505,7 @@ sub recent {
 sub modules {
     my ( $self,   $req )     = @_;
     my ( $author, $release ) = @{ $req->parameters }{qw< author release >};
+    return unless $author and $release;
     my $query = {
         filtered => {
             query  => { match_all => {} },

--- a/lib/MetaCPAN/Document/Release.pm
+++ b/lib/MetaCPAN/Document/Release.pm
@@ -368,23 +368,26 @@ sub find_github_based {
 }
 
 sub latest_by_author {
-    my ( $self, $author ) = @_;
+    my ( $self, $req ) = @_;
+    my $author = $req->parameters->{'author'};
+    return $self->es_by_terms_vals(
+        req  => $req,
+        must => {
+            author => uc($author),
+            status => 'latest'
+        },
+    );
+}
 
-    my $filter = {
-        and => [
-            { term => { author => uc($author) } },
-            { term => { status => 'latest' } }
-        ]
-    };
-
-    my $file
-        = $self->filter($filter)
-        ->sort(
-        [ 'distribution', { 'version_numified' => { reverse => 1 } } ] )
-        ->fields( [qw< author distribution name status abstract date >] )
-        ->size(1000)->all;
-
-    return $file;
+sub all_by_author {
+    my ( $self, $req ) = @_;
+    my $author = $req->parameters->{'author'};
+    return $self->es_by_terms_vals(
+        req  => $req,
+        must => {
+            author => uc($author),
+        },
+    );
 }
 
 sub top_uploaders {

--- a/lib/MetaCPAN/Document/Release.pm
+++ b/lib/MetaCPAN/Document/Release.pm
@@ -372,10 +372,10 @@ sub top_uploaders {
         range => {
             date => {
                 from => $range eq 'all' ? 0 : DateTime->now->subtract(
-                    $range eq 'weekly'  ? 'weeks'
-                        : $range eq 'monthly' ? 'months'
-                            : $range eq 'yearly'  ? 'years'
-                                :                       'weeks' => 1
+                      $range eq 'weekly'  ? 'weeks'
+                    : $range eq 'monthly' ? 'months'
+                    : $range eq 'yearly'  ? 'years'
+                    :                       'weeks' => 1
                 )->truncate( to => 'day' )->iso8601
             },
         }
@@ -396,11 +396,13 @@ sub top_uploaders {
         size => 0,
     };
 
-    return $self->es->search({
-        index => $self->index->name,
-        type  => 'release',
-        body  => $body,
-    });
+    return $self->es->search(
+        {
+            index => $self->index->name,
+            type  => 'release',
+            body  => $body,
+        }
+    );
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MetaCPAN/Role/ES/Query.pm
+++ b/lib/MetaCPAN/Role/ES/Query.pm
@@ -65,11 +65,11 @@ sub _filter_from_args {
         }
         if $constant_score;
 
-    my ( $should, $must ) = delete @{$args}{qw< should must >};
+    my ( $or, $and ) = delete @{$args}{qw< -or -and >};
     my $filter
-        = $should
-        ? _filter_bool_terms_values( should => $should )
-        : _filter_bool_terms_values( must   => $must );
+        = $or
+        ? _filter_bool_terms_values( should => $or )
+        : _filter_bool_terms_values( must   => $and );
 
     return $filter;
 }

--- a/lib/MetaCPAN/Role/ES/Query.pm
+++ b/lib/MetaCPAN/Role/ES/Query.pm
@@ -29,7 +29,9 @@ sub es_query_res {
     my ( $req, $res, $cb ) = @args{qw< req res cb >};
     my $params = $req->parameters;
 
-    my $size = $params->{size} || 5000;
+    my $size = $params->{size} // 5000;
+    my $from = 0;
+    $params->{page} and $from = ( $params->{page} - 1 ) * $size;
 
     my @fields;
     if ( $params->{fields} ) {
@@ -45,6 +47,7 @@ sub es_query_res {
 
     $res = $res->fields( \@fields ) if @fields;
     $res = $res->sort( \@sort )     if @sort;
+    $res = $res->from($from)        if $from;
     $res = $res->size($size)->all;
     $res = $cb->($res) if $cb and is_coderef($cb);
 

--- a/lib/MetaCPAN/Server/Controller/Author.pm
+++ b/lib/MetaCPAN/Server/Controller/Author.pm
@@ -8,6 +8,7 @@ use Moose;
 BEGIN { extends 'MetaCPAN::Server::Controller' }
 
 with 'MetaCPAN::Server::Role::JSONP';
+with 'MetaCPAN::Server::Role::ES::Query';
 
 __PACKAGE__->config(
     relationships => {
@@ -57,6 +58,13 @@ sub get : Path('') : Args(1) {
     $c->stash($st)
         || $c->detach( '/not_found',
         ['The requested field(s) could not be found'] );
+}
+
+# endpoint: /author/by_user?user=<csv_user_ids>[&fields=<csv_fields>][&sort=<csv_sort>][&size=N]
+sub by_user : Path('by_user') : Args(0) {
+    my ( $self, $c ) = @_;
+    my @users = split /,/ => $c->req->parameters->{user};
+    $self->es_query_by_key( $c, 'user', \@users );
 }
 
 1;

--- a/lib/MetaCPAN/Server/Controller/Author.pm
+++ b/lib/MetaCPAN/Server/Controller/Author.pm
@@ -79,8 +79,10 @@ sub by_user : Path('by_user') : Args(0) {
 # endpoint: /author/search?key=<key>[&fields=<field>][&sort=<sort_key>][&size=N]
 sub search : Path('search') : Args(0) {
     my ( $self, $c ) = @_;
-    my $key    = $c->req->parameters->{key};
-    my $filter = +{
+    my $key = $c->req->parameters->{key};
+
+    my $filter = +{ match_all => {} };
+    $key and $filter = +{
         bool => {
             should => [
                 {

--- a/lib/MetaCPAN/Server/Controller/Author.pm
+++ b/lib/MetaCPAN/Server/Controller/Author.pm
@@ -76,13 +76,12 @@ sub by_user : Path('by_user') : Args(0) {
         $self->es_by_terms_vals( c => $c, should => +{ user => \@users } ) );
 }
 
-# endpoint: /author/search?key=<key>[&fields=<field>][&sort=<sort_key>][&size=N]
-sub search : Path('search') : Args(0) {
+# endpoint: /author/by_key?key=<key>[&fields=<field>][&sort=<sort_key>][&size=N]
+sub by_key : Path('by_key') : Args(0) {
     my ( $self, $c ) = @_;
     my $key = $c->req->parameters->{key};
-
-    my $filter = +{ match_all => {} };
-    $key and $filter = +{
+    $key or return;
+    my $filter = +{
         bool => {
             should => [
                 {

--- a/lib/MetaCPAN/Server/Controller/Author.pm
+++ b/lib/MetaCPAN/Server/Controller/Author.pm
@@ -97,14 +97,21 @@ sub search : Path('search') : Args(0) {
         };
     };
 
-    $self->es_by_filter( $c, $filter, $cb );
+    $self->es_by_filter( c => $c, filter => $filter, cb => $cb );
+}
+
+# endpoint: /author/by_id?id=<csv_author_ids>[&fields=<csv_fields>][&sort=<csv_sort>][&size=N]
+sub by_id : Path('by_id') : Args(0) {
+    my ( $self, $c ) = @_;
+    my @ids = map {uc} split /,/ => $c->req->parameters->{id};
+    $self->es_by_key_vals( c => $c, key => 'pauseid', vals => \@ids );
 }
 
 # endpoint: /author/by_user?user=<csv_user_ids>[&fields=<csv_fields>][&sort=<csv_sort>][&size=N]
 sub by_user : Path('by_user') : Args(0) {
     my ( $self, $c ) = @_;
     my @users = split /,/ => $c->req->parameters->{user};
-    $self->es_by_key_vals( $c, 'user', \@users );
+    $self->es_by_key_vals( c => $c, key => 'user', vals => \@users );
 }
 
 1;

--- a/lib/MetaCPAN/Server/Controller/Author.pm
+++ b/lib/MetaCPAN/Server/Controller/Author.pm
@@ -59,21 +59,27 @@ sub get : Path('') : Args(1) {
         ['The requested field(s) could not be found'] );
 }
 
-# endpoint: /author/by_id?id=<pauseid>[&fields=<field>][&sort=<sort_key>][&size=N]
+# endpoint: /author/by_id
+# params:   id=<pauseid>
+# optional: [&fields=<field>][&sort=<sort_key>][&size=N][&page=N]
 sub by_id : Path('by_id') : Args(0) {
     my ( $self, $c ) = @_;
     my $data = $self->model($c)->raw->by_id( $c->req );
     $c->stash($data);
 }
 
-# endpoint: /author/by_user?user=<user_id>[&fields=<field>][&sort=<sort_key>][&size=N]
+# endpoint: /author/by_user
+# params:   user=<user_id>
+# optional: [&fields=<field>][&sort=<sort_key>][&size=N][&page=N]
 sub by_user : Path('by_user') : Args(0) {
     my ( $self, $c ) = @_;
     my $data = $self->model($c)->raw->by_user( $c->req );
     $c->stash($data);
 }
 
-# endpoint: /author/by_key?key=<key>[&fields=<field>][&sort=<sort_key>][&size=N]
+# endpoint: /author/by_key
+# params:   key=<key>
+# optional: [&fields=<field>][&sort=<sort_key>][&size=N][&page=N]
 sub by_key : Path('by_key') : Args(0) {
     my ( $self, $c ) = @_;
     my $data = $self->model($c)->raw->by_key( $c->req );
@@ -81,7 +87,9 @@ sub by_key : Path('by_key') : Args(0) {
     $c->stash($data);
 }
 
-# endpoint: /author/top_uploaders?range=<range>[&fields=<field>][&sort=<sort_key>][&size=N]
+# endpoint: /author/top_uploaders
+# params:   range=<range>
+# [&fields=<field>][&sort=<sort_key>][&size=N][&page=N]
 sub top_uploaders : Path('top_uploaders') : Args(0) {
     my ( $self, $c ) = @_;
     my $range   = $c->req->parameters->{range};

--- a/lib/MetaCPAN/Server/Controller/Favorite.pm
+++ b/lib/MetaCPAN/Server/Controller/Favorite.pm
@@ -35,5 +35,14 @@ sub by_user : Path('by_user') : Args(0) {
     $c->stash($data);
 }
 
+# endpoint: /favorite/by_distribution
+# params:   distribution=<distribution>
+# optional: [&fields=<field>][&sort=<sort_key>][&size=N][&page=N]
+sub by_distribution : Path('by_distribution') : Args(0) {
+    my ( $self, $c ) = @_;
+    my $data = $self->model($c)->raw->by_distribution( $c->req );
+    $c->stash($data);
+}
+
 __PACKAGE__->meta->make_immutable;
 1;

--- a/lib/MetaCPAN/Server/Controller/Favorite.pm
+++ b/lib/MetaCPAN/Server/Controller/Favorite.pm
@@ -26,7 +26,9 @@ sub find : Path('') : Args(2) {
     } or $c->detach( '/not_found', [$@] );
 }
 
-# endpoint: /favorite/by_user?user=<id>[&user=<id2>][&fields=<field>][&sort=<sort_key>][&size=N]
+# endpoint: /favorite/by_user
+# params:   user=<id>[&user=<id2>]...
+# optional: [&fields=<field>][&sort=<sort_key>][&size=N][&page=N]
 sub by_user : Path('by_user') : Args(0) {
     my ( $self, $c ) = @_;
     my $data = $self->model($c)->raw->by_user( $c->req );

--- a/lib/MetaCPAN/Server/Controller/Favorite.pm
+++ b/lib/MetaCPAN/Server/Controller/Favorite.pm
@@ -31,7 +31,7 @@ sub find : Path('') : Args(2) {
 sub by_user : Path('by_user') : Args(0) {
     my ( $self, $c ) = @_;
     my @users = split /,/ => $c->req->parameters->{user};
-    $self->es_query_by_key( $c, 'user', \@users );
+    $self->es_by_key_vals( $c, 'user', \@users );
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MetaCPAN/Server/Controller/Favorite.pm
+++ b/lib/MetaCPAN/Server/Controller/Favorite.pm
@@ -8,6 +8,7 @@ use Moose;
 BEGIN { extends 'MetaCPAN::Server::Controller' }
 
 with 'MetaCPAN::Server::Role::JSONP';
+with 'MetaCPAN::Server::Role::ES::Query';
 
 sub find : Path('') : Args(2) {
     my ( $self, $c, $user, $distribution ) = @_;
@@ -24,6 +25,13 @@ sub find : Path('') : Args(2) {
         );
         $c->stash( $favorite->{_source} || $favorite->{fields} );
     } or $c->detach( '/not_found', [$@] );
+}
+
+# endpoint: /favorite/by_user?user=<csv_user_ids>[&fields=<csv_fields>][&sort=<csv_sort>][&size=N]
+sub by_user : Path('by_user') : Args(0) {
+    my ( $self, $c ) = @_;
+    my @users = split /,/ => $c->req->parameters->{user};
+    $self->es_query_by_key( $c, 'user', \@users );
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MetaCPAN/Server/Controller/Favorite.pm
+++ b/lib/MetaCPAN/Server/Controller/Favorite.pm
@@ -69,5 +69,13 @@ sub recent : Path('recent') : Args(0) {
     $c->stash($data);
 }
 
+# endpoint: /favorite/agg_dists_user
+# optional: [&fields=<field>][&sort=<sort_key>][&size=N][&page=N]
+sub agg_dists_user : Path('agg_dists_user') : Args(0) {
+    my ( $self, $c ) = @_;
+    my $data = $self->model($c)->raw->agg_dists_user( $c->req );
+    $c->stash($data);
+}
+
 __PACKAGE__->meta->make_immutable;
 1;

--- a/lib/MetaCPAN/Server/Controller/Favorite.pm
+++ b/lib/MetaCPAN/Server/Controller/Favorite.pm
@@ -8,7 +8,6 @@ use Moose;
 BEGIN { extends 'MetaCPAN::Server::Controller' }
 
 with 'MetaCPAN::Server::Role::JSONP';
-with 'MetaCPAN::Server::Role::ES::Query';
 
 sub find : Path('') : Args(2) {
     my ( $self, $c, $user, $distribution ) = @_;
@@ -30,9 +29,8 @@ sub find : Path('') : Args(2) {
 # endpoint: /favorite/by_user?user=<id>[&user=<id2>][&fields=<field>][&sort=<sort_key>][&size=N]
 sub by_user : Path('by_user') : Args(0) {
     my ( $self, $c ) = @_;
-    my @users = $c->req->read_param('user');
-    $c->stash(
-        $self->es_by_terms_vals( c => $c, should => +{ user => \@users } ) );
+    my $data = $self->model($c)->raw->by_user( $c->req );
+    $c->stash($data);
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MetaCPAN/Server/Controller/Favorite.pm
+++ b/lib/MetaCPAN/Server/Controller/Favorite.pm
@@ -53,5 +53,13 @@ sub plusser_by_user : Path('plusser_by_user') : Args(0) {
     $c->stash($data);
 }
 
+# endpoint: /favorite/recent
+# optional: [&fields=<field>][&sort=<sort_key>][&size=N][&page=N]
+sub recent : Path('recent') : Args(0) {
+    my ( $self, $c ) = @_;
+    my $data = $self->model($c)->raw->recent( $c->req );
+    $c->stash($data);
+}
+
 __PACKAGE__->meta->make_immutable;
 1;

--- a/lib/MetaCPAN/Server/Controller/Favorite.pm
+++ b/lib/MetaCPAN/Server/Controller/Favorite.pm
@@ -27,13 +27,12 @@ sub find : Path('') : Args(2) {
     } or $c->detach( '/not_found', [$@] );
 }
 
-# endpoint: /favorite/by_user?user=<csv_user_ids>[&fields=<csv_fields>][&sort=<csv_sort>][&size=N]
+# endpoint: /favorite/by_user?user=<id>[&user=<id2>][&fields=<field>][&sort=<sort_key>][&size=N]
 sub by_user : Path('by_user') : Args(0) {
     my ( $self, $c ) = @_;
-    my @users = split /,/ => $c->req->parameters->{user};
+    my @users = $c->req->read_param('user');
     $c->stash(
-        $self->es_by_key_vals( $c, 'user', \@users )
-    );
+        $self->es_by_key_vals( c => $c, key => 'user', vals => \@users ) );
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MetaCPAN/Server/Controller/Favorite.pm
+++ b/lib/MetaCPAN/Server/Controller/Favorite.pm
@@ -44,6 +44,14 @@ sub by_distribution : Path('by_distribution') : Args(0) {
     $c->stash($data);
 }
 
+# endpoint: /favorite/leaderboard
+# optional: [&size=N]
+sub leaderboard : Path('leaderboard') : Args(0) {
+    my ( $self, $c ) = @_;
+    my $data = $self->model($c)->raw->leaderboard( $c->req );
+    $c->stash($data);
+}
+
 # endpoint: /favorite/plusser_by_user
 # params:   user=<user>
 # optional: [&fields=<field>][&sort=<sort_key>][&size=N][&page=N]

--- a/lib/MetaCPAN/Server/Controller/Favorite.pm
+++ b/lib/MetaCPAN/Server/Controller/Favorite.pm
@@ -44,5 +44,14 @@ sub by_distribution : Path('by_distribution') : Args(0) {
     $c->stash($data);
 }
 
+# endpoint: /favorite/plusser_by_user
+# params:   user=<user>
+# optional: [&fields=<field>][&sort=<sort_key>][&size=N][&page=N]
+sub plusser_by_user : Path('plusser_by_user') : Args(0) {
+    my ( $self, $c ) = @_;
+    my $data = $c->model('CPAN::Author')->raw->plusser_by_user( $c->req );
+    $c->stash($data);
+}
+
 __PACKAGE__->meta->make_immutable;
 1;

--- a/lib/MetaCPAN/Server/Controller/Favorite.pm
+++ b/lib/MetaCPAN/Server/Controller/Favorite.pm
@@ -32,7 +32,7 @@ sub by_user : Path('by_user') : Args(0) {
     my ( $self, $c ) = @_;
     my @users = $c->req->read_param('user');
     $c->stash(
-        $self->es_by_key_vals( c => $c, key => 'user', vals => \@users ) );
+        $self->es_by_terms_vals( c => $c, should => +{ user => \@users } ) );
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MetaCPAN/Server/Controller/Favorite.pm
+++ b/lib/MetaCPAN/Server/Controller/Favorite.pm
@@ -31,7 +31,9 @@ sub find : Path('') : Args(2) {
 sub by_user : Path('by_user') : Args(0) {
     my ( $self, $c ) = @_;
     my @users = split /,/ => $c->req->parameters->{user};
-    $self->es_by_key_vals( $c, 'user', \@users );
+    $c->stash(
+        $self->es_by_key_vals( $c, 'user', \@users )
+    );
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MetaCPAN/Server/Controller/File.pm
+++ b/lib/MetaCPAN/Server/Controller/File.pm
@@ -47,4 +47,13 @@ sub find : Path('') {
     } or $c->detach( '/not_found', [$@] );
 }
 
+# endpoint: /file/dir
+# params:   dir=<dir>&author=<pauseid>&release=<name>
+# optional: [&fields=<field>][&sort=<sort_key>][&size=N][&page=N]
+sub dir : Path('dir') : Args(0) {
+    my ( $self, $c ) = @_;
+    my $data = $self->model($c)->raw->dir( $c->req );
+    $c->stash($data);
+}
+
 1;

--- a/lib/MetaCPAN/Server/Controller/Release.pm
+++ b/lib/MetaCPAN/Server/Controller/Release.pm
@@ -49,5 +49,25 @@ sub get : Path('') : Args(2) {
         ['The requested field(s) could not be found'] );
 }
 
+sub latest_by_author : Path('latest_by_author') : Args(1) {
+    my ( $self, $c, $author ) = @_;
+
+    my $filter = {
+        and => [
+            { term => { author => uc($author) } },
+            { term => { status => 'latest' } }
+        ]
+    };
+
+    my $file
+        = $self->model($c)->raw->filter($filter)
+        ->sort(
+        [ 'distribution', { 'version_numified' => { reverse => 1 } } ] )
+        ->fields( [qw< author distribution name status abstract date >] )
+        ->size(1000)->all;
+
+    $c->stash($file);
+}
+
 __PACKAGE__->meta->make_immutable;
 1;

--- a/lib/MetaCPAN/Server/Controller/Release.pm
+++ b/lib/MetaCPAN/Server/Controller/Release.pm
@@ -52,21 +52,7 @@ sub get : Path('') : Args(2) {
 
 sub latest_by_author : Path('latest_by_author') : Args(1) {
     my ( $self, $c, $author ) = @_;
-
-    my $filter = {
-        and => [
-            { term => { author => uc($author) } },
-            { term => { status => 'latest' } }
-        ]
-    };
-
-    my $file
-        = $self->model($c)->raw->filter($filter)
-        ->sort(
-        [ 'distribution', { 'version_numified' => { reverse => 1 } } ] )
-        ->fields( [qw< author distribution name status abstract date >] )
-        ->size(1000)->all;
-
+    my $file = $self->model($c)->raw->latest_by_author($author);
     $c->stash($file);
 }
 

--- a/lib/MetaCPAN/Server/Controller/Release.pm
+++ b/lib/MetaCPAN/Server/Controller/Release.pm
@@ -85,5 +85,14 @@ sub versions : Path('versions') : Args(0) {
     $c->stash($data);
 }
 
+# endpoint: /release/recent
+# params:   distribution=<distribution>
+# optional: [&fields=<field>][&sort=<sort_key>][&size=N][&page=N]
+sub recent : Path('recent') : Args(0) {
+    my ( $self, $c ) = @_;
+    my $data = $self->model($c)->raw->recent( $c->req );
+    $c->stash($data);
+}
+
 __PACKAGE__->meta->make_immutable;
 1;

--- a/lib/MetaCPAN/Server/Controller/Release.pm
+++ b/lib/MetaCPAN/Server/Controller/Release.pm
@@ -50,23 +50,26 @@ sub get : Path('') : Args(2) {
 }
 
 # endpoint: /release/latest_by_author
-# params:   author=<pauseid>[&fields=<field>][&sort=<sort_key>][&size=N]
+# params:   author=<pauseid>
+# optional: [&fields=<field>][&sort=<sort_key>][&size=N][&page=N]
 sub latest_by_author : Path('latest_by_author') : Args(0) {
     my ( $self, $c ) = @_;
-    my $data = $self->model($c)->raw->latest_by_author($c->req);
+    my $data = $self->model($c)->raw->latest_by_author( $c->req );
     $c->stash($data);
 }
 
 # endpoint: /release/all_by_author
-# params:   author=<pauseid>[&fields=<field>][&sort=<sort_key>][&size=N]
+# params:   author=<pauseid>
+# optional: [&fields=<field>][&sort=<sort_key>][&size=N][&page=N]
 sub all_by_author : Path('all_by_author') : Args(0) {
     my ( $self, $c ) = @_;
-    my $data = $self->model($c)->raw->all_by_author($c->req);
+    my $data = $self->model($c)->raw->all_by_author( $c->req );
     $c->stash($data);
 }
 
 # endpoint: /release/by_name_and_author
-# params:   name=<name>&author=<author>[&fields=<field>][&sort=<sort_key>][&size=N]
+# params:   name=<name>&author=<author>
+# optional: [&fields=<field>][&sort=<sort_key>][&size=N][&page=N]
 sub by_name_and_author : Path('by_name_and_author') : Args(0) {
     my ( $self, $c ) = @_;
     my $data = $self->model($c)->raw->by_name_and_author( $c->req );
@@ -74,7 +77,8 @@ sub by_name_and_author : Path('by_name_and_author') : Args(0) {
 }
 
 # endpoint: /release/versions
-# params:   distribution=<distribution>[&fields=<field>][&sort=<sort_key>][&size=N]
+# params:   distribution=<distribution>
+# optional: [&fields=<field>][&sort=<sort_key>][&size=N][&page=N]
 sub versions : Path('versions') : Args(0) {
     my ( $self, $c ) = @_;
     my $data = $self->model($c)->raw->versions( $c->req );

--- a/lib/MetaCPAN/Server/Controller/Release.pm
+++ b/lib/MetaCPAN/Server/Controller/Release.pm
@@ -49,15 +49,6 @@ sub get : Path('') : Args(2) {
         ['The requested field(s) could not be found'] );
 }
 
-# endpoint: /release/latest_by_author
-# params:   author=<pauseid>
-# optional: [&fields=<field>][&sort=<sort_key>][&size=N][&page=N]
-sub latest_by_author : Path('latest_by_author') : Args(0) {
-    my ( $self, $c ) = @_;
-    my $data = $self->model($c)->raw->latest_by_author( $c->req );
-    $c->stash($data);
-}
-
 # endpoint: /release/all_by_author
 # params:   author=<pauseid>
 # optional: [&fields=<field>][&sort=<sort_key>][&size=N][&page=N]
@@ -76,12 +67,21 @@ sub by_name_and_author : Path('by_name_and_author') : Args(0) {
     $c->stash($data);
 }
 
-# endpoint: /release/versions
+# endpoint: /release/latest_by_author
+# params:   author=<pauseid>
+# optional: [&fields=<field>][&sort=<sort_key>][&size=N][&page=N]
+sub latest_by_author : Path('latest_by_author') : Args(0) {
+    my ( $self, $c ) = @_;
+    my $data = $self->model($c)->raw->latest_by_author( $c->req );
+    $c->stash($data);
+}
+
+# endpoint: /release/modules
 # params:   distribution=<distribution>
 # optional: [&fields=<field>][&sort=<sort_key>][&size=N][&page=N]
-sub versions : Path('versions') : Args(0) {
+sub modules : Path('modules') : Args(0) {
     my ( $self, $c ) = @_;
-    my $data = $self->model($c)->raw->versions( $c->req );
+    my $data = $self->model($c)->raw->modules( $c->req );
     $c->stash($data);
 }
 
@@ -91,6 +91,15 @@ sub versions : Path('versions') : Args(0) {
 sub recent : Path('recent') : Args(0) {
     my ( $self, $c ) = @_;
     my $data = $self->model($c)->raw->recent( $c->req );
+    $c->stash($data);
+}
+
+# endpoint: /release/versions
+# params:   distribution=<distribution>
+# optional: [&fields=<field>][&sort=<sort_key>][&size=N][&page=N]
+sub versions : Path('versions') : Args(0) {
+    my ( $self, $c ) = @_;
+    my $data = $self->model($c)->raw->versions( $c->req );
     $c->stash($data);
 }
 

--- a/lib/MetaCPAN/Server/Controller/Release.pm
+++ b/lib/MetaCPAN/Server/Controller/Release.pm
@@ -70,15 +70,35 @@ sub latest_by_author : Path('latest_by_author') : Args(1) {
     $c->stash($file);
 }
 
-# endpoint: /release/versions?distribution=<distribution>[&fields=<field>][&sort=<sort_key>][&size=N]
+# endpoint: /release/by_name_and_author
+# params:   name=<name>&author=<author>[&fields=<field>][&sort=<sort_key>][&size=N]
+sub by_name_and_author : Path('by_name_and_author') : Args(0) {
+    my ( $self, $c )      = @_;
+    my ( $name, $author ) = @{ $c->req->parameters }{qw< name author >};
+    $c->stash(
+        $self->es_by_terms_vals(
+            c    => $c,
+            must => {
+                name   => $name,
+                author => $author,
+            }
+        )
+    );
+}
+
+# endpoint: /release/versions
+# params:   distribution=<distribution>[&fields=<field>][&sort=<sort_key>][&size=N]
 sub versions : Path('versions') : Args(0) {
     my ( $self, $c ) = @_;
     my @dists = $c->req->read_param('distribution');
     $c->stash(
-        $self->es_by_key_vals( c => $c, key => 'distribution', vals => \@dists )
+        $self->es_by_key_vals(
+            c    => $c,
+            key  => 'distribution',
+            vals => \@dists
+        )
     );
 }
-
 
 __PACKAGE__->meta->make_immutable;
 1;

--- a/lib/MetaCPAN/Server/Controller/Release.pm
+++ b/lib/MetaCPAN/Server/Controller/Release.pm
@@ -49,11 +49,19 @@ sub get : Path('') : Args(2) {
         ['The requested field(s) could not be found'] );
 }
 
-# endpoint: /release/latest_by_author/AUTHOR
-# params:   [&fields=<field>][&sort=<sort_key>][&size=N]
-sub latest_by_author : Path('latest_by_author') : Args(1) {
-    my ( $self, $c, $author ) = @_;
-    my $data = $self->model($c)->raw->latest_by_author($author);
+# endpoint: /release/latest_by_author
+# params:   author=<pauseid>[&fields=<field>][&sort=<sort_key>][&size=N]
+sub latest_by_author : Path('latest_by_author') : Args(0) {
+    my ( $self, $c ) = @_;
+    my $data = $self->model($c)->raw->latest_by_author($c->req);
+    $c->stash($data);
+}
+
+# endpoint: /release/all_by_author
+# params:   author=<pauseid>[&fields=<field>][&sort=<sort_key>][&size=N]
+sub all_by_author : Path('all_by_author') : Args(0) {
+    my ( $self, $c ) = @_;
+    my $data = $self->model($c)->raw->all_by_author($c->req);
     $c->stash($data);
 }
 

--- a/lib/MetaCPAN/Server/Controller/Release.pm
+++ b/lib/MetaCPAN/Server/Controller/Release.pm
@@ -8,6 +8,7 @@ use Moose;
 BEGIN { extends 'MetaCPAN::Server::Controller' }
 
 with 'MetaCPAN::Server::Role::JSONP';
+with 'MetaCPAN::Server::Role::ES::Query';
 
 __PACKAGE__->config(
     relationships => {
@@ -68,6 +69,16 @@ sub latest_by_author : Path('latest_by_author') : Args(1) {
 
     $c->stash($file);
 }
+
+# endpoint: /release/versions?distribution=<distribution>[&fields=<field>][&sort=<sort_key>][&size=N]
+sub versions : Path('versions') : Args(0) {
+    my ( $self, $c ) = @_;
+    my @dists = $c->req->read_param('distribution');
+    $c->stash(
+        $self->es_by_key_vals( c => $c, key => 'distribution', vals => \@dists )
+    );
+}
+
 
 __PACKAGE__->meta->make_immutable;
 1;

--- a/lib/MetaCPAN/Server/Role/ES/Query.pm
+++ b/lib/MetaCPAN/Server/Role/ES/Query.pm
@@ -16,7 +16,7 @@ sub es_by_key_vals {
         = +{
         bool => { should => [ map +{ term => { $key => $_ } }, @vals ] }
         };
-    $self->es_by_filter( c => $c, cb => $cb, filter => $filter );
+    return $self->es_by_filter( c => $c, cb => $cb, filter => $filter );
 }
 
 # queries by given filter
@@ -54,7 +54,7 @@ sub es_query_res {
     $res = $res->size($size)->all;
     $res = $cb->($res) if $cb and is_coderef($cb);
 
-    $c->stash($res);
+    return $res;
 }
 
 no Moose::Role;

--- a/lib/MetaCPAN/Server/Role/ES/Query.pm
+++ b/lib/MetaCPAN/Server/Role/ES/Query.pm
@@ -39,14 +39,14 @@ sub es_query_res {
 
     my @fields;
     if ( $params->{fields} ) {
-        @fields = split /,/ => $params->{fields};
+        @fields = $c->req->read_param('fields');
     }
 
     my @sort;
     if ( $params->{sort} ) {
         @sort
             = map { /^(.*):((?:desc|asc))$/ ? { $1 => { order => $2 } } : $_ }
-            split /,/ => $params->{sort};
+            $c->req->read_param('sort');
     }
 
     $res = $res->fields( \@fields ) if @fields;

--- a/lib/MetaCPAN/Server/Role/ES/Query.pm
+++ b/lib/MetaCPAN/Server/Role/ES/Query.pm
@@ -7,15 +7,14 @@ use Moose::Role;
 
 use Ref::Util qw( is_arrayref is_coderef );
 
-# queries by given key and values
-sub es_by_key_vals {
+# queries by given terms and values
+sub es_by_terms_vals {
     my ( $self, %args ) = @_;
-    my ( $c, $cb, $key, $vals ) = @args{qw< c cb key vals >};
-    my @vals = is_arrayref $vals ? @{$vals} : $vals;
+    my ( $c, $cb, $should, $must ) = @args{qw< c cb should must >};
     my $filter
-        = +{
-        bool => { should => [ map +{ term => { $key => $_ } }, @vals ] }
-        };
+        = $should
+        ? _filter_bool_terms_values( should => $should )
+        : _filter_bool_terms_values( must   => $must );
     return $self->es_by_filter( c => $c, cb => $cb, filter => $filter );
 }
 
@@ -55,6 +54,27 @@ sub es_query_res {
     $res = $cb->($res) if $cb and is_coderef($cb);
 
     return $res;
+}
+
+sub _filter_key_multi_vals { +{ terms => {@_} } }
+
+sub _filter_term_key_vals {
+    my ( $k, $v ) = @_;
+    return (
+        is_arrayref $v
+        ? _filter_key_multi_vals( $k, $v )
+        : +{ term => { $k => $v } }
+    );
+}
+
+sub _filter_bool_terms_values {
+    my ( $op, $kv ) = @_;
+    return +{
+        bool => {
+            $op =>
+                [ map { _filter_term_key_vals( $_, $kv->{$_} ) } keys %$kv ]
+        }
+    };
 }
 
 no Moose::Role;

--- a/lib/MetaCPAN/Server/Role/ES/Query.pm
+++ b/lib/MetaCPAN/Server/Role/ES/Query.pm
@@ -1,0 +1,45 @@
+package MetaCPAN::Server::Role::ES::Query;
+
+use strict;
+use warnings;
+
+use Moose::Role;
+
+use Ref::Util qw( is_arrayref );
+
+sub es_query_by_filter {
+    my ( $self, $c, $filter ) = @_;
+    my $params = $c->req->parameters;
+
+    my $size = $params->{size} || 5000;
+
+    my @fields;
+    if ( $params->{fields} ) {
+        @fields = split /,/ => $params->{fields};
+    }
+
+    my @sort;
+    if ( $params->{sort} ) {
+        @sort
+            = map { /^(.*):((?:desc|asc))$/ ? { $1 => { order => $2 } } : $_ }
+            split /,/ => $params->{sort};
+    }
+
+    my $res = $self->model($c)->raw->filter($filter);
+    $res = $res->fields( \@fields ) if @fields;
+    $res = $res->sort( \@sort )     if @sort;
+    $res = $res->size($size)->all;
+
+    $c->stash($res);
+}
+
+sub es_query_by_key {
+    my ( $self, $c, $key, $vals ) = @_;
+    my @vals = is_arrayref $vals ? @{$vals} : $vals;
+    $self->es_query_by_filter( $c,
+        { bool => { should => [ map +{ term => { $key => $_ } }, @vals ] } }
+    );
+}
+
+no Moose::Role;
+1;

--- a/lib/MetaCPAN/Server/Role/ES/Query.pm
+++ b/lib/MetaCPAN/Server/Role/ES/Query.pm
@@ -9,26 +9,30 @@ use Ref::Util qw( is_arrayref is_coderef );
 
 # queries by given key and values
 sub es_by_key_vals {
-    my ( $self, $c, $key, $vals, $cb ) = @_;
+    my ( $self, %args ) = @_;
+    my ( $c, $cb, $key, $vals ) = @args{qw< c cb key vals >};
     my @vals = is_arrayref $vals ? @{$vals} : $vals;
     my $filter
         = +{
         bool => { should => [ map +{ term => { $key => $_ } }, @vals ] }
         };
-    $self->es_query_by_filter( $c, $filter, $cb );
+    $self->es_by_filter( c => $c, cb => $cb, filter => $filter );
 }
 
 # queries by given filter
 sub es_by_filter {
-    my ( $self, $c, $filter, $cb ) = @_;
-    my $res = $self->model($c)->raw->filter($filter);
-    return $self->es_query_res( $c, $res, $cb );
+    my ( $self, %args ) = @_;
+    my ( $c, $cb, $filter, $_model ) = @args{qw< c cb filter model >};
+    my $model = $_model ? $c->model($_model) : $self->model($c);
+    my $res = $model->raw->filter($filter);
+    return $self->es_query_res( c => $c, cb => $cb, res => $res );
 }
 
 # applies generic 'size', 'sort' & 'fields' to
 # query result
 sub es_query_res {
-    my ( $self, $c, $res, $cb ) = @_;
+    my ( $self, %args ) = @_;
+    my ( $c, $cb, $res ) = @args{qw< c cb res >};
     my $params = $c->req->parameters;
 
     my $size = $params->{size} || 5000;

--- a/lib/MetaCPAN/Server/Role/Request.pm
+++ b/lib/MetaCPAN/Server/Role/Request.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Moose::Role;
+use Ref::Util qw( is_arrayref );
 
 around [qw(content_type header)] => sub {
     my ( $orig, $self ) = ( shift, shift );
@@ -13,5 +14,11 @@ around [qw(content_type header)] => sub {
         ? 'application/json'
         : $header;
 };
+
+sub read_param {
+    my ( $self, $param ) = @_;
+    my $params = $self->parameters->{$param};
+    return ( is_arrayref $params ? @$params : $params );
+}
 
 1;


### PR DESCRIPTION
as discussed before, i'd like to start moving some ES queries done in metacpan-web to the API as new endpoints.

the idea is to hide the storage behind the API and allow consolidation of functionality between all API using tools (web, client, etc.)

this is just a first step (out of many) so the PR is mostly for the welcomed discussion.
