### PR TITLE
Find module query revamp.

### DIFF
--- a/lib/MetaCPAN/Document/File/Set.pm
+++ b/lib/MetaCPAN/Document/File/Set.pm
@@ -23,14 +23,23 @@ sub find {
                     { term => { indexed    => 1, } },
                     { term => { authorized => 1 } },
                     { term => { status     => 'latest' } },
+                    { or => [
+                        {
+                            nested => {
+                                path => "module",
+                                filter => {
+                                    and => [
+                                        { term => { "module.name" => $module } },
+                                        { term => { "module.authorized" => 1 } },
+                                    ]
+                                }
+                            }
+                        },
+                        { term => { documentation => $module } },
+                    ] },
                 ],
                 should => [
-                    {
-                        and => [
-                            { term => { documentation => $module } },
-                            { term => { pod           => $module } },
-                        ]
-                    },
+                    { term => { documentation => $module } },
                     {
                         nested => {
                             path   => 'module',
@@ -45,13 +54,13 @@ sub find {
                                 ]
                             }
                         }
-                    }
-                ],
-                minimum_should_match => 1,
+                    },
+                ]
             }
         }
         )->sort(
         [
+            '_score',
             { 'version_numified' => { order => 'desc' } },
             { 'date'             => { order => 'desc' } },
             { 'mime'             => { order => 'asc' } },


### PR DESCRIPTION
Drawing on the work from find_download_url, simplify the query to return
modules with valid POD entries.  Return documents where either
the documentation and pod contain the module name, *OR* the
module.associated_pod is set with module.name matching the request path.

Using 'minimum_should_match=1' to ensure that a valid .pm/POD is
selected.