### PR TITLE
/search/autocomplete: Collapse single-valued arrays in fields

### DIFF
--- a/lib/MetaCPAN/Server/Controller/Search/Autocomplete.pm
+++ b/lib/MetaCPAN/Server/Controller/Search/Autocomplete.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Moose;
+use MetaCPAN::Util qw( single_valued_arrayref_to_scalar );
 
 BEGIN { extends 'MetaCPAN::Server::Controller' }
 
@@ -16,8 +17,12 @@ sub get : Local : Path('') : Args(0) {
     my $model = $self->model($c);
     $model = $model->fields( [qw(documentation release author distribution)] )
         unless $model->fields;
-    my $data = $model->autocomplete( $c->req->param("q") )->raw;
-    $c->stash( $data->all );
+    my $data = $model->autocomplete( $c->req->param("q") )->raw->all;
+
+    single_valued_arrayref_to_scalar( $_->{fields} )
+        for @{ $data->{hits}{hits} };
+
+    $c->stash($data);
 }
 
 1;

--- a/t/server/controller/search/autocomplete.t
+++ b/t/server/controller/search/autocomplete.t
@@ -14,7 +14,7 @@ test_psgi app, sub {
             'GET' );
         my $json = decode_json_ok($res);
 
-        my $got = [ map { @{ $_->{fields}{documentation} } }
+        my $got = [ map { $_->{fields}{documentation} }
                 @{ $json->{hits}{hits} } ];
 
         is_deeply $got, [


### PR DESCRIPTION
To be consistent with API v0 and other v1 endpoints.  No need to leak
more crazy from Elasticsearch than necessary.