### PR TITLE
Return all author info for endpoint /author/by_user/USER

### DIFF
--- a/lib/MetaCPAN/Document/Author.pm
+++ b/lib/MetaCPAN/Document/Author.pm
@@ -167,16 +167,15 @@ sub by_user {
         index => $self->index->name,
         type  => 'author',
         body  => {
-            query  => { terms => { user => $users } },
-            size   => 100,
-            fields => [qw( user pauseid )],
+            query => { terms => { user => $users } },
+            size  => 100,
         }
     );
     return {} unless $authors->{hits}{total};
 
     my @authors = map {
-        single_valued_arrayref_to_scalar( $_->{fields} );
-        $_->{fields}
+        single_valued_arrayref_to_scalar( $_->{_source} );
+        $_->{_source}
     } @{ $authors->{hits}{hits} };
 
     return { authors => \@authors };


### PR DESCRIPTION
For more reuse in WEB, we need extra info from the author type.
Removing the fields list and returning _source will allow more
use cases.