### PR TITLE
temp. revert cron scripts to use 'old' index

### DIFF
--- a/bin/cron/author.sh
+++ b/bin/cron/author.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
-export ES_SCRIPT_INDEX=author_01
-/home/metacpan/bin/metacpan-api-carton-exec bin/metacpan author --index author_01
+# export ES_SCRIPT_INDEX=author_01
+# /home/metacpan/bin/metacpan-api-carton-exec bin/metacpan author --index author_01
+
+export ES_SCRIPT_INDEX=cpan_v1_01
+/home/metacpan/bin/metacpan-api-carton-exec bin/metacpan author --index cpan_v1_01
+
 unset ES_SCRIPT_INDEX

--- a/bin/cron/backups.sh
+++ b/bin/cron/backups.sh
@@ -1,10 +1,14 @@
 #!/bin/sh
 
-export ES_SCRIPT_INDEX=favorite_01
-/home/metacpan/bin/metacpan-api-carton-exec bin/metacpan backup --index favorite_01 --type favorite
+#export ES_SCRIPT_INDEX=favorite_01
+#/home/metacpan/bin/metacpan-api-carton-exec bin/metacpan backup --index favorite_01 --type favorite
 
-export ES_SCRIPT_INDEX=author_01
-/home/metacpan/bin/metacpan-api-carton-exec bin/metacpan backup --index author_01 --type author
+#export ES_SCRIPT_INDEX=author_01
+#/home/metacpan/bin/metacpan-api-carton-exec bin/metacpan backup --index author_01 --type author
+
+export ES_SCRIPT_INDEX=cpan_v1_01
+/home/metacpan/bin/metacpan-api-carton-exec bin/metacpan backup --index cpan_v1_01 --type favorite
+/home/metacpan/bin/metacpan-api-carton-exec bin/metacpan backup --index cpan_v1_01 --type author
 
 export ES_SCRIPT_INDEX=user
 /home/metacpan/bin/metacpan-api-carton-exec bin/metacpan backup --index user


### PR DESCRIPTION
since we reverted the index split, this is to prevent cron failure