### PR TITLE
Added new /reverse_dependencies API endpoints

### DIFF
--- a/lib/MetaCPAN/Server/Controller/Release.pm
+++ b/lib/MetaCPAN/Server/Controller/Release.pm
@@ -67,6 +67,7 @@ sub files : Path('files') : Args(1) {
     $c->stash($data);
 }
 
+# TODO: remove after deployed in Controller::ReverseDependencies
 sub requires : Path('requires') : Args(1) {
     my ( $self, $c, $module ) = @_;
     my @params = @{ $c->req->params }{qw< page page_size sort >};

--- a/lib/MetaCPAN/Server/Controller/ReverseDependencies.pm
+++ b/lib/MetaCPAN/Server/Controller/ReverseDependencies.pm
@@ -1,0 +1,29 @@
+package MetaCPAN::Server::Controller::ReverseDependencies;
+
+use strict;
+use warnings;
+
+use Moose;
+
+BEGIN { extends 'MetaCPAN::Server::Controller' }
+
+__PACKAGE__->config( namespace => 'reverse_dependencies' );
+
+with 'MetaCPAN::Server::Role::JSONP';
+
+sub dist : Path('dist') : Args(1) {
+    my ( $self, $c, $dist ) = @_;
+    my $data = $c->model('CPAN::Release')->reverse_dependencies($dist);
+    $c->detach('/not_found') unless $data;
+    $c->stash($data);
+}
+
+sub module : Path('module') : Args(1) {
+    my ( $self, $c, $module ) = @_;
+    my @params = @{ $c->req->params }{qw< page page_size sort >};
+    my $data = $c->model('CPAN::Release')->raw->requires( $module, @params );
+    $c->detach('/not_found') unless $data;
+    $c->stash($data);
+}
+
+1;


### PR DESCRIPTION
Added 2 new endpoints:

* /reverse_dependencies/dist/DISTRIBUTION
moved query from WEB (+ will replace the current complicated endpoint in /search/reverse_dependencies)

* /reverse_dependencies/module/MODULE
copied (& later will remove) current /release/requires endpoint

Added a new controller Controller/ReverseDependencies.pm to
later replace the current Controller/Search/ReverseDependencies.pm
(will be removed with all supporting code once WEB is set to
point to new endpoints)

Note: the cleanup part of the current endpoint will be submitted after this PR is deployed and the code in WEB will be changed to use it.