### PR TITLE
Added 'custodial' flag to 'author' mapping.

### DIFF
--- a/lib/MetaCPAN/Document/Author.pm
+++ b/lib/MetaCPAN/Document/Author.pm
@@ -92,6 +92,12 @@ has updated => (
     isa => 'DateTime',
 );
 
+has is_pause_custodial_account => (
+    is      => 'ro',
+    isa     => Bool,
+    default => 0,
+);
+
 sub _build_gravatar_url {
     my $self = shift;
 

--- a/lib/MetaCPAN/Script/Author.pm
+++ b/lib/MetaCPAN/Script/Author.pm
@@ -96,6 +96,9 @@ sub index_authors {
                 grep {$_} @{ $put->{website} }
         ];
 
+        $put->{is_pause_custodial_account} = 1
+            if $name and $name =~ /\(PAUSE Custodial Account\)/;
+
         # Now check the format we have is actually correct
         my @errors = MetaCPAN::Document::Author->validate($put);
         next if scalar @errors;

--- a/lib/MetaCPAN/Script/Mapping/CPAN/Author.pm
+++ b/lib/MetaCPAN/Script/Mapping/CPAN/Author.pm
@@ -47,6 +47,9 @@ sub mapping {
               "index" : "not_analyzed",
               "type" : "string"
            },
+           "is_pause_custodial_account" : {
+              "type" : "boolean"
+           },
            "donation" : {
               "dynamic" : true,
               "properties" : {


### PR DESCRIPTION
This flag will be set through Script::Author (bin/metacpan author).

To deploy we need to update the mapping of the current author type, running (on lw-mc-03):
`curl -X PUT 0:9200/cpan/_mapping/author -d'{"properties":{"is_pause_custodial_account":{"type":"boolean"}}}'`
**BEFORE** merging (can poke me to do it when we agree to merge)

This addresses #620 