### PR TITLE
Use the existing ua object

### DIFF
--- a/lib/MetaCPAN/Role/Script.pm
+++ b/lib/MetaCPAN/Role/Script.pm
@@ -148,6 +148,8 @@ sub _build_ua {
             : $ua->proxy( [qw<http https>], $proxy );
     }
 
+    $ua->agent('MetaCPAN');
+
     return $ua;
 }
 

--- a/lib/MetaCPAN/Script/CPANTesters.pm
+++ b/lib/MetaCPAN/Script/CPANTesters.pm
@@ -8,7 +8,6 @@ use File::Spec::Functions qw(catfile);
 use File::Temp qw(tempdir);
 use File::stat qw(stat);
 use IO::Uncompress::Bunzip2 qw(bunzip2);
-use LWP::UserAgent ();
 use Log::Contextual qw( :log :dlog );
 use MetaCPAN::Types qw( Bool File Uri );
 use Moose;
@@ -75,12 +74,11 @@ sub index_reports {
     my $self = shift;
 
     my $es = $self->model->es;
-    my $ua = LWP::UserAgent->new;
 
     log_info { 'Mirroring ' . $self->db };
     my $db = $self->mirror_file;
 
-    $ua->mirror( $self->db, "$db.bz2" ) unless $self->skip_download;
+    $self->ua->mirror( $self->db, "$db.bz2" ) unless $self->skip_download;
 
     if ( -e $db && stat($db)->mtime >= stat("$db.bz2")->mtime ) {
         log_info {'DB hasn\'t been modified'};

--- a/lib/MetaCPAN/Script/Mirrors.pm
+++ b/lib/MetaCPAN/Script/Mirrors.pm
@@ -4,7 +4,6 @@ use strict;
 use warnings;
 
 use Cpanel::JSON::XS ();
-use LWP::UserAgent;
 use Log::Contextual qw( :log :dlog );
 use MetaCPAN::Document::Mirror;
 use Moose;
@@ -19,7 +18,6 @@ sub run {
 
 sub index_mirrors {
     my $self = shift;
-    my $ua   = LWP::UserAgent->new;
     log_info { 'Getting mirrors.json file from ' . $self->cpan };
 
     my $json = $self->cpan->file( 'indices', 'mirrors.json' )->slurp;

--- a/lib/MetaCPAN/Script/Release.pm
+++ b/lib/MetaCPAN/Script/Release.pm
@@ -10,7 +10,6 @@ BEGIN {
 use CPAN::DistnameInfo ();
 use File::Find::Rule;
 use File::stat ();
-use LWP::UserAgent;
 use Log::Contextual qw( :log :dlog );
 use MetaCPAN::Util;
 use MetaCPAN::Model::Release;
@@ -112,15 +111,12 @@ sub run {
                 MetaCPAN::Util::author_dir( $d->cpanid ),
                 $d->filename,
             );
-            my $ua = LWP::UserAgent->new(
-                parse_head => 0,
-                env_proxy  => 1,
-                agent      => 'metacpan',
-                timeout    => 30,
-            );
             $file->dir->mkpath;
             log_info {"Downloading $_"};
-            $ua->mirror( $_, $file );
+
+            $self->ua->parse_head(0);
+            $self->ua->timeout(30);
+            $self->ua->mirror( $_, $file );
             if ( -e $file ) {
                 push( @files, $file );
             }

--- a/lib/MetaCPAN/Script/River.pm
+++ b/lib/MetaCPAN/Script/River.pm
@@ -5,7 +5,6 @@ use namespace::autoclean;
 
 use Cpanel::JSON::XS qw( decode_json );
 use Log::Contextual qw( :log :dlog );
-use LWP::UserAgent ();
 use MetaCPAN::Types qw( ArrayRef Str Uri);
 
 with 'MetaCPAN::Role::Script', 'MooseX::Getopt';
@@ -16,12 +15,6 @@ has river_url => (
     coerce   => 1,
     required => 1,
     default  => 'http://neilb.org/river-of-cpan.json.gz',
-);
-
-has _ua => (
-    is      => 'ro',
-    isa     => 'LWP::UserAgent',
-    default => sub { LWP::UserAgent->new( agent => 'MetaCPAN' ) },
 );
 
 sub run {
@@ -49,7 +42,8 @@ sub index_river_summaries {
 
 sub retrieve_river_summaries {
     my $self = shift;
-    my $resp = $self->_ua->get( $self->river_url );
+
+    my $resp = $self->ua->get( $self->river_url );
 
     $self->handle_error( $resp->status_line ) unless $resp->is_success;
 


### PR DESCRIPTION
We have a 'ua' object defined as attribute in the script role -
use it instead of creating one everywhere.