### PR TITLE
Minor cleanup: 'es' is accessible directly

### DIFF
--- a/lib/MetaCPAN/Script/CPANTesters.pm
+++ b/lib/MetaCPAN/Script/CPANTesters.pm
@@ -49,7 +49,7 @@ has _bulk => (
     isa     => 'Search::Elasticsearch::Bulk',
     lazy    => 1,
     default => sub {
-        $_[0]->model->es->bulk_helper(
+        $_[0]->es->bulk_helper(
             index => $_[0]->index->name,
             type  => 'release'
         );
@@ -73,7 +73,7 @@ sub run {
 sub index_reports {
     my $self = shift;
 
-    my $es = $self->model->es;
+    my $es = $self->es;
 
     log_info { 'Mirroring ' . $self->db };
     my $db = $self->mirror_file;

--- a/lib/MetaCPAN/Script/Latest.pm
+++ b/lib/MetaCPAN/Script/Latest.pm
@@ -171,7 +171,7 @@ sub run {
         }
     }
 
-    my $bulk = $self->model->es->bulk_helper(
+    my $bulk = $self->es->bulk_helper(
         index => $self->index->name,
         type  => 'file'
     );


### PR DESCRIPTION
`$self->es` is available... no need for `$self->model->es`