### PR TITLE
Always use the index alias instead of the name

### DIFF
--- a/lib/MetaCPAN/Script/Backpan.pm
+++ b/lib/MetaCPAN/Script/Backpan.pm
@@ -91,7 +91,7 @@ sub build_release_status_map {
     my $scroll = $self->es->scroll_helper(
         size   => 500,
         scroll => '5m',
-        index  => 'cpan_v1',
+        index  => $self->index->name,
         type   => 'release',
         fields => [ 'author', 'archive', 'name' ],
         body   => $self->_get_release_query,
@@ -150,7 +150,7 @@ sub update_releases {
     log_info {"update_releases"};
 
     $self->_bulk->{release} ||= $self->es->bulk_helper(
-        index     => 'cpan_v1',
+        index     => $self->index->name,
         type      => 'release',
         max_count => 250,
         timeout   => '5m',
@@ -193,7 +193,7 @@ sub update_files_author {
     my $scroll = $self->es->scroll_helper(
         size   => 500,
         scroll => '5m',
-        index  => 'cpan_v1',
+        index  => $self->index->name,
         type   => 'file',
         fields => ['release'],
         body   => {
@@ -209,7 +209,7 @@ sub update_files_author {
     );
 
     $self->_bulk->{file} ||= $self->es->bulk_helper(
-        index     => 'cpan_v1',
+        index     => $self->index->name,
         type      => 'file',
         max_count => 250,
         timeout   => '5m',

--- a/t/server/controller/author.t
+++ b/t/server/controller/author.t
@@ -26,8 +26,11 @@ test_psgi app, sub {
         my $json = decode_json_ok($res);
         ok( $json->{pauseid} eq 'MO', 'pauseid is MO' )
             if ( $k eq '/author/MO' );
-        ok( ref $json->{cpan_v1}{mappings}{author} eq 'HASH', '_mapping' )
-            if ( $k eq '/author/_mapping' );
+
+        if ( $k eq '/author/_mapping' ) {
+            my ($index) = keys %{$json};
+            ok( ref $json->{$index}{mappings}{author} eq 'HASH', '_mapping' );
+        }
     }
 
     ok( my $res = $cb->( GET '/author/MO?callback=jsonp' ), 'GET jsonp' );


### PR DESCRIPTION
We should always use the alias of the index ('cpan') rather than the actual index name ('cpan_v1') to allow hot-swapping of newly created indices (in some of the mapping changing cases like #516)