### PR TITLE
script/watcher: use the queue

### DIFF
--- a/lib/MetaCPAN/Script/Watcher.pm
+++ b/lib/MetaCPAN/Script/Watcher.pm
@@ -168,7 +168,8 @@ sub index_release {
 
     my @run = (
         $FindBin::RealBin . "/metacpan",
-        'release', $archive, '--latest', '--index', $self->index->name
+        'release', $archive, '--latest', '--queue', '--index',
+        $self->index->name
     );
     log_debug {"Running @run"};
     system(@run) unless ( $self->dry_run );


### PR DESCRIPTION
watcher doesn't always get the 'latest' setting right.
attempting to solve through queuing (uses separate tasks with priorities to ensure order)