### PR TITLE
favs by user query fix

### DIFF
--- a/lib/MetaCPAN/Server/Controller/Favorite.pm
+++ b/lib/MetaCPAN/Server/Controller/Favorite.pm
@@ -30,7 +30,8 @@ sub find : Path('') : Args(2) {
 
 sub by_user : Path('by_user') : Args(1) {
     my ( $self, $c, $user ) = @_;
-    my $data = $self->model($c)->raw->by_user($user);
+    my $size = $c->req->param('size') || 250;
+    my $data = $self->model($c)->raw->by_user( $user, $size );
     $data or return;
     $c->stash($data);
 }


### PR DESCRIPTION
this change will:

1. allow passing `size` parameter from the `/favorite/by_user` endpoint to the query  
2. rename the inner filtering query to 'no_backpan' which better reflects its function (filtering out distributions with only backpan releases)
3. pass `size` value to no_backpan to get all matches (rather than default ES results limit) 