### PR TITLE
The Fastly role is required to purge_author_key

### DIFF
--- a/lib/MetaCPAN/Server/Controller/User.pm
+++ b/lib/MetaCPAN/Server/Controller/User.pm
@@ -8,6 +8,8 @@ use Moose;
 
 BEGIN { extends 'Catalyst::Controller::REST' }
 
+with 'MetaCPAN::Role::Fastly';
+
 __PACKAGE__->config(
     json_options => { relaxed => 1, allow_nonref => 1 },
     default      => 'text/html',


### PR DESCRIPTION
It was throwing an error because after saving the profile because $self->purge_author_key didn't exist, which resulted in the frontend showing an empty profile with a success message. In the frontend the result $res came in with only a `raw` key, but no `error` key, so no error was ever displayed.

Fixes metacpan/metacpan-web#1846.