### PR TITLE
Added /search/web/first API endpoint

### DIFF
--- a/lib/MetaCPAN/Model/Search.pm
+++ b/lib/MetaCPAN/Model/Search.pm
@@ -44,6 +44,16 @@ sub search_simple {
     return $results;
 }
 
+sub search_for_first_result {
+    my ( $self, $query ) = @_;
+    my $es_query = $self->build_query($query);
+    my $results = $self->run_query( file => $es_query );
+    return unless $results->{hits}{total};
+    my $data = $results->{hits}{hits}[0];
+    single_valued_arrayref_to_scalar( $data->{fields} );
+    return $data->{fields};
+}
+
 sub search_web {
     my ( $self, $query, $from, $page_size, $collapsed ) = @_;
     $page_size //= 20;

--- a/lib/MetaCPAN/Server/Controller/Search/Web.pm
+++ b/lib/MetaCPAN/Server/Controller/Search/Web.pm
@@ -25,6 +25,18 @@ sub simple : Chained('/search/index') : PathPart('simple') : Args(0) {
     $c->stash($results);
 }
 
+# returns the contents of the first result of a query similar to
+# the one done by 'search_simple'
+sub first : Chained('/search/index') : PathPart('first') : Args(0) {
+    my ( $self, $c ) = @_;
+    my $args = $c->req->params;
+
+    my $model   = $c->model('Search');
+    my $results = $model->search_for_first_result( $args->{q} );
+
+    $c->stash($results) if $results;
+}
+
 # The web endpoint is the primary one, this handles the front-end's user-facing search
 
 sub web : Chained('/search/index') : PathPart('web') : Args(0) {

--- a/lib/MetaCPAN/Server/Model/Search.pm
+++ b/lib/MetaCPAN/Server/Model/Search.pm
@@ -12,7 +12,7 @@ has search => (
     is      => 'ro',
     isa     => 'MetaCPAN::Model::Search',
     lazy    => 1,
-    handles => [qw( search_simple search_web )],
+    handles => [qw( search_for_first_result search_simple search_web )],
     default => sub {
         my $self = shift;
         return MetaCPAN::Model::Search->new(


### PR DESCRIPTION
This will simplify the reading of /search/web/simple output by
extracting the first element and eliminating the need for WEB
to read an ES output structure.