### PR TITLE
/rating/by_distributions: change output structure

### DIFF
--- a/lib/MetaCPAN/Document/Rating.pm
+++ b/lib/MetaCPAN/Document/Rating.pm
@@ -93,13 +93,13 @@ sub by_distributions {
     );
     return unless $ret->{hits}{total};
 
-    my $data = [ map { $_->{key} => $_->{ratings_dist} }
-            @{ $ret->{aggregations}{ratings}{buckets} } ];
+    my %distributions = map { $_->{key} => $_->{ratings_dist} }
+        @{ $ret->{aggregations}{ratings}{buckets} };
 
     return {
-        releases => $data,
-        total    => $ret->{hits}{total},
-        took     => $ret->{took}
+        distributions => \%distributions,
+        total         => $ret->{hits}{total},
+        took          => $ret->{took}
     };
 }
 


### PR DESCRIPTION
Make the distributions output a hash.

This will make it easier to adopt by WEB.