### PR TITLE
Script/Mapping: add mirror type mapping

### DIFF
--- a/lib/MetaCPAN/Script/Mapping.pm
+++ b/lib/MetaCPAN/Script/Mapping.pm
@@ -389,6 +389,8 @@ sub deploy_mapping {
                 ),
             file =>
                 decode_json(MetaCPAN::Script::Mapping::CPAN::File::mapping),
+            mirror =>
+                decode_json(MetaCPAN::Script::Mapping::CPAN::Mirror::mapping),
             permission =>
                 decode_json( MetaCPAN::Script::Mapping::CPAN::Permission::mapping
                 ),


### PR DESCRIPTION
This will only affect VM.
Apparently I forgot to list Mirror type mapping and we don't
catch this with tests.