### PR TITLE
[WIP] mapping deploy simplified

### DIFF
--- a/lib/MetaCPAN/Document/File.pm
+++ b/lib/MetaCPAN/Document/File.pm
@@ -363,6 +363,33 @@ sub _build_documentation {
     return undef;
 }
 
+=head2 suggest
+
+Autocomplete suggester data.
+
+=cut
+
+has suggest => (
+    is      => 'ro',
+    lazy    => 1,
+    builder => '_build_suggest',
+);
+
+sub _build_suggest {
+    my $self = shift;
+    my $doc  = $self->documentation;
+    return unless $doc;
+
+    my $weight = 1000 - length($doc);
+    $weight = 0 if $weight < 0;
+
+    return {
+        input   => [$doc],
+        payload => { doc_name => $doc },
+        weight  => $weight
+    };
+}
+
 =head2 indexed
 
 B<Default 0>

--- a/lib/MetaCPAN/Document/File/Set.pm
+++ b/lib/MetaCPAN/Document/File/Set.pm
@@ -31,7 +31,7 @@ sub find {
                                     filter => {
                                         and => [
                                             {
-                                                term => {
+                                                match => {
                                                     "module.name" => $module
                                                 }
                                             },
@@ -55,7 +55,7 @@ sub find {
                             path   => 'module',
                             filter => {
                                 and => [
-                                    { term => { 'module.name' => $module } },
+                                    { match => { 'module.name' => $module } },
                                     {
                                         exists => {
                                             field => 'module.associated_pod'
@@ -243,9 +243,9 @@ sub find_download_url {
             filter     => {
                 bool => {
                     must => [
-                        { term => { 'module.authorized' => 1 } },
-                        { term => { 'module.indexed'    => 1 } },
-                        { term => { 'module.name'       => $module } },
+                        { term  => { 'module.authorized' => 1 } },
+                        { term  => { 'module.indexed'    => 1 } },
+                        { match => { 'module.name'       => $module } },
                         (
                             exists $version_filters->{must}
                             ? @{ $version_filters->{must} }
@@ -391,7 +391,7 @@ sub history {
                                 must => [
                                     { term => { "module.authorized" => 1 } },
                                     { term => { "module.indexed"    => 1 } },
-                                    { term => { "module.name" => $module } },
+                                    { match => { "module.name" => $module } },
                                 ]
                             }
                         }

--- a/lib/MetaCPAN/Script/Check.pm
+++ b/lib/MetaCPAN/Script/Check.pm
@@ -93,9 +93,9 @@ sub check_modules {
                     query  => { match_all => {} },
                     filter => {
                         and => [
-                            { term => { 'module.name' => $pkg } },
-                            { term => { 'authorized'  => 'true' } },
-                            { term => { 'maturity'    => 'released' } },
+                            { match => { 'module.name' => $pkg } },
+                            { term  => { 'authorized'  => 'true' } },
+                            { term  => { 'maturity'    => 'released' } },
                         ],
                     },
                 );

--- a/lib/MetaCPAN/Script/Mapping/Cpan/Author.pm
+++ b/lib/MetaCPAN/Script/Mapping/Cpan/Author.pm
@@ -1,0 +1,163 @@
+package MetaCPAN::Script::Mapping::Cpan::Author;
+
+use strict;
+use warnings;
+
+sub mapping {
+    '{
+        "dynamic" : false,
+        "properties" : {
+           "profile" : {
+              "include_in_root" : true,
+              "dynamic" : false,
+              "type" : "nested",
+              "properties" : {
+                 "name" : {
+                    "ignore_above" : 2048,
+                    "index" : "not_analyzed",
+                    "type" : "string"
+                 },
+                 "id" : {
+                    "ignore_above" : 2048,
+                    "index" : "not_analyzed",
+                    "fields" : {
+                       "analyzed" : {
+                          "store" : true,
+                          "fielddata" : {
+                             "format" : "disabled"
+                          },
+                          "type" : "string",
+                          "analyzer" : "simple"
+                       }
+                    },
+                    "type" : "string"
+                 }
+              }
+           },
+           "website" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "email" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "city" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "user" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "updated" : {
+              "format" : "strict_date_optional_time||epoch_millis",
+              "type" : "date"
+           },
+           "pauseid" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "country" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "gravatar_url" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "location" : {
+              "type" : "geo_point"
+           },
+           "donation" : {
+              "dynamic" : true,
+              "properties" : {
+                 "name" : {
+                    "ignore_above" : 2048,
+                    "index" : "not_analyzed",
+                    "type" : "string"
+                 },
+                 "id" : {
+                    "ignore_above" : 2048,
+                    "index" : "not_analyzed",
+                    "type" : "string"
+                 }
+              }
+           },
+           "asciiname" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "fields" : {
+                 "analyzed" : {
+                    "store" : true,
+                    "fielddata" : {
+                       "format" : "disabled"
+                    },
+                    "type" : "string",
+                    "analyzer" : "standard"
+                 }
+              },
+              "type" : "string"
+           },
+           "name" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "fields" : {
+                 "analyzed" : {
+                    "store" : true,
+                    "fielddata" : {
+                       "format" : "disabled"
+                    },
+                    "type" : "string",
+                    "analyzer" : "standard"
+                 }
+              },
+              "type" : "string"
+           },
+           "region" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "blog" : {
+              "dynamic" : true,
+              "properties" : {
+                 "feed" : {
+                    "ignore_above" : 2048,
+                    "index" : "not_analyzed",
+                    "type" : "string"
+                 },
+                 "url" : {
+                    "ignore_above" : 2048,
+                    "index" : "not_analyzed",
+                    "type" : "string"
+                 }
+              }
+           },
+           "perlmongers" : {
+              "dynamic" : true,
+              "properties" : {
+                 "url" : {
+                    "ignore_above" : 2048,
+                    "index" : "not_analyzed",
+                    "type" : "string"
+                 },
+                 "name" : {
+                    "ignore_above" : 2048,
+                    "index" : "not_analyzed",
+                    "type" : "string"
+                 }
+              }
+           }
+        }
+     }';
+}
+
+1;

--- a/lib/MetaCPAN/Script/Mapping/Cpan/Distribution.pm
+++ b/lib/MetaCPAN/Script/Mapping/Cpan/Distribution.pm
@@ -1,0 +1,91 @@
+package MetaCPAN::Script::Mapping::Cpan::Distribution;
+
+use strict;
+use warnings;
+
+sub mapping {
+    '{
+        "dynamic" : false,
+        "properties" : {
+           "river" : {
+              "dynamic" : true,
+              "properties" : {
+                 "immediate" : {
+                    "type" : "integer"
+                 },
+                 "bucket" : {
+                    "type" : "integer"
+                 },
+                 "total" : {
+                    "type" : "integer"
+                 }
+              }
+           },
+           "name" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "bugs" : {
+              "dynamic" : true,
+              "properties" : {
+                 "rt" : {
+                    "dynamic" : true,
+                    "properties" : {
+                       "source" : {
+                          "ignore_above" : 2048,
+                          "index" : "not_analyzed",
+                          "type" : "string"
+                       },
+                       "closed" : {
+                          "type" : "integer"
+                       },
+                       "rejected" : {
+                          "type" : "integer"
+                       },
+                       "resolved" : {
+                          "type" : "integer"
+                       },
+                       "active" : {
+                          "type" : "integer"
+                       },
+                       "patched" : {
+                          "type" : "integer"
+                       },
+                       "stalled" : {
+                          "type" : "integer"
+                       },
+                       "open" : {
+                          "type" : "integer"
+                       },
+                       "new" : {
+                          "type" : "integer"
+                       }
+                    }
+                 },
+                 "github" : {
+                    "dynamic" : true,
+                    "properties" : {
+                       "source" : {
+                          "ignore_above" : 2048,
+                          "index" : "not_analyzed",
+                          "type" : "string"
+                       },
+                       "open" : {
+                          "type" : "integer"
+                       },
+                       "closed" : {
+                          "type" : "integer"
+                       },
+                       "active" : {
+                          "type" : "integer"
+                       }
+                    }
+                 }
+              }
+           }
+        }
+     }';
+}
+
+1;

--- a/lib/MetaCPAN/Script/Mapping/Cpan/Favorite.pm
+++ b/lib/MetaCPAN/Script/Mapping/Cpan/Favorite.pm
@@ -1,0 +1,43 @@
+package MetaCPAN::Script::Mapping::Cpan::Favorite;
+
+use strict;
+use warnings;
+
+sub mapping {
+    '{
+        "dynamic" : false,
+        "properties" : {
+           "date" : {
+              "format" : "strict_date_optional_time||epoch_millis",
+              "type" : "date"
+           },
+           "user" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "release" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "id" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "author" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "distribution" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           }
+        }
+     }';
+}
+
+1;

--- a/lib/MetaCPAN/Script/Mapping/Cpan/File.pm
+++ b/lib/MetaCPAN/Script/Mapping/Cpan/File.pm
@@ -53,7 +53,7 @@ sub mapping {
            },
            "documentation" : {
               "ignore_above" : 2048,
-              "index" : "not_analyzed",
+              "index" : "analyzed",
               "fields" : {
                  "analyzed" : {
                     "store" : true,
@@ -112,7 +112,7 @@ sub mapping {
                  },
                  "name" : {
                     "ignore_above" : 2048,
-                    "index" : "not_analyzed",
+                    "index" : "analyzed",
                     "fields" : {
                        "analyzed" : {
                           "store" : true,

--- a/lib/MetaCPAN/Script/Mapping/Cpan/File.pm
+++ b/lib/MetaCPAN/Script/Mapping/Cpan/File.pm
@@ -7,6 +7,12 @@ sub mapping {
     '{
         "dynamic" : false,
         "properties" : {
+           "suggest": {
+              "type" : "completion",
+              "analyzer" : "simple",
+              "search_analyzer" : "simple",
+              "payloads" : true
+           },
            "pod" : {
               "index" : "no",
               "fields" : {
@@ -82,6 +88,10 @@ sub mapping {
                     "store" : true,
                     "type" : "string",
                     "analyzer" : "camelcase"
+                 },
+                 "raw" : {
+                    "type" : "string",
+                    "index" : "not_analyzed"
                  }
               },
               "type" : "string"
@@ -131,6 +141,10 @@ sub mapping {
                           "store" : true,
                           "type" : "string",
                           "analyzer" : "camelcase"
+                       },
+                       "raw" : {
+                          "type" : "string",
+                          "index" : "not_analyzed"
                        }
                     },
                     "type" : "string"

--- a/lib/MetaCPAN/Script/Mapping/Cpan/File.pm
+++ b/lib/MetaCPAN/Script/Mapping/Cpan/File.pm
@@ -1,0 +1,286 @@
+package MetaCPAN::Script::Mapping::Cpan::File;
+
+use strict;
+use warnings;
+
+sub mapping {
+    '{
+        "dynamic" : false,
+        "properties" : {
+           "pod" : {
+              "index" : "no",
+              "fields" : {
+                 "analyzed" : {
+                    "fielddata" : {
+                       "format" : "disabled"
+                    },
+                    "type" : "string",
+                    "analyzer" : "standard",
+                    "term_vector" : "with_positions_offsets"
+                 }
+              },
+              "type" : "string"
+           },
+           "status" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "date" : {
+              "format" : "strict_date_optional_time||epoch_millis",
+              "type" : "date"
+           },
+           "author" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "maturity" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "directory" : {
+              "type" : "boolean"
+           },
+           "dir" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "indexed" : {
+              "type" : "boolean"
+           },
+           "documentation" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "fields" : {
+                 "analyzed" : {
+                    "store" : true,
+                    "fielddata" : {
+                       "format" : "disabled"
+                    },
+                    "type" : "string",
+                    "analyzer" : "standard"
+                 },
+                 "edge_camelcase" : {
+                    "store" : true,
+                    "type" : "string",
+                    "analyzer" : "edge_camelcase"
+                 },
+                 "lowercase" : {
+                    "store" : true,
+                    "type" : "string",
+                    "analyzer" : "lowercase"
+                 },
+                 "edge" : {
+                    "store" : true,
+                    "type" : "string",
+                    "analyzer" : "edge"
+                 },
+                 "camelcase" : {
+                    "store" : true,
+                    "type" : "string",
+                    "analyzer" : "camelcase"
+                 }
+              },
+              "type" : "string"
+           },
+           "id" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "module" : {
+              "include_in_root" : true,
+              "dynamic" : false,
+              "type" : "nested",
+              "properties" : {
+                 "indexed" : {
+                    "type" : "boolean"
+                 },
+                 "authorized" : {
+                    "type" : "boolean"
+                 },
+                 "associated_pod" : {
+                    "type" : "string"
+                 },
+                 "version" : {
+                    "ignore_above" : 2048,
+                    "index" : "not_analyzed",
+                    "type" : "string"
+                 },
+                 "name" : {
+                    "ignore_above" : 2048,
+                    "index" : "not_analyzed",
+                    "fields" : {
+                       "analyzed" : {
+                          "store" : true,
+                          "fielddata" : {
+                             "format" : "disabled"
+                          },
+                          "type" : "string",
+                          "analyzer" : "standard"
+                       },
+                       "lowercase" : {
+                          "store" : true,
+                          "type" : "string",
+                          "analyzer" : "lowercase"
+                       },
+                       "camelcase" : {
+                          "store" : true,
+                          "type" : "string",
+                          "analyzer" : "camelcase"
+                       }
+                    },
+                    "type" : "string"
+                 },
+                 "version_numified" : {
+                    "type" : "float"
+                 }
+              }
+           },
+           "authorized" : {
+              "type" : "boolean"
+           },
+           "pod_lines" : {
+              "doc_values" : true,
+              "ignore_above" : 2048,
+              "index" : "no",
+              "type" : "string"
+           },
+           "download_url" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "version" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "name" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "binary" : {
+              "type" : "boolean"
+           },
+           "version_numified" : {
+              "type" : "float"
+           },
+           "release" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "fields" : {
+                 "analyzed" : {
+                    "store" : true,
+                    "fielddata" : {
+                       "format" : "disabled"
+                    },
+                    "type" : "string",
+                    "analyzer" : "standard"
+                 },
+                 "lowercase" : {
+                    "store" : true,
+                    "type" : "string",
+                    "analyzer" : "lowercase"
+                 },
+                 "camelcase" : {
+                    "store" : true,
+                    "type" : "string",
+                    "analyzer" : "camelcase"
+                 }
+              },
+              "type" : "string"
+           },
+           "path" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "description" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "stat" : {
+              "dynamic" : true,
+              "properties" : {
+                 "uid" : {
+                    "type" : "long"
+                 },
+                 "mtime" : {
+                    "type" : "integer"
+                 },
+                 "mode" : {
+                    "type" : "integer"
+                 },
+                 "size" : {
+                    "type" : "integer"
+                 },
+                 "gid" : {
+                    "type" : "long"
+                 }
+              }
+           },
+           "distribution" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "fields" : {
+                 "analyzed" : {
+                    "store" : true,
+                    "fielddata" : {
+                       "format" : "disabled"
+                    },
+                    "type" : "string",
+                    "analyzer" : "standard"
+                 },
+                 "lowercase" : {
+                    "store" : true,
+                    "type" : "string",
+                    "analyzer" : "lowercase"
+                 },
+                 "camelcase" : {
+                    "store" : true,
+                    "type" : "string",
+                    "analyzer" : "camelcase"
+                 }
+              },
+              "type" : "string"
+           },
+           "level" : {
+              "type" : "integer"
+           },
+           "sloc" : {
+              "type" : "integer"
+           },
+           "abstract" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "fields" : {
+                 "analyzed" : {
+                    "store" : true,
+                    "fielddata" : {
+                       "format" : "disabled"
+                    },
+                    "type" : "string",
+                    "analyzer" : "standard"
+                 }
+              },
+              "type" : "string"
+           },
+           "slop" : {
+              "type" : "integer"
+           },
+           "mime" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           }
+        }
+     }';
+}
+
+1;

--- a/lib/MetaCPAN/Script/Mapping/Cpan/Mirror.pm
+++ b/lib/MetaCPAN/Script/Mapping/Cpan/Mirror.pm
@@ -1,0 +1,175 @@
+package MetaCPAN::Script::Mapping::Cpan::Mirror;
+
+use strict;
+use warnings;
+
+sub mapping {
+    '{
+        "dynamic" : false,
+        "properties" : {
+           "inceptdate" : {
+              "format" : "strict_date_optional_time||epoch_millis",
+              "type" : "date"
+           },
+           "contact" : {
+              "dynamic" : false,
+              "properties" : {
+                 "contact_site" : {
+                    "ignore_above" : 2048,
+                    "index" : "not_analyzed",
+                    "type" : "string"
+                 },
+                 "contact_user" : {
+                    "ignore_above" : 2048,
+                    "index" : "not_analyzed",
+                    "type" : "string"
+                 }
+              }
+           },
+           "reitredate" : {
+              "format" : "strict_date_optional_time||epoch_millis",
+              "type" : "date"
+           },
+           "ftp" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "A_or_CNAME" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "city" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "fields" : {
+                 "analyzed" : {
+                    "store" : true,
+                    "fielddata" : {
+                       "format" : "disabled"
+                    },
+                    "type" : "string",
+                    "analyzer" : "standard"
+                 }
+              },
+              "type" : "string"
+           },
+           "rsync" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "http" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "aka_name" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "country" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "fields" : {
+                 "analyzed" : {
+                    "store" : true,
+                    "fielddata" : {
+                       "format" : "disabled"
+                    },
+                    "type" : "string",
+                    "analyzer" : "standard"
+                 }
+              },
+              "type" : "string"
+           },
+           "dnsrr" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "ccode" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "location" : {
+              "type" : "geo_point"
+           },
+           "org" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "fields" : {
+                 "analyzed" : {
+                    "store" : true,
+                    "fielddata" : {
+                       "format" : "disabled"
+                    },
+                    "type" : "string",
+                    "analyzer" : "standard"
+                 }
+              },
+              "type" : "string"
+           },
+           "src" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "region" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "fields" : {
+                 "analyzed" : {
+                    "store" : true,
+                    "fielddata" : {
+                       "format" : "disabled"
+                    },
+                    "type" : "string",
+                    "analyzer" : "standard"
+                 }
+              },
+              "type" : "string"
+           },
+           "name" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "note" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "freq" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "continent" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "fields" : {
+                 "analyzed" : {
+                    "store" : true,
+                    "fielddata" : {
+                       "format" : "disabled"
+                    },
+                    "type" : "string",
+                    "analyzer" : "standard"
+                 }
+              },
+              "type" : "string"
+           },
+           "tz" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           }
+        }
+    }';
+}
+
+1;

--- a/lib/MetaCPAN/Script/Mapping/Cpan/Rating.pm
+++ b/lib/MetaCPAN/Script/Mapping/Cpan/Rating.pm
@@ -1,0 +1,64 @@
+package MetaCPAN::Script::Mapping::Cpan::Rating;
+
+use strict;
+use warnings;
+
+sub mapping {
+    '{
+        "dynamic" : false,
+        "properties" : {
+           "date" : {
+              "format" : "strict_date_optional_time||epoch_millis",
+              "type" : "date"
+           },
+           "release" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "author" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "details" : {
+              "dynamic" : false,
+              "properties" : {
+                 "documentation" : {
+                    "ignore_above" : 2048,
+                    "index" : "not_analyzed",
+                    "type" : "string"
+                 }
+              }
+           },
+           "rating" : {
+              "type" : "float"
+           },
+           "distribution" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "helpful" : {
+              "dynamic" : false,
+              "properties" : {
+                 "value" : {
+                    "type" : "boolean"
+                 },
+                 "user" : {
+                    "ignore_above" : 2048,
+                    "index" : "not_analyzed",
+                    "type" : "string"
+                 }
+              }
+           },
+           "user" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           }
+        }
+     }';
+}
+
+1;

