### PR TITLE
convert fields output using single_valued_arrayref_to_scalar

### DIFF
--- a/lib/MetaCPAN/Util.pm
+++ b/lib/MetaCPAN/Util.pm
@@ -8,12 +8,14 @@ use version;
 
 use Digest::SHA1;
 use Encode;
+use Ref::Util qw( is_arrayref );
 use Sub::Exporter -setup => {
     exports => [
         'author_dir',      'digest',
         'extract_section', 'fix_pod',
         'fix_version',     'numify_version',
         'pod_lines',       'strip_pod',
+        'single_valued_arrayref_to_scalar'
     ]
 };
 
@@ -125,6 +127,28 @@ sub pod_lines {
     return \@return, $slop;
 }
 
+sub single_valued_arrayref_to_scalar {
+    my ( $array, $fields ) = @_;
+    my $is_arrayref = is_arrayref($array);
+
+    $array = [$array] unless $is_arrayref;
+
+    my $has_fields = defined $fields ? 1 : 0;
+    $fields ||= [];
+    my %fields_to_extract = map { $_ => 1 } @{$fields};
+    foreach my $hash ( @{$array} ) {
+        foreach my $field ( %{$hash} ) {
+            next if ( $has_fields and not $fields_to_extract{$field} );
+            my $value = $hash->{$field};
+
+            # We only operate when have an ArrayRef of one value
+            next unless is_arrayref($value) && scalar @{$value} == 1;
+            $hash->{$field} = $value->[0];
+        }
+    }
+    return $is_arrayref ? $array : @{$array};
+}
+
 1;
 
 __END__
@@ -137,3 +161,58 @@ This function will digest the passed parameters to a 32 byte string and makes it
 It consists of the characters A-Z, a-z, 0-9, - and _.
 
 The digest is built using L<Digest::SHA1>.
+
+=head2 single_valued_arrayref_to_scalar
+
+Elasticsearch 1.x changed the data structure returned when fields are used.
+For example before one could get a ArrayRef[HashRef[Str]] where now
+that will come in the form of ArrayRef[HashRef[ArrayRef[Str]]]
+
+This function reverses that behavior
+By default it will do that for all fields that are a single valued array,
+but one may pass in a list of fields to restrict this behavior only to the
+fields given.
+
+So this:
+
+    $self->single_valued_arrayref_to_scalar(
+    [
+      {
+        name     => ['WhizzBang'],
+        provides => ['Food', 'Bar'],
+      },
+       ...
+   ]);
+
+yields:
+
+    [
+      {
+        name     => 'WhizzBang',
+        provides => ['Food', 'Bar'],
+      },
+      ...
+    ]
+
+and this estrictive example):
+
+    $self->single_valued_arrayref_to_scalar(
+    [
+      {
+        name     => ['WhizzBang'],
+        provides => ['Food'],
+      },
+       ...
+   ], ['name']);
+
+yields:
+
+    [
+      {
+        name     => 'WhizzBang',
+        provides => ['Food'],
+      },
+      ...
+    ]
+
+=cut

--- a/t/server/controller/search/reverse_dependencies.t
+++ b/t/server/controller/search/reverse_dependencies.t
@@ -124,7 +124,7 @@ test_psgi app, sub {
 
         my $json = decode_json_ok($res);
         is( $json->{hits}->{total}, 1, 'total is 1' );
-        is( $json->{hits}->{hits}->[0]->{fields}->{distribution}->[0],
+        is( $json->{hits}->{hits}->[0]->{fields}->{distribution},
             'Multiple-Modules-RDeps-A', 'filter worked' );
     }
 };


### PR DESCRIPTION

21:47:29 � grantm� I've just been trying out the /v1 API and noticed that in the JSON field values are represented as arrays rather 
                   than simple scalars, is that deliberate?
21:47:29 � grantm� Example: https://gist.github.com/grantm/2f4b262677c329438f3b9c42dba827b2
