### PR TITLE
Introducing 'contributor' type (release contributors info)

### DIFF
--- a/lib/MetaCPAN/Document/Contributor.pm
+++ b/lib/MetaCPAN/Document/Contributor.pm
@@ -1,0 +1,90 @@
+package MetaCPAN::Document::Contributor;
+
+use MetaCPAN::Moose;
+
+use ElasticSearchX::Model::Document;
+use MetaCPAN::Types qw( Str );
+
+has distribution => (
+    is       => 'ro',
+    isa      => Str,
+    required => 1,
+);
+
+has release_author => (
+    is       => 'ro',
+    isa      => Str,
+    required => 1,
+);
+
+has release_name => (
+    is       => 'ro',
+    isa      => Str,
+    required => 1,
+);
+
+has pauseid => (
+    is       => 'ro',
+    isa      => Str,
+    required => 1,
+);
+
+__PACKAGE__->meta->make_immutable;
+
+package MetaCPAN::Document::Contributor::Set;
+
+use strict;
+use warnings;
+
+use Moose;
+
+extends 'ElasticSearchX::Model::Document::Set';
+
+sub find_release_contributors {
+    my ( $self, $author, $name ) = @_;
+
+    my $query = +{
+        bool => {
+            must => [
+                { term => { release_author => $author } },
+                { term => { release_name   => $name } },
+            ]
+        }
+    };
+
+    my $res = $self->es->search(
+        index => 'contributor',
+        type  => 'contributor',
+        body  => {
+            query => $query,
+            size  => 999,
+        }
+    );
+    $res->{hits}{total} or return {};
+
+    return +{
+        contributors => [ map { $_->{_source} } @{ $res->{hits}{hits} } ]
+    };
+}
+
+sub find_author_contributions {
+    my ( $self, $pauseid ) = @_;
+
+    my $query = +{ term => { pauseid => $pauseid } };
+
+    my $res = $self->es->search(
+        index => 'contributor',
+        type  => 'contributor',
+        body  => {
+            query => $query,
+            size  => 999,
+        }
+    );
+    $res->{hits}{total} or return {};
+
+    return +{
+        contributors => [ map { $_->{_source} } @{ $res->{hits}{hits} } ]
+    };
+}
+
+1;

--- a/lib/MetaCPAN/Document/Release.pm
+++ b/lib/MetaCPAN/Document/Release.pm
@@ -413,6 +413,14 @@ sub get_contributors {
     }
     $authors = [ grep { $_ ne 'unknown' } @$authors ];
 
