### PR TITLE
Pod linking cleanups

### DIFF
--- a/lib/MetaCPAN/Pod/Renderer.pm
+++ b/lib/MetaCPAN/Pod/Renderer.pm
@@ -50,6 +50,7 @@ sub html_renderer {
     $parser->html_footer('');
     $parser->html_header('');
     $parser->index(1);
+    $parser->anchor_items(1);
     $parser->no_errata_section( $self->no_errata_section );
     $parser->perldoc_url_prefix( $self->perldoc_url_prefix );
     $parser->link_mappings( $self->link_mappings );

--- a/lib/MetaCPAN/Pod/Renderer.pm
+++ b/lib/MetaCPAN/Pod/Renderer.pm
@@ -52,7 +52,6 @@ sub html_renderer {
     $parser->index(1);
     $parser->no_errata_section( $self->no_errata_section );
     $parser->perldoc_url_prefix( $self->perldoc_url_prefix );
-    $parser->nix_X_codes( $self->nix_X_codes );
     $parser->link_mappings( $self->link_mappings );
 
     return $parser;

--- a/lib/MetaCPAN/Pod/XHTML.pm
+++ b/lib/MetaCPAN/Pod/XHTML.pm
@@ -8,17 +8,11 @@ use warnings;
 
 use parent 'Pod::Simple::XHTML';
 
-sub link_mappings {
-    my $self = shift;
-    if (@_) {
-        $self->{_link_map} = $_[0];
-    }
-    $self->{_link_map};
-}
+__PACKAGE__->_accessorize('link_mappings');
 
 sub resolve_pod_page_link {
     my ( $self, $module, $section ) = @_;
-    my $link_map = $self->{_link_map} || {};
+    my $link_map = $self->link_mappings || {};
     if ( $module and my $link = $link_map->{$module} ) {
         $module = $link;
     }

--- a/lib/MetaCPAN/Pod/XHTML.pm
+++ b/lib/MetaCPAN/Pod/XHTML.pm
@@ -25,30 +25,6 @@ sub resolve_pod_page_link {
     $self->SUPER::resolve_pod_page_link( $module, $section );
 }
 
-sub start_item_text {
-
-    # see end_item_text
-}
-
-sub end_item_text {
-
-    # idify =item content, reset 'scratch'
-    my $id   = $_[0]->idify( $_[0]{'scratch'} );
-    my $text = $_[0]{scratch};
-    $_[0]{'scratch'} = '';
-
-    # construct whole element here because we need the
-    # contents of the =item to idify it
-    if ( $_[0]{'in_dd'}[ $_[0]{'dl_level'} ] ) {
-        $_[0]{'scratch'} = "</dd>\n";
-        $_[0]{'in_dd'}[ $_[0]{'dl_level'} ] = 0;
-    }
-
-    $_[0]{'scratch'} .= qq{<dt id="$id">$text</dt>\n<dd>};
-    $_[0]{'in_dd'}[ $_[0]{'dl_level'} ] = 1;
-    $_[0]->emit;
-}
-
 # Custom handling of errata section
 
 sub _gen_errata {

--- a/lib/MetaCPAN/Pod/XHTML.pm
+++ b/lib/MetaCPAN/Pod/XHTML.pm
@@ -8,25 +8,6 @@ use warnings;
 
 use parent 'Pod::Simple::XHTML';
 
-sub start_X {
-    $_[0]{_in_X_} = 1;
-}
-
-sub end_X {
-    $_[0]{_in_X_} = 0;
-    $_[0]{'scratch'}
-        .= '<a id="' . $_[0]->idify( $_[0]{_last_X_} ) . '"></a>';
-}
-
-sub handle_text {
-    if ( $_[0]{_in_X_} ) {
-        $_[0]{_last_X_} = $_[1];
-    }
-    else {
-        $_[0]->SUPER::handle_text( $_[1] );
-    }
-}
-
 sub link_mappings {
     my $self = shift;
     if (@_) {

--- a/lib/MetaCPAN/Server/Controller/Pod.pm
+++ b/lib/MetaCPAN/Server/Controller/Pod.pm
@@ -15,10 +15,14 @@ sub find : Path('') {
     # $c->add_author_key($author) called from /source/get request below
     $c->cdn_max_age('1y');
 
+    my $q = $c->req->query_params;
+    for my $opt (qw(show_errors url_prefix)) {
+        $c->stash->{$opt} = $q->{$opt}
+            if exists $q->{$opt};
+    }
+
     $c->stash->{link_mappings}
-        = $self->find_dist_links( $c, $author, $release,
-        !!$c->req->query_params->{permalinks} );
-    $c->stash->{url_prefix} = $c->req->query_params->{url_prefix};
+        = $self->find_dist_links( $c, $author, $release, !!$q->{permalinks} );
 
     $c->forward( '/source/get', [ $author, $release, @path ] );
     my $path = $c->stash->{path};

--- a/lib/MetaCPAN/Server/View/Pod.pm
+++ b/lib/MetaCPAN/Server/View/Pod.pm
@@ -18,7 +18,7 @@ sub process {
 
     my ( $body, $content_type );
     my $accept = eval { $c->req->preferred_content_type } || 'text/html';
-    my $show_errors = $c->req->params->{show_errors};
+    my $show_errors = $c->stash->{show_errors};
 
     my $renderer = $self->_factory(
         ( $url_prefix ? ( perldoc_url_prefix => $url_prefix ) : () ),

--- a/lib/MetaCPAN/Server/View/Pod.pm
+++ b/lib/MetaCPAN/Server/View/Pod.pm
@@ -20,13 +20,9 @@ sub process {
     my $accept = eval { $c->req->preferred_content_type } || 'text/html';
     my $show_errors = $c->req->params->{show_errors};
 
-    my $x_codes = $c->req->params->{x_codes};
-    $x_codes = $c->config->{pod_html_x_codes} unless defined $x_codes;
-
     my $renderer = $self->_factory(
         ( $url_prefix ? ( perldoc_url_prefix => $url_prefix ) : () ),
         no_errata_section => !$show_errors,
-        nix_X_codes       => !$x_codes,
         ( $link_mappings ? ( link_mappings => $link_mappings ) : () ),
     );
     if ( $accept eq 'text/plain' ) {

--- a/metacpan_server.conf
+++ b/metacpan_server.conf
@@ -1,7 +1,6 @@
 git /usr/bin/git
 
 minion_dsn = postgresql:///minion_queue
-pod_html_x_codes = 0
 
 <controller User::Turing>
     # required for server startup -- override this in metacpan_server_local.conf

--- a/t/release/pod-examples.t
+++ b/t/release/pod-examples.t
@@ -47,15 +47,9 @@ sub test_pod_examples {
 
     # NOTE: This may change.
     $pod_like->(
-        'text/html&x_codes=0',    # hack
+        'text/html',
         qr{<h1 id="DESCRIPTION">DESCRIPTION </h1>},
         'X codes are ignored in html'
-    );
-
-    $pod_like->(
-        'text/html&x_codes=1',    # hack
-        qr{<h1 id="DESCRIPTION">DESCRIPTION <a id="desc"></a></h1>},
-        'X codes are included when requested'
     );
 
     $pod_like->(


### PR DESCRIPTION
Remove unused X linking feature.  Use built in Pod::Simple::XHTML anchor linking.  Clean up link mapping accessor.