### PR TITLE
Fixes Issue #534

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -12,6 +12,7 @@ verbose = 11
 [-RegularExpressions::RequireLineBoundaryMatching]
 [-Subroutines::ProhibitExplicitReturnUndef]
 [-ValuesAndExpressions::ProhibitNoisyQuotes]
+[-ValuesAndExpressions::ProhibitAccessOfPrivateData]
 [-Variables::ProhibitPunctuationVars]
 
 [CodeLayout::RequireTrailingCommas]

--- a/lib/MetaCPAN/Document/File/Set.pm
+++ b/lib/MetaCPAN/Document/File/Set.pm
@@ -38,6 +38,7 @@ sub find {
         }
         )->sort(
         [
+            '_score',
             { 'date'       => { order => 'desc' } },
             { 'mime'       => { order => 'asc' } },
             { 'stat.mtime' => { order => 'desc' } }


### PR DESCRIPTION
The sort being performed was ignoring the search score.  This short
circuited the 'should' section of the query completely.  This patch
sets the _score as the primary sort criteria, and falls back on the
existing criteria to find the latest, most up-to-date file.