### PR TITLE
/release/modules: no single-value collapsing on 'modules'

### DIFF
--- a/lib/MetaCPAN/Document/Release.pm
+++ b/lib/MetaCPAN/Document/Release.pm
@@ -1148,8 +1148,10 @@ sub modules {
     );
     return unless $ret->{hits}{total};
 
-    my @files = map { single_valued_arrayref_to_scalar($_) }
-        map +{ %{ $_->{fields} }, %{ $_->{_source} } },
+    my @files = map +{
+        %{ ( single_valued_arrayref_to_scalar( $_->{fields} ) )[0] },
+        %{ $_->{_source} }
+        },
         @{ $ret->{hits}{hits} };
 
     return {


### PR DESCRIPTION
Keep single-value collapsing on data from 'fields', not from
'_source'.

This will fix:
19:40:20 � haarg� something happened to our linking on release pages
19:40:55 � haarg� https://metacpan.org/release/Moo they are using file paths rather than /pod/Module