--- a/lib/MetaCPAN/Script/Mapping/Cpan/Release.pm
+++ b/lib/MetaCPAN/Script/Mapping/Cpan/Release.pm
@@ -1,0 +1,267 @@
+package MetaCPAN::Script::Mapping::Cpan::Release;
+
+use strict;
+use warnings;
+
+sub mapping {
+    '{
+        "dynamic" : false,
+        "properties" : {
+           "resources" : {
+              "include_in_root" : true,
+              "dynamic" : true,
+              "type" : "nested",
+              "properties" : {
+                 "repository" : {
+                    "include_in_root" : true,
+                    "dynamic" : true,
+                    "type" : "nested",
+                    "properties" : {
+                       "web" : {
+                          "ignore_above" : 2048,
+                          "index" : "not_analyzed",
+                          "type" : "string"
+                       },
+                       "url" : {
+                          "ignore_above" : 2048,
+                          "index" : "not_analyzed",
+                          "type" : "string"
+                       },
+                       "type" : {
+                          "ignore_above" : 2048,
+                          "index" : "not_analyzed",
+                          "type" : "string"
+                       }
+                    }
+                 },
+                 "homepage" : {
+                    "ignore_above" : 2048,
+                    "index" : "not_analyzed",
+                    "type" : "string"
+                 },
+                 "bugtracker" : {
+                    "include_in_root" : true,
+                    "dynamic" : true,
+                    "type" : "nested",
+                    "properties" : {
+                       "web" : {
+                          "ignore_above" : 2048,
+                          "index" : "not_analyzed",
+                          "type" : "string"
+                       },
+                       "mailto" : {
+                          "ignore_above" : 2048,
+                          "index" : "not_analyzed",
+                          "type" : "string"
+                       }
+                    }
+                 },
+                 "license" : {
+                    "ignore_above" : 2048,
+                    "index" : "not_analyzed",
+                    "type" : "string"
+                 }
+              }
+           },
+           "status" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "date" : {
+              "format" : "strict_date_optional_time||epoch_millis",
+              "type" : "date"
+           },
+           "author" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "maturity" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "dependency" : {
+              "include_in_root" : true,
+              "dynamic" : false,
+              "type" : "nested",
+              "properties" : {
+                 "version" : {
+                    "ignore_above" : 2048,
+                    "index" : "not_analyzed",
+                    "type" : "string"
+                 },
+                 "relationship" : {
+                    "ignore_above" : 2048,
+                    "index" : "not_analyzed",
+                    "type" : "string"
+                 },
+                 "phase" : {
+                    "ignore_above" : 2048,
+                    "index" : "not_analyzed",
+                    "type" : "string"
+                 },
+                 "module" : {
+                    "ignore_above" : 2048,
+                    "index" : "not_analyzed",
+                    "type" : "string"
+                 }
+              }
+           },
+           "id" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "authorized" : {
+              "type" : "boolean"
+           },
+           "changes_file" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "download_url" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "first" : {
+              "type" : "boolean"
+           },
+           "archive" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "version" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "name" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "fields" : {
+                 "analyzed" : {
+                    "store" : true,
+                    "fielddata" : {
+                       "format" : "disabled"
+                    },
+                    "type" : "string",
+                    "analyzer" : "standard"
+                 },
+                 "lowercase" : {
+                    "store" : true,
+                    "type" : "string",
+                    "analyzer" : "lowercase"
+                 },
+                 "camelcase" : {
+                    "store" : true,
+                    "type" : "string",
+                    "analyzer" : "camelcase"
+                 }
+              },
+              "type" : "string"
+           },
+           "version_numified" : {
+              "type" : "float"
+           },
+           "license" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "stat" : {
+              "dynamic" : true,
+              "properties" : {
+                 "uid" : {
+                    "type" : "long"
+                 },
+                 "mtime" : {
+                    "type" : "integer"
+                 },
+                 "mode" : {
+                    "type" : "integer"
+                 },
+                 "size" : {
+                    "type" : "integer"
+                 },
+                 "gid" : {
+                    "type" : "long"
+                 }
+              }
+           },
+           "distribution" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "fields" : {
+                 "analyzed" : {
+                    "store" : true,
+                    "fielddata" : {
+                       "format" : "disabled"
+                    },
+                    "type" : "string",
+                    "analyzer" : "standard"
+                 },
+                 "lowercase" : {
+                    "store" : true,
+                    "type" : "string",
+                    "analyzer" : "lowercase"
+                 },
+                 "camelcase" : {
+                    "store" : true,
+                    "type" : "string",
+                    "analyzer" : "camelcase"
+                 }
+              },
+              "type" : "string"
+           },
+           "provides" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "tests" : {
+              "dynamic" : true,
+              "properties" : {
+                 "pass" : {
+                    "type" : "integer"
+                 },
+                 "fail" : {
+                    "type" : "integer"
+                 },
+                 "unknown" : {
+                    "type" : "integer"
+                 },
+                 "na" : {
+                    "type" : "integer"
+                 }
+              }
+           },
+           "abstract" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "fields" : {
+                 "analyzed" : {
+                    "store" : true,
+                    "fielddata" : {
+                       "format" : "disabled"
+                    },
+                    "type" : "string",
+                    "analyzer" : "standard"
+                 }
+              },
+              "type" : "string"
+           },
+           "main_module" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           }
+        }
+     }';
+}
+
+1;

