### PR TITLE
Fix profile update - pass proper 'updated' value

### DIFF
--- a/lib/MetaCPAN/Server/Controller/User.pm
+++ b/lib/MetaCPAN/Server/Controller/User.pm
@@ -92,7 +92,7 @@ sub profile_PUT {
         gravatar_url profile blog
         donation city region country
         location extra perlmongers);
-    $profile->{updated} = DateTime->now;
+    $profile->{updated} = DateTime->now->iso8601;
     my @errors = $c->model('CPAN::Author')->new_document->validate($profile);
 
     if (@errors) {


### PR DESCRIPTION
Since 62dacc7e, the 'updated' field in the profile is a Str
rather than DateTime.

This fixes the validation error when saving a change in the
profile page.

Related discussion on IRC:
12:15:47 � ribasushi� trying to update something in my profile ( email change )
12:15:51 � ribasushi� get back the following:
12:16:41 � ribasushi� https://paste.debian.net/plain/932487
12:17:09 � ribasushi� in your system logs look around May 15th 10:14:00 UTC
18:07:43 � trs� Something stopped accepting the DateTime object used for the "updated" timestamp: 
https://github.com/metacpan/metacpan-api/blob/master/lib/MetaCPAN/Server/Controller/User.pm#L95
18:08:16 � trs� likely culprit: https://github.com/metacpan/metacpan-api/commit/62dacc7e

