### PR TITLE
script role: ua attribute (lazy) + proxy attribute + cleanup

### DIFF
--- a/lib/MetaCPAN/Script/Ratings.pm
+++ b/lib/MetaCPAN/Script/Ratings.pm
@@ -18,18 +18,13 @@ has ratings => (
 
 sub run {
     my $self = shift;
-    my $ua   = LWP::UserAgent->new;
-
-    if ( my $proxy = $ENV{http_proxy} || $ENV{HTTP_PROXY} ) {
-        $ua->proxy( ['http'], $proxy );
-    }
 
     log_info { 'Downloading ' . $self->ratings };
 
     my @path   = qw( var tmp ratings.csv );
     my $target = $self->home->file(@path);
     my $md5    = -e $target ? $self->digest($target) : 0;
-    my $res    = $ua->mirror( $self->ratings, $target );
+    my $res    = $self->ua->mirror( $self->ratings, $target );
     if ( $md5 eq $self->digest($target) ) {
         log_info {'No changes to ratings.csv'};
         return;

--- a/lib/MetaCPAN/Script/Tickets.pm
+++ b/lib/MetaCPAN/Script/Tickets.pm
@@ -46,11 +46,6 @@ has source => (
     default  => sub { [qw(rt github)] },
 );
 
-has ua => (
-    is      => 'ro',
-    default => sub { LWP::UserAgent->new },
-);
-
 has pithub => (
     is      => 'ro',
     isa     => 'Pithub',


### PR DESCRIPTION
made shared `ua` and `proxy` attributes available for all scripts.
cleaned up the setting from 2 scripts.