### PR TITLE
Improved /author/by_user endpoint

### DIFF
--- a/lib/MetaCPAN/Document/Author.pm
+++ b/lib/MetaCPAN/Document/Author.pm
@@ -155,16 +155,19 @@ use warnings;
 use Moose;
 extends 'ElasticSearchX::Model::Document::Set';
 
+use Ref::Util qw( is_arrayref );
+
 use MetaCPAN::Util qw( single_valued_arrayref_to_scalar );
 
 sub by_user {
     my ( $self, $users ) = @_;
+    $users = [$users] unless is_arrayref($users);
 
     my $authors = $self->es->search(
         index => $self->index->name,
         type  => 'author',
         body  => {
-            query  => { term => { user => $users } },
+            query  => { terms => { user => $users } },
             size   => 100,
             fields => [qw( user pauseid )],
         }

--- a/lib/MetaCPAN/Server/Controller/Author.pm
+++ b/lib/MetaCPAN/Server/Controller/Author.pm
@@ -61,9 +61,20 @@ sub get : Path('') : Args(1) {
         ['The requested field(s) could not be found'] );
 }
 
+# /author/by_user/USER_ID
 sub by_user : Path('by_user') : Args(1) {
     my ( $self, $c, $user ) = @_;
     my $data = $self->model($c)->raw->by_user($user);
+    $data or return;
+    $c->stash($data);
+}
+
+# /author/by_user?user=USER_ID1&user=USER_ID2...
+sub by_users : Path('by_user') : Args(0) {
+    my ( $self, $c ) = @_;
+    my @users = $c->req->param('user');
+    return unless @users;
+    my $data = $self->model($c)->raw->by_user( \@users );
     $data or return;
     $c->stash($data);
 }


### PR DESCRIPTION
In WEB use, the query runs against multiple user ids.

This change first fixes the query to support multi-value check
(term -> terms).

Added another support for this endpoint which takes the users'
ids through a 'user' URL param: 'user=USER_ID1&user=USER_ID2...'

If you don't see a need for the URL param support I can drop it (I found it useful for manual testing using curl but WEB will probably not need it).