### PR TITLE
Corrected permission query

### DIFF
--- a/lib/MetaCPAN/Document/Permission.pm
+++ b/lib/MetaCPAN/Document/Permission.pm
@@ -69,9 +69,11 @@ sub by_modules {
     my ( $self, $modules ) = @_;
     $modules = [$modules] unless is_arrayref($modules);
 
+    my @modules = map +{ term => { module_name => $_ } }, @{$modules};
+
     my $body = {
         query => {
-            terms => { module_name => $modules },
+            bool => { should => \@modules }
         },
         size => 1_000,
     };


### PR DESCRIPTION
Not sure why the terms query doesn't work properly, **I suspect
an Elasticsearch bug** (following its documentation it **should** work).