--- a/lib/MetaCPAN/Script/Mapping/DeployStatement.pm
+++ b/lib/MetaCPAN/Script/Mapping/DeployStatement.pm
@@ -1,0 +1,67 @@
+package MetaCPAN::Script::Mapping::DeployStatement;
+
+use strict;
+use warnings;
+
+sub mapping {
+    '{
+        "analysis" : {
+           "filter" : {
+              "edge" : {
+                 "max_gram" : 20,
+                 "type" : "edge_ngram",
+                 "min_gram" : 1
+              }
+           },
+           "analyzer" : {
+              "lowercase" : {
+                 "tokenizer" : "keyword",
+                 "filter" : "lowercase"
+              },
+              "fulltext" : {
+                 "type" : "english"
+              },
+              "edge_camelcase" : {
+                 "filter" : [
+                    "lowercase",
+                    "edge"
+                 ],
+                 "tokenizer" : "camelcase",
+                 "type" : "custom"
+              },
+              "edge" : {
+                 "filter" : [
+                    "lowercase",
+                    "edge"
+                 ],
+                 "tokenizer" : "standard",
+                 "type" : "custom"
+              },
+              "camelcase" : {
+                 "filter" : [
+                    "lowercase",
+                    "unique"
+                 ],
+                 "type" : "custom",
+                 "tokenizer" : "camelcase"
+              }
+           },
+           "tokenizer" : {
+              "camelcase" : {
+                 "type" : "pattern",
+                 "pattern" : "([^\\\\p{L}\\\\d]+)|(?<=\\\\D)(?=\\\\d)|(?<=\\\\d)(?=\\\\D)|(?<=[\\\\p{L}&&[^\\\\p{Lu}]])(?=\\\\p{Lu})|(?<=\\\\p{Lu})(?=\\\\p{Lu}[\\\\p{L}&&[^\\\\p{Lu}]])"
+              }
+           }
+        },
+        "index" : {
+           "number_of_shards" : 1,
+           "mapper" : {
+              "dynamic" : false
+           },
+           "refresh_interval" : "1s",
+           "number_of_replicas":1
+        }
+    }'
+}
+
+1;

