### PR TITLE
/release/latest_by_distribution: return one element

### DIFF
--- a/lib/MetaCPAN/Document/Release.pm
+++ b/lib/MetaCPAN/Document/Release.pm
@@ -670,13 +670,13 @@ sub latest_by_distribution {
     );
     return unless $ret->{hits}{total};
 
-    my $data = [ map { $_->{_source} } @{ $ret->{hits}{hits} } ];
+    my $data = $ret->{hits}{hits}[0]{_source};
     single_valued_arrayref_to_scalar($data);
 
     return {
-        took     => $ret->{took},
-        releases => $data,
-        total    => $ret->{hits}{total}
+        release => $data,
+        took    => $ret->{took},
+        total   => $ret->{hits}{total}
     };
 }
 


### PR DESCRIPTION
There is no reason to return an arrayref with one element.
Changed the returned structure from:
{ total => ... , took => ... , releases => [ {RELEASE_DATA} ] }
to:
{ total => ... , took => ... , release => {RELEASE_DATA} }