+    # this check is against a failure in tests (because fake author)
+    return
+        unless $self->es->exists(
+        index => $self->index->name,
+        type  => 'author',
+        id    => $author_name,
+        );
+
     my $author = $self->es->get(
         index => $self->index->name,
         type  => 'author',

--- a/lib/MetaCPAN/Script/Contributor.pm
+++ b/lib/MetaCPAN/Script/Contributor.pm
@@ -1,0 +1,114 @@
+package MetaCPAN::Script::Contributor;
+
+use strict;
+use warnings;
+
+use Moose;
+use Ref::Util qw( is_arrayref );
+
+use MetaCPAN::Types qw( Bool HashRef Str );
+
+with 'MetaCPAN::Role::Script', 'MooseX::Getopt',
+    'MetaCPAN::Script::Role::Contributor';
+
+has all => (
+    is            => 'ro',
+    isa           => Bool,
+    default       => 0,
+    documentation => 'update contributors for *all* releases',
+);
+
+has distribution => (
+    is  => 'ro',
+    isa => Str,
+    documentation =>
+        'update contributors for all releases matching distribution name',
+);
+
+has release => (
+    is  => 'ro',
+    isa => Str,
+    documentation =>
+        'update contributors for a single release (format: author/release_name)',
+);
+
+has author_release => (
+    is      => 'ro',
+    isa     => HashRef,
+    lazy    => 1,
+    builder => '_build_author_release',
+);
+
+sub _build_author_release {
+    my $self = shift;
+    return unless $self->release;
+    my ( $author, $release ) = split m{/}, $self->release;
+    $author && $release
+        or die
+        "Error: invalid 'release' argument (format: PAUSEID/DISTRIBUTION-VERSION)";
+    return +{
+        author  => $author,
+        release => $release,
+    };
+}
+
+sub run {
+    my $self = shift;
+
+    my $query
+        = $self->all ? { match_all => {} }
+        : $self->distribution
+        ? { term => { distribution => $self->distribution } }
+        : $self->release ? {
+        bool => {
+            must => [
+                { term => { author => $self->author_release->{author} } },
+                { term => { name   => $self->author_release->{release} } },
+            ]
+        }
+        }
+        : return;
+
+    my $timeout = $self->all ? '60m' : '5m';
+
+    my $scroll = $self->es->scroll_helper(
+        size   => 500,
+        scroll => $timeout,
+        index  => $self->index->name,
+        type   => 'release',
+        body   => { query => $query },
+        fields => [qw( author distribution name )],
+    );
+
+    my @data;
+
+    while ( my $r = $scroll->next ) {
+        my $contrib_data = $self->get_cpan_author_contributors(
+            $r->{fields}{author}[0],
+            $r->{fields}{name}[0],
+            $r->{fields}{distribution}[0],
+        );
+        next unless is_arrayref($contrib_data);
+        push @data => @{$contrib_data};
+    }
+
+    $self->update_release_contirbutors( \@data, $timeout );
+}
+
+__PACKAGE__->meta->make_immutable;
+1;
+
+__END__
+
+=head1 SYNOPSIS
+
+ # bin/metacpan contributor --all
+ # bin/metacpan contributor --distribution Moose
+ # bin/metacpan contributor --release ETHER/Moose-2.1806
+
+=head1 DESCRIPTION
+
+Update the list of contributors (CPAN authors only) of all/matching
+releases in the 'contributor' type (index).
+
+=cut

--- a/lib/MetaCPAN/Script/Mapping.pm
+++ b/lib/MetaCPAN/Script/Mapping.pm
@@ -20,6 +20,7 @@ use MetaCPAN::Script::Mapping::DeployStatement    ();
 use MetaCPAN::Script::Mapping::User::Account      ();
 use MetaCPAN::Script::Mapping::User::Identity     ();
 use MetaCPAN::Script::Mapping::User::Session      ();
+use MetaCPAN::Script::Mapping::Contributor        ();
 use MetaCPAN::Types qw( Bool Str );
 
 use constant {
@@ -412,6 +413,11 @@ sub deploy_mapping {
                 decode_json( MetaCPAN::Script::Mapping::User::Session::mapping
                 ),
         },
+        contributor => {
+            contributor =>
+                decode_json( MetaCPAN::Script::Mapping::Contributor::mapping
+                ),
+        }
     );
 
     my $deploy_statement

--- a/lib/MetaCPAN/Script/Mapping/Contributor.pm
+++ b/lib/MetaCPAN/Script/Mapping/Contributor.pm
@@ -1,0 +1,34 @@
+package MetaCPAN::Script::Mapping::Contributor;
+
+use strict;
+use warnings;
+
+sub mapping {
+    '{
+        "dynamic" : false,
+        "properties" : {
+           "release_author" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "release_name" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "distribution" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "pauseid" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           }
+        }
+     }';
+}
+
+1;

--- a/lib/MetaCPAN/Script/Release.pm
+++ b/lib/MetaCPAN/Script/Release.pm
@@ -19,7 +19,8 @@ use Moose;
 use PerlIO::gzip;
 use Try::Tiny qw( catch try );
 