--- a/lib/MetaCPAN/Script/Mapping/User/Account.pm
+++ b/lib/MetaCPAN/Script/Mapping/User/Account.pm
@@ -1,0 +1,64 @@
+package MetaCPAN::Script::Mapping::User::Account;
+
+use strict;
+use warnings;
+
+sub mapping {
+    '{
+        "_timestamp" : {
+           "enabled" : true
+        },
+        "dynamic" : "false",
+        "properties" : {
+           "looks_human" : {
+              "type" : "boolean"
+           },
+           "identity" : {
+              "dynamic" : "false",
+              "properties" : {
+                 "name" : {
+                    "ignore_above" : 2048,
+                    "index" : "not_analyzed",
+                    "type" : "string"
+                 },
+                 "key" : {
+                    "ignore_above" : 2048,
+                    "index" : "not_analyzed",
+                    "type" : "string"
+                 }
+              }
+           },
+           "access_token" : {
+              "dynamic" : "true",
+              "properties" : {
+                 "client" : {
+                    "ignore_above" : 2048,
+                    "index" : "not_analyzed",
+                    "type" : "string"
+                 },
+                 "token" : {
+                    "ignore_above" : 2048,
+                    "index" : "not_analyzed",
+                    "type" : "string"
+                 }
+              }
+           },
+           "id" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "passed_captcha" : {
+              "format" : "strict_date_optional_time||epoch_millis",
+              "type" : "date"
+           },
+           "code" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           }
+        }
+     }';
+}
+
+1;

