### PR TITLE
force documentation to get built when indexing

### DIFF
--- a/lib/MetaCPAN/Script/Release.pm
+++ b/lib/MetaCPAN/Script/Release.pm
@@ -255,6 +255,7 @@ sub import_archive {
             push( @provides, $_->name ) if $_->indexed && $_->authorized;
         }
         $file->clear_module if ( $file->is_pod_file );
+        $file->documentation;
         log_trace {"reindexing file $file->{path}"};
         $bulk->put($file);
         if ( !$document->has_abstract && $file->abstract ) {


### PR DESCRIPTION
With most dists, documentation will get built by set_authorized.  That
isn't reliable though, especially since for the perl dist, we skip that
method.