### PR TITLE
Dockerize the MetaCPAN

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -13,12 +13,12 @@
 /Makefile.old
 /blib
 /etc/metacpan_local.pl
-/local/
 /pm_to_blib
 /t/var/darkpan/
 /t/var/log/
 /t/var/tmp/
 /var
 cover_db/
+local/
 metacpan_server_local.conf
 perltidy.LOG

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,6 @@ RUN apt-get update && \
     cpm install -L /carton && \
     rm -fr /root/.cpanm /root/.perl-cpm /var/cache/apt/lists/* /tmp/*
 
-COPY . /metacpan-api
-
 RUN chown -R metacpan-api:users /metacpan-api /carton /CPAN
 
 VOLUME /carton

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,12 @@ WORKDIR /metacpan-api
 
 RUN apt-get update && \
     apt-get install -y libgmp-dev rsync && \
-    cpanm App::cpm Carton && \
+    cpanm App::cpm && \
+    cpm install -g Carton && \
     useradd -m metacpan-api -g users && \
     mkdir /carton /CPAN && \
-    cpm install -L /carton
+    cpm install -L /carton && \
+    rm -fr /root/.cpanm /root/.perl-cpm /var/cache/apt/lists/* /tmp/*
 
 COPY . /metacpan-api
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,14 @@ ENV PERL_MM_USE_DEFAULT=1 PERL_CARTON_PATH=/carton
 COPY cpanfile cpanfile.snapshot /metacpan-api/
 WORKDIR /metacpan-api
 
-RUN apt-get update && \
-    apt-get install -y libgmp-dev rsync && \
-    cpanm App::cpm && \
-    cpm install -g Carton && \
-    useradd -m metacpan-api -g users && \
-    mkdir /carton /CPAN && \
-    cpm install -L /carton && \
-    rm -fr /root/.cpanm /root/.perl-cpm /var/cache/apt/lists/* /tmp/*
+RUN apt-get update \
+    && apt-get install -y libgmp-dev rsync \
+    && cpanm App::cpm \
+    && cpm install -g Carton \
+    && useradd -m metacpan-api -g users \
+    && mkdir /carton /CPAN \
+    && cpm install -L /carton \
+    && rm -fr /root/.cpanm /root/.perl-cpm /var/cache/apt/lists/* /tmp/*
 
 RUN chown -R metacpan-api:users /metacpan-api /carton /CPAN
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM perl:5.22
+
+ENV PERL_MM_USE_DEFAULT=1 PERL_CARTON_PATH=/carton
+
+COPY cpanfile cpanfile.snapshot /metacpan-api/
+WORKDIR /metacpan-api
+
+RUN apt-get update && \
+    apt-get install -y libgmp-dev rsync && \
+    cpanm App::cpm Carton && \
+    useradd -m metacpan-api -g users && \
+    mkdir /carton /CPAN && \
+    cpm install -L /carton
+
+COPY . /metacpan-api
+
+RUN chown -R metacpan-api:users /metacpan-api /carton /CPAN
+
+VOLUME /carton
+
+VOLUME /CPAN
+
+USER metacpan-api:users
+
+EXPOSE 5000
+
+CMD ["carton", "exec", "plackup", "-p", "5000", "-r"]

--- a/app.psgi
+++ b/app.psgi
@@ -1,6 +1,12 @@
 use strict;
 use warnings;
 
+# prevent output buffering when in Docker containers (e.g. in docker-compose)
+if ( -e "/.dockerenv" ) {
+    STDERR->autoflush;
+    STDOUT->autoflush;
+}
+
 use FindBin;
 use lib "$FindBin::RealBin/lib";
 use Catalyst::Middleware::Stash 'stash';

--- a/app.psgi
+++ b/app.psgi
@@ -1,12 +1,6 @@
 use strict;
 use warnings;
 
-# prevent output buffering when in Docker containers (e.g. in docker-compose)
-if ( -e "/.dockerenv" ) {
-    STDERR->autoflush;
-    STDOUT->autoflush;
-}
-
 use FindBin;
 use lib "$FindBin::RealBin/lib";
 use Catalyst::Middleware::Stash 'stash';

--- a/bin/prove
+++ b/bin/prove
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 export EMAIL_SENDER_TRANSPORT=Test
-export ES=localhost:9900
+export ES=${ES_TEST:-"localhost:9900"}
 export METACPAN_SERVER_CONFIG_LOCAL_SUFFIX=testing
 unset ES_SCRIPT_INDEX
 

--- a/lib/MetaCPAN/Server.pm
+++ b/lib/MetaCPAN/Server.pm
@@ -114,6 +114,12 @@ if ( $ENV{PLACK_ENV} && $ENV{PLACK_ENV} eq 'development' ) {
     );
 }
 
+# prevent output buffering when in Docker containers (e.g. in docker-compose)
+if ( -e "/.dockerenv" and __PACKAGE__->log->isa('Catalyst::Log') ) {
+    STDERR->autoflush;
+    STDOUT->autoflush;
+}
+
 sub to_app {
     return $app;
 }


### PR DESCRIPTION
This adds a `Dockerfile` so that the app can be built as a Docker image.

    docker build -t metacpan-api .

One can start a development server on Docker via

    docker run -p 5000:5000 -v /path/to/metacpan-api:/metacpan-api -it metacpan-api

although additional configuration may be necessary (e.g. linking a CPAN mirror and ElasticSearch to the container, setting up the indices/mappings, and importing metadata.)

This is extracted and rewritten from metacpan-docker to allow independent usage (i.e. one doesn't need to source any other repo in order to build this as a Docker image.)

This is part of an effort to Dockerize MetaCPAN (including the web frontend and ElasticSearch services.)  See https://github.com/metacpan/metacpan-docker/pull/11 for more info.