### PR TITLE
favorite: set by_user default to match WEB usage

### DIFF
--- a/lib/MetaCPAN/Document/Favorite.pm
+++ b/lib/MetaCPAN/Document/Favorite.pm
@@ -47,7 +47,7 @@ use MetaCPAN::Util qw( single_valued_arrayref_to_scalar );
 
 sub by_user {
     my ( $self, $user, $size ) = @_;
-    $size ||= 250;
+    $size ||= 1000;
 
     my $favs = $self->es->search(
         index => $self->index->name,


### PR DESCRIPTION
WEB is running this query with a fixed 1000 value... no point in setting the default to a different one. 