### PR TITLE
Controller::Release::find - move data handling to Document module

### DIFF
--- a/lib/MetaCPAN/Document/Release.pm
+++ b/lib/MetaCPAN/Document/Release.pm
@@ -318,7 +318,7 @@ sub aggregate_status_by_author {
 
 sub find {
     my ( $self, $name ) = @_;
-    return $self->filter(
+    my $file = $self->filter(
         {
             and => [
                 { term => { distribution => $name } },
@@ -326,6 +326,11 @@ sub find {
             ]
         }
     )->sort( [ { date => 'desc' } ] )->first;
+    return unless $file;
+
+    my $data = $file->{_source}
+        || single_valued_arrayref_to_scalar( $file->{fields} );
+    return $data;
 }
 
 sub predecessor {

--- a/lib/MetaCPAN/Server/Controller/Changes.pm
+++ b/lib/MetaCPAN/Server/Controller/Changes.pm
@@ -107,8 +107,7 @@ sub get : Chained('index') : PathPart('') : Args(2) {
 
 sub find : Chained('index') : PathPart('') : Args(1) {
     my ( $self, $c, $name ) = @_;
-    my $release
-        = eval { $c->model('CPAN::Release')->raw->find($name)->{_source}; }
+    my $release = eval { $c->model('CPAN::Release')->raw->find($name); }
         or $c->detach( '/not_found', [] );
 
     $c->forward( 'get', [ @$release{qw( author name )} ] );

--- a/lib/MetaCPAN/Server/Controller/Diff.pm
+++ b/lib/MetaCPAN/Server/Controller/Diff.pm
@@ -34,7 +34,7 @@ sub release : Chained('index') : PathPart('release') : Args(1) {
     my ( $latest, $previous );
     try {
         $latest
-            = $c->model('CPAN::Release')->inflate(0)->find($name)->{_source};
+            = $c->model('CPAN::Release')->inflate(0)->find($name);
         $previous
             = $c->model('CPAN::Release')->inflate(0)->predecessor($name)
             ->{_source};

--- a/lib/MetaCPAN/Server/Controller/Package.pm
+++ b/lib/MetaCPAN/Server/Controller/Package.pm
@@ -13,7 +13,7 @@ sub modules : Path('modules') : Args(1) {
     my $last = $c->model('CPAN::Release')->raw->find($dist);
     return unless $last;
     my $data
-        = $self->model($c)->get_modules( $dist, $last->{_source}{version} );
+        = $self->model($c)->get_modules( $dist, $last->{version} );
     $c->stash($data);
 }
 

--- a/lib/MetaCPAN/Server/Controller/Release.pm
+++ b/lib/MetaCPAN/Server/Controller/Release.pm
@@ -22,13 +22,8 @@ __PACKAGE__->config(
 sub find : Path('') : Args(1) {
     my ( $self, $c, $name ) = @_;
     my $file = $self->model($c)->raw->find($name);
-    if ( !defined $file ) {
-        $c->detach( '/not_found', [] );
-    }
-    $c->stash( $file->{_source}
-            || single_valued_arrayref_to_scalar( $file->{fields} ) )
-        || $c->detach( '/not_found',
-        ['The requested field(s) could not be found'] );
+    $c->detach( '/not_found', [] ) unless $file;
+    $c->stash($file);
 }
 
 sub get : Path('') : Args(2) {


### PR DESCRIPTION
Keep the controller code concise and unaware of the data structure.