### PR TITLE
Added cleanup mode for script/permission

### DIFF
--- a/t/server/controller/permission.t
+++ b/t/server/controller/permission.t
@@ -39,8 +39,9 @@ test_psgi app, sub {
         is_deeply(
             decode_json( $res->content ),
             {
-                module_name => $module_name,
-                owner       => 'RWSTAUNER',
+                co_maintainers => [],
+                module_name    => $module_name,
+                owner          => 'RWSTAUNER',
             },
             'Owned by RWSTAUNER, no co-maint'
         );


### PR DESCRIPTION
This will allow cleaning up removed records once in a while
(it requires a longer run time so not suited for every cron run,
and records don't get deleted often anyways).

Usage: add --cleanup flag to the permission script execution.