-with 'MetaCPAN::Role::Script', 'MooseX::Getopt';
+with 'MetaCPAN::Role::Script', 'MooseX::Getopt',
+    'MetaCPAN::Script::Role::Contributor';
 
 has latest => (
     is            => 'ro',
@@ -287,6 +288,10 @@ sub import_archive {
         local @ARGV = ( qw(latest --distribution), $document->distribution );
         MetaCPAN::Script::Runner->run;
     }
+
+    my $contrib_data = $self->get_cpan_author_contributors( $document->author,
+        $document->name, $document->distribution );
+    $self->update_release_contirbutors($contrib_data);
 }
 
 sub _build_cpan_files_list {

--- a/lib/MetaCPAN/Script/Role/Contributor.pm
+++ b/lib/MetaCPAN/Script/Role/Contributor.pm
@@ -1,0 +1,67 @@
+package MetaCPAN::Script::Role::Contributor;
+
+use Moose::Role;
+
+use MetaCPAN::Util qw( digest );
+use Ref::Util qw( is_arrayref );
+
+sub get_cpan_author_contributors {
+    my ( $self, $author, $release, $distribution ) = @_;
+    my @ret;
+    my $es = $self->es;
+
+    my $type = $self->index->type('release');
+    my $data = $type->get_contributors( $author, $release );
+
+    for my $d ( @{ $data->{contributors} } ) {
+        next unless exists $d->{pauseid};
+
+        # skip existing records
+        my $id = digest( $d->{pauseid}, $release );
+        my $exists = $es->exists(
+            index => 'contributor',
+            type  => 'contributor',
+            id    => $id,
+        );
+        next if $exists;
+
+        $d->{release_author} = $author;
+        $d->{release_name}   = $release;
+        $d->{distribution}   = $distribution;
+        push @ret, $d;
+    }
+
+    return \@ret;
+}
+
+sub update_release_contirbutors {
+    my ( $self, $data, $timeout ) = @_;
+    return unless $data and is_arrayref($data);
+
+    my $bulk = $self->es->bulk_helper(
+        index   => 'contributor',
+        type    => 'contributor',
+        timeout => $timeout || '5m',
+    );
+
+    for my $d ( @{$data} ) {
+        my $id = digest( $d->{pauseid}, $d->{release_name} );
+        $bulk->update(
+            {
+                id  => $id,
+                doc => {
+                    pauseid        => $d->{pauseid},
+                    release_name   => $d->{release_name},
+                    release_author => $d->{release_author},
+                    distribution   => $d->{distribution},
+                },
+                doc_as_upsert => 1,
+            }
+        );
+    }
+
+    $bulk->flush;
+}
+
+no Moose::Role;
+1;

--- a/lib/MetaCPAN/Server/Controller/Contributor.pm
+++ b/lib/MetaCPAN/Server/Controller/Contributor.pm
@@ -1,0 +1,28 @@
+package MetaCPAN::Server::Controller::Contributor;
+
+use strict;
+use warnings;
+
+use Moose;
+use MetaCPAN::Util qw( digest );
+
+BEGIN { extends 'MetaCPAN::Server::Controller' }
+
+with 'MetaCPAN::Server::Role::JSONP';
+
+sub get : Path('') : Args(2) {
+    my ( $self, $c, $author, $name ) = @_;
+    my $data
+        = $self->model($c)->raw->find_release_contributors( $author, $name );
+    return unless $data;
+    $c->stash($data);
+}
+
+sub by_pauseid : Path('by_pauseid') : Args(1) {
+    my ( $self, $c, $pauseid ) = @_;
+    my $data = $self->model($c)->raw->find_author_contributions($pauseid);
+    return unless $data;
+    $c->stash($data);
+}
+
+1;

--- a/t/server/controller/contributor.t
+++ b/t/server/controller/contributor.t
@@ -1,0 +1,61 @@
+use strict;
+use warnings;
+
+use Cpanel::JSON::XS qw( decode_json );
+use MetaCPAN::Server::Test;
+use MetaCPAN::TestServer;
+use Test::More;
+
+my $server = MetaCPAN::TestServer->new;
+
+test_psgi app, sub {
+    my $cb = shift;
+
+    {
+        my $release_name = 'DOY/Try-Tiny-0.22';
+        ok( my $res = $cb->( GET "/contributor/$release_name" ),
+            "GET contributors for $release_name" );
+        is( $res->code, 200, '200 OK' );
+
+        is_deeply(
+            decode_json( $res->content ),
+            {
+                contributors => [
+                    {
+                        "release_name"   => "Try-Tiny-0.22",
+                        "pauseid"        => "CEBJYRE",
+                        "distribution"   => "Try-Tiny",
+                        "release_author" => "DOY"
+                    },
+                    {
+                        "distribution"   => "Try-Tiny",
+                        "release_author" => "DOY",
+                        "pauseid"        => "JAWNSY",
+                        "release_name"   => "Try-Tiny-0.22"
+                    },
+                    {
+                        "release_name"   => "Try-Tiny-0.22",
+                        "pauseid"        => "ETHER",
+                        "distribution"   => "Try-Tiny",
+                        "release_author" => "DOY"
+                    },
+                    {
+                        "release_author" => "DOY",
+                        "distribution"   => "Try-Tiny",
+                        "pauseid"        => "RIBASUSHI",
+                        "release_name"   => "Try-Tiny-0.22"
+                    },
+                    {
+                        "pauseid"        => "RJBS",
+                        "release_author" => "DOY",
+                        "distribution"   => "Try-Tiny",
+                        "release_name"   => "Try-Tiny-0.22"
+                    }
+                ]
+            },
+            'Has the correct contributors info'
+        );
+    }
+};
+
+done_testing;

--- a/t/server/controller/package.t
+++ b/t/server/controller/package.t
@@ -7,7 +7,6 @@ use MetaCPAN::TestServer;
 use Test::More;
 
 my $server = MetaCPAN::TestServer->new;
-$server->index_packages;
 
 test_psgi app, sub {
     my $cb = shift;

--- a/t/server/controller/permission.t
+++ b/t/server/controller/permission.t
@@ -7,7 +7,6 @@ use MetaCPAN::TestServer;
 use Test::More;
 
 my $server = MetaCPAN::TestServer->new;
-$server->index_permissions;
 
 test_psgi app, sub {
     my $cb = shift;


### PR DESCRIPTION
New type and supporting code & test to fill/fetch the
release contributors info to/from the index.

* MetaCPAN::Script::Mapping::CPAN::Contributor
Added for type mapping for Elasticseach

* Script::Contributor
Added for data filling of release contributors.
Script can run in different modes:
--all          # run for all releases in the 'release' type
--distribution # run for all releases matching a given distribution
--release      # run for a single release (format: PAUSEID/DISTRIBUTION-VERSION)

* Script::Release
Updated to store contributor info for processed releases

* Script::Role::Contributor
Added to support common functionality shared by the scripts
for handling contributors info fetching/updating.

* Document::Contributor
Model representation of the new type.

* Server::Controller::Contributor
Controller endpoints for the new type.