--- a/lib/MetaCPAN/Script/Mapping/User/Identity.pm
+++ b/lib/MetaCPAN/Script/Mapping/User/Identity.pm
@@ -1,0 +1,24 @@
+package MetaCPAN::Script::Mapping::User::Identity;
+
+use strict;
+use warnings;
+
+sub mapping {
+    '{
+        "dynamic" : false,
+        "properties" : {
+           "name" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "key" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           }
+        }
+     }';
+}
+
+1;

--- a/lib/MetaCPAN/Script/Mapping/User/Session.pm
+++ b/lib/MetaCPAN/Script/Mapping/User/Session.pm
@@ -1,0 +1,15 @@
+package MetaCPAN::Script::Mapping::User::Session;
+
+use strict;
+use warnings;
+
+sub mapping {
+    '{
+        "_timestamp" : {
+           "enabled" : true
+        },
+        "dynamic" : "false"
+     }';
+}
+
+1;

--- a/lib/MetaCPAN/Script/Release.pm
+++ b/lib/MetaCPAN/Script/Release.pm
@@ -255,7 +255,8 @@ sub import_archive {
             push( @provides, $_->name ) if $_->indexed && $_->authorized;
         }
         $file->clear_module if ( $file->is_pod_file );
-        $file->documentation;
+        $file->documentation;    # force build
+        $file->suggest;          # force build
         log_trace {"reindexing file $file->{path}"};
         $bulk->put($file);
         if ( !$document->has_abstract && $file->abstract ) {

--- a/lib/MetaCPAN/Script/Suggest.pm
+++ b/lib/MetaCPAN/Script/Suggest.pm
@@ -1,0 +1,117 @@
+package MetaCPAN::Script::Suggest;
+
+use strict;
+use warnings;
+
+use Log::Contextual qw( :log );
+use Moose;
+use MetaCPAN::Types qw( Bool Int );
+use DateTime;
+
+with 'MetaCPAN::Role::Script', 'MooseX::Getopt';
+
+has age => (
+    is            => 'ro',
+    isa           => Int,
+    default       => 1,
+    documentation => 'number of days back to cover.',
+);
+
+has all => (
+    is            => 'ro',
+    isa           => Bool,
+    default       => 0,
+    documentation => 'update all records',
+);
+
+sub run {
+    my $self = shift;
+
+    if ( $self->all ) {
+        my $dt = DateTime->new( year => 1994, month => 1 );
+        my $end_time = DateTime->now()->add( months => 1 );
+
+        while ( $dt < $end_time ) {
+            my $gte = $dt->strftime("%Y-%m");
+            $dt->add( months => 1 );
+            my $lt = $dt->strftime("%Y-%m");
+
+            my $range = +{ range => { date => { gte => $gte, lt => $lt } } };
+            log_info {"updating suggest data for month: $gte"};
+            $self->_update_slice($range);
+        }
+    }
+    else {
+        my $gte = DateTime->now()->subtract( days => $self->age )
+            ->strftime("%Y-%m-%d");
+        my $range = +{ range => { date => { gte => $gte } } };
+        log_info {"updating suggest data since: $gte "};
+        $self->_update_slice($range);
+    }
+
+    log_info {"done."};
+}
+
+sub _update_slice {
+    my ( $self, $range ) = @_;
+
+    my $files = $self->es->scroll_helper(
+        index       => $self->index->name,
+        type        => 'file',
+        search_type => 'scan',
+        scroll      => '5m',
+        fields      => [qw< id documentation >],
+        size        => 500,
+        body        => {
+            query => {
+                bool => {
+                    must => [
+                        { exists => { field => "documentation" } }, $range
+                    ],
+                }
+            }
+        },
+    );
+
+    my $bulk = $self->es->bulk_helper(
+        index     => $self->index->name,
+        type      => 'file',
+        max_count => 250,
+        timeout   => '5m',
+    );
+
+    while ( my $file = $files->next ) {
+        my $documentation = $file->{fields}{documentation}[0];
+        my $weight        = 1000 - length($documentation);
+        $weight = 0 if $weight < 0;
+
+        $bulk->update(
+            {
+                id  => $file->{fields}{id}[0],
+                doc => {
+                    suggest => {
+                        input   => [$documentation],
+                        payload => { doc_name => $documentation },
+                        weight  => $weight,
+                    }
+                },
+            }
+        );
+    }
+
+    $bulk->flush;
+}
+
+__PACKAGE__->meta->make_immutable;
+1;
+
+__END__
+
+=head1 SYNOPSIS
+
+ # bin/metacpan suggest
+
+=head1 DESCRIPTION
+
+After importing releases from cpan, this script will set the suggest
+field for autocompletion searches.

--- a/lib/MetaCPAN/Server/Controller/Search/Autocomplete.pm
+++ b/lib/MetaCPAN/Server/Controller/Search/Autocomplete.pm
@@ -4,7 +4,6 @@ use strict;
 use warnings;
 
 use Moose;
-use MetaCPAN::Util qw( single_valued_arrayref_to_scalar );
 
 BEGIN { extends 'MetaCPAN::Server::Controller' }
 
@@ -17,12 +16,7 @@ sub get : Local : Path('') : Args(0) {
     my $model = $self->model($c);
     $model = $model->fields( [qw(documentation release author distribution)] )
         unless $model->fields;
-    my $data
-        = $model->autocomplete( $c->req->param("q") )->source(0)->raw->all;
-
-    single_valued_arrayref_to_scalar( $_->{fields} )
-        for @{ $data->{hits}{hits} };
-
+    my $data = $model->autocomplete( $c->req->param("q") );
     $c->stash($data);
 }
 

--- a/t/server/controller/search/autocomplete.t
+++ b/t/server/controller/search/autocomplete.t
@@ -13,9 +13,7 @@ test_psgi app, sub {
         ok( my $res = $cb->( GET '/search/autocomplete?q=Multiple::Modu' ),
             'GET' );
         my $json = decode_json_ok($res);
-
-        my $got = [ map { $_->{fields}{documentation} }
-                @{ $json->{hits}{hits} } ];
+        my $got  = $json->{suggestions};
 
         is_deeply $got, [
             qw(


### PR DESCRIPTION
so, 1st commit just changes the way we currently do (rarely) a rebuild of the index and mappings for all the types.
this commit removes the use of the `ElasticSearchX::Model` functionality to achieve this (so ignores the attributes' meta black magic) and adds simple JSON string methods to reflect the mappings for the types (to be fully ES compatible, easier to read and update)

the 2nd commit changes what I think is wrong with the current mapping - the module.name and documentation were marked as 'index => not_analyzed' which is probably due to wrong logic I introduced into the module when fighting all the fires of adapting it to ES 2.x.
I am sure there are other fields that probably should be changed as well (they are assigned with analyzers but marked as 'not_analyzed', but we can do those one later (even though it does require cloning a new index)

please review the changes first, to make sure the queries are not being completely broken here (tests work)

to deploy this we will need an update to the WEB repo (a parallel branch with the same name, though a small fix there) and replacing the index with a new clone with the updated mapping (I will prepare this one when we're ready)