### PR TITLE
use numified versions for exact version checks in download_url

### DIFF
--- a/lib/MetaCPAN/Document/File/Set.pm
+++ b/lib/MetaCPAN/Document/File/Set.pm
@@ -318,7 +318,15 @@ sub _version_filters {
     return () unless $version;
 
     if ( $version =~ s/^==\s*// ) {
-        return +{ must => [ { term => { 'module.version' => $version } } ] };
+        return +{
+            must => [
+                {
+                    term => {
+                        'module.version_numified' => $self->_numify($version)
+                    }
+                }
+            ]
+        };
     }
     elsif ( $version =~ /^[<>!]=?\s*/ ) {
         my %ops = qw(< lt <= lte > gt >= gte);


### PR DESCRIPTION
If we are given a version spec like '== 1.013030', it should match 1.013_03.
This matches the behavior of the other version specs.

Re: miyagawa/cpanminus#533