### PR TITLE
Removed needless calls to model settings (raw)

### DIFF
--- a/lib/MetaCPAN/Document/Release/Set.pm
+++ b/lib/MetaCPAN/Document/Release/Set.pm
@@ -44,7 +44,7 @@ sub find {
                 { term => { status       => 'latest' } }
             ]
         }
-    )->sort( [ { date => 'desc' } ] )->first;
+    )->sort( [ { date => 'desc' } ] )->raw->first;
     return unless $file;
 
     my $data = $file->{_source}

--- a/lib/MetaCPAN/Model/#Search.pm#
+++ b/lib/MetaCPAN/Model/#Search.pm#
@@ -1,0 +1,494 @@
+package MetaCPAN::Model::Search;
+
+use Moose;
+
+use v5.10;
+
+use Log::Contextual qw( :log :dlog );
+use MooseX::StrictConstructor;
+
+use Hash::Merge qw( merge );
+use List::Util qw( sum uniq );
+use MetaCPAN::Types qw( Object Str );
+use MetaCPAN::Util qw( single_valued_arrayref_to_scalar );
+
+has es => (
+    is      => 'ro',
+    isa     => Object,
+    handles => {
+        _run_query => 'search',
+    },
+    required => 1,
+);
+
+has index => (
+    is       => 'ro',
+    isa      => Str,
+    required => 1,
+);
+
+my $RESULTS_PER_RUN = 200;
+my @ROGUE_DISTRIBUTIONS
+    = qw(kurila perl_debug perl_mlb perl-5.005_02+apache1.3.3+modperl pod2texi perlbench spodcxx Bundle-Everything);
+
+sub _not_rogue {
+    my @rogue_dists
+        = map { { term => { 'distribution' => $_ } } } @ROGUE_DISTRIBUTIONS;
+    return { not => { filter => { or => \@rogue_dists } } };
+}
+
+sub search_simple {
+    my ( $self, $query ) = @_;
+    my $es_query = $self->build_query($query);
+    my $results = $self->run_query( file => $es_query );
+    return $results;
+}
+
+sub search_for_first_result {
+    my ( $self, $query ) = @_;
+    my $es_query = $self->build_query($query);
+    my $results = $self->run_query( file => $es_query );
+    return unless $results->{hits}{total};
+    my $data = $results->{hits}{hits}[0];
+    single_valued_arrayref_to_scalar( $data->{fields} );
+    return $data->{fields};
+}
+
+sub search_web {
+    my ( $self, $query, $from, $page_size, $collapsed ) = @_;
+    $page_size //= 20;
+    $from      //= 0;
+
+    # munge the query
+    # these would be nicer if we had variable-length lookbehinds...
+    $query =~ s{(^|\s)author:([a-zA-Z]+)(?=\s|$)}{$1author:\U$2\E}g;
+    $query =~ s/(^|\s)dist(ribution)?:([\w-]+)(?=\s|$)/$1distribution:$3/g;
+    $query =~ s/(^|\s)module:(\w[\w:]*)(?=\s|$)/$1module.name.analyzed:$2/g;
+
+    my $results
+        = $collapsed // $query !~ /(distribution|module\.name\S*):/
+        ? $self->_search_collapsed( $query, $from, $page_size )
+        : $self->_search_expanded( $query, $from, $page_size );
+
+    return $results;
+}
+
+sub _search_expanded {
+    my ( $self, $query, $from, $page_size ) = @_;
+
+    # When used for a distribution or module search, the limit is included in
+    # thl query and ES does the right thing.
+    my $es_query = $self->build_query(
+        $query,
+        {
+            size => $page_size,
+            from => $from
+        }
+    );
+
+    #return $es_query;
+    my $data = $self->run_query( file => $es_query );
+
+    my @distributions = uniq
+        map {
+        single_valued_arrayref_to_scalar( $_->{fields} );
+        $_->{fields}->{distribution}
+        } @{ $data->{hits}->{hits} };
+
+    # Everything after this will fail (slowly and silently) without results.
+    return {} unless @distributions;
+
+    my @ids          = map { $_->{fields}->{id} } @{ $data->{hits}->{hits} };
+    my $descriptions = $self->search_descriptions(@ids);
+    my $favorites    = $self->search_favorites(@distributions);
+    my $results      = $self->_extract_results( $data, $favorites );
+    map { $_->{description} = $descriptions->{results}->{ $_->{id} } }
+        @{$results};
+    my $return = {
+        results => [ map { [$_] } @$results ],
+        total   => $data->{hits}->{total},
+        took      => sum( grep {defined} $data->{took}, $favorites->{took} ),
+        collapsed => \0,
+    };
+    return $return;
+}
+
+sub _search_collapsed {
+    my ( $self, $query, $from, $page_size ) = @_;
+
+    my $took = 0;
+    my $total;
+    my $run  = 1;
+    my $hits = 0;
+    my @distributions;
+    my $process_or_repeat;
+    my $data;
+    do {
+        # We need to scan enough modules to build up a sufficient number of
+        # distributions to fill the results to the number requested
+        my $es_query_opts = {
+            size   => $RESULTS_PER_RUN,
+            from   => ( $run - 1 ) * $RESULTS_PER_RUN,
+            fields => [qw(distribution)],
+        };
+
+        # On the first request also fetch the number of total distributions
+        # that match the query so that can be reported to the user. There is
+        # no need to do it on each iteration though, once is enough.
+        $es_query_opts->{aggregations}
+            = {
+            count => { terms => { size => 999, field => 'distribution' } }
+            }
+            if $run == 1;
+        my $es_query = $self->build_query( $query, $es_query_opts );
+
+        $data = $self->run_query( file => $es_query );
+        $took += $data->{took} || 0;
+        $total = @{ $data->{aggregations}->{count}->{buckets} || [] }
+            if $run == 1;
+        $hits = @{ $data->{hits}->{hits} || [] };
+        @distributions = uniq(
+            @distributions,
+            map {
+                single_valued_arrayref_to_scalar( $_->{fields} );
+                $_->{fields}->{distribution}
+            } @{ $data->{hits}->{hits} }
+        );
+        $run++;
+        } while ( @distributions < $page_size + $from
+        && $data->{hits}->{total}
+        && $data->{hits}->{total} > $hits + ( $run - 2 ) * $RESULTS_PER_RUN );
+
+    # Avoid "splice() offset past end of array" warning.
+    @distributions
+        = $from > @distributions
+        ? ()
+        : splice( @distributions, $from, $page_size );
+
+    # Everything else will fail (slowly and quietly) without distributions.
+    return {} unless @distributions;
+
+    # Now that we know which distributions are going to be displayed on the
+    # results page, fetch the details about those distributions
+    my $favorites = $self->search_favorites(@distributions);
+    my $es_query  = $self->build_query(
+        $query,
+        {
+# we will probably never hit that limit, since we are searching in $page_size=20 distributions max
+            size  => 5000,
+            query => {
+                filtered => {
+                    filter => {
+                        and => [
+                            {
+                                or => [
+                                    map {
+                                        { term => { 'distribution' => $_ } }
+                                    } @distributions
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    );
+    my $results = $self->run_query( file => $es_query );
+
+    $took += sum( grep {defined} $results->{took}, $favorites->{took} );
+    $results = $self->_extract_results( $results, $favorites );
+    $results = $self->_collapse_results($results);
+    my @ids = map { $_->[0]{id} } @$results;
+    $data = {
+        results   => $results,
+        total     => $total,
+        took      => $took,
+        collapsed => \1,
+    };
+    my $descriptions = $self->search_descriptions(@ids);
+    $data->{took} += $descriptions->{took} || 0;
+    map { $_->[0]{description} = $descriptions->{results}{ $_->[0]{id} } }
+        @{ $data->{results} };
+    return $data;
+}
+
+sub _collapse_results {
+    my ( $self, $results ) = @_;
+    my %collapsed;
+    foreach my $result (@$results) {
+        my $distribution = $result->{distribution};
+        $collapsed{$distribution}
+            = { position => scalar keys %collapsed, results => [] }
+            unless ( $collapsed{$distribution} );
+        push( @{ $collapsed{$distribution}->{results} }, $result );
+    }
+    return [
+        map      { $collapsed{$_}->{results} }
+            sort { $collapsed{$a}->{position} <=> $collapsed{$b}->{position} }
+            keys %collapsed
+    ];
+}
+
+sub build_query {
+    my ( $self, $query, $params ) = @_;
+    $params //= {};
+    ( my $clean = $query ) =~ s/::/ /g;
+
+    my $negative
+        = { term => { 'mime' => { value => 'text/x-script.perl' } } };
+
+    my $positive = {
+        bool => {
+            should => [
+
+                # exact matches result in a huge boost
+                {
+                    term => {
+                        'documentation' => {
+                            value => $query,
+                            boost => 20,
+                        }
+                    }
+                },
+                {
+                    term => {
+                        'module.name' => {
+                            value => $query,
+                            boost => 20,
+                        }
+                    }
+                },
+
+            # take the maximum score from the module name and the abstract/pod
+                {
+                    dis_max => {
+                        queries => [
+                            {
+                                query_string => {
+                                    fields => [
+                                        qw(documentation.analyzed^2 module.name.analyzed^2 distribution.analyzed),
+                                        qw(documentation.camelcase module.name.camelcase distribution.camelcase)
+                                    ],
+                                    query                  => $clean,
+                                    boost                  => 3,
+                                    default_operator       => 'AND',
+                                    allow_leading_wildcard => 0,
+                                    use_dis_max            => 1,
+
+                                }
+                            },
+                            {
+                                query_string => {
+                                    fields =>
+                                        [qw(abstract.analyzed pod.analyzed)],
+                                    query                  => $clean,
+                                    default_operator       => 'AND',
+                                    allow_leading_wildcard => 0,
+                                    use_dis_max            => 1,
+
+                                }
+                            }
+                        ]
+                    }
+                }
+
+            ]
+        }
+    };
+
+    my $search = merge(
+        $params,
+        {
+            query => {
+                filtered => {
+                    query => {
+                        function_score => {
+
+                            # prefer shorter module names
+                            script_score => {
+                                script => {
+                                    lang => 'groovy',
+                                    file => 'prefer_shorter_module_names_400',
+                                },
+                            },
+                            query => {
+                                boosting => {
+                                    negative_boost => 0.5,
+                                    negative       => $negative,
+                                    positive       => $positive
+                                }
+                            }
+                        }
+                    },
+                    filter => {
+                        and => [
+                            $self->_not_rogue,
+                            { term => { status       => 'latest' } },
+                            { term => { 'authorized' => 1 } },
+                            { term => { 'indexed'    => 1 } },
+                            {
+                                or => [
+                                    {
+                                        and => [
+                                            {
+                                                exists => {
+                                                    field => 'module.name'
+                                                }
+                                            },
+                                            {
+                                                term => {
+                                                    'module.indexed' => 1
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        exists => { field => 'documentation' }
+                                    },
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            _source => "module",
+            fields  => [
+                qw(
+                    documentation
+                    author
+                    abstract.analyzed
+                    release
+                    path
+                    status
+                    indexed
+                    authorized
+                    distribution
+                    date
+                    id
+                    pod_lines
+                    )
+            ],
+        }
+    );
+
+    # Ensure our requested fields are unique so that Elasticsearch doesn't
+    # return us the same value multiple times in an unexpected arrayref.
+    $search->{fields} = [ uniq @{ $search->{fields} || [] } ];
+
+    return $search;
+}
+
+sub run_query {
+    my ( $self, $type, $query ) = @_;
+    return $self->_run_query(
+        index => $self->index,
+        type  => $type,
+        body  => $query,
+    );
+}
+
+sub _build_search_descriptions_query {
+    my ( $self, @ids ) = @_;
+    my $query = {
+        query => {
+            filtered => {
+                query  => { match_all => {} },
+                filter => {
+                    or => [ map { { term => { id => $_ } } } @ids ]
+                }
+            }
+        },
+        fields => [qw(description id)],
+        size   => scalar @ids,
+    };
+    return $query;
+}
+
+sub search_descriptions {
+    my ( $self, @ids ) = @_;
+    return {} unless @ids;
+
+    my $query   = $self->_build_search_descriptions_query(@ids);
+    my $data    = $self->run_query( file => $query );
+    my $results = {
+        results => {
+            map { $_->{id} => $_->{description} }
+                map { single_valued_arrayref_to_scalar( $_->{fields} ) }
+                @{ $data->{hits}->{hits} }
+        },
+        took => $data->{took}
+    };
+    return $results;
+}
+
+sub _build_search_favorites_query {
+    my ( $self, @distributions ) = @_;
+
+    my $query = {
+        size  => 0,
+        query => {
+            filtered => {
+                query  => { match_all => {} },
+                filter => {
+                    or => [
+                        map { { term => { 'distribution' => $_ } } }
+                            @distributions
+                    ]
+                }
+            }
+        },
+        aggregations => {
+            favorites => {
+                terms => {
+                    field => 'distribution',
+                    size  => scalar @distributions,
+                },
+            },
+        }
+    };
+
+    return $query;
+}
+
+sub search_favorites {
+    my ( $self, @distributions ) = @_;
+    @distributions = uniq @distributions;
+
+    # If there are no distributions this will build a query with an empty
+    # filter and ES will return a parser error... so just skip it.
+    return {} unless @distributions;
+
+    my $query = $self->_build_search_favorites_query(@distributions);
+    my $data = $self->run_query( favorite => $query );
+
+    my $results = {
+        took      => $data->{took},
+        favorites => {
+            map { $_->{key} => $_->{doc_count} }
+                @{ $data->{aggregations}->{favorites}->{buckets} }
+        },
+    };
+    return $results;
+}
+
+sub _extract_results {
+    my ( $self, $results, $favorites ) = @_;
+    return [
+        map {
+            my $res = $_;
+            single_valued_arrayref_to_scalar( $res->{fields} );
+            my $dist = $res->{fields}{distribution};
+            +{
+                %{ $res->{fields} },
+                %{ $res->{_source} },
+                abstract   => $res->{fields}{'abstract.analyzed'},
+                score      => $res->{_score},
+                favorites  => $favorites->{favorites}{$dist},
+                myfavorite => $favorites->{myfavorites}{$dist},
+                }
+        } @{ $results->{hits}{hits} }
+    ];
+}
+
+1;
+

--- a/lib/MetaCPAN/Role/HasRogueDistributions.pm
+++ b/lib/MetaCPAN/Role/HasRogueDistributions.pm
@@ -1,0 +1,27 @@
+package MetaCPAN::Role::HasRogueDistributions;
+
+use Moose::Role;
+
+use MetaCPAN::Types qw( ArrayRef );
+
+has rogue_distributions => (
+    is      => 'ro',
+    isa     => ArrayRef,
+    default => sub {
+        [
+            qw(
+                Bundle-Everything
+                kurila
+                perl-5.005_02+apache1.3.3+modperl
+                perlbench
+                perl_debug
+                perl_mlb
+                pod2texi
+                spodcxx
+                )
+        ];
+    },
+);
+
+no Moose::Role;
+1;

--- a/lib/MetaCPAN/Script/Author.pm
+++ b/lib/MetaCPAN/Script/Author.pm
@@ -52,7 +52,7 @@ sub index_authors {
 
     log_debug {"Getting last update dates"};
     my $dates
-        = $type->inflate(0)->filter( { exists => { field => 'updated' } } )
+        = $type->raw->filter( { exists => { field => 'updated' } } )
         ->size(10000)->all;
     $dates = {
         map {

--- a/lib/MetaCPAN/Script/Release.pm
+++ b/lib/MetaCPAN/Script/Release.pm
@@ -160,7 +160,7 @@ sub run {
                         { term => { author  => $d->cpanid } },
                     ]
                 }
-            )->inflate(0)->count;
+            )->raw->count;
             if ($count) {
                 log_info {"Skipping $file"};
                 next;

--- a/lib/MetaCPAN/Script/Watcher.pm
+++ b/lib/MetaCPAN/Script/Watcher.pm
@@ -145,7 +145,7 @@ sub skip {
                 { term => { author  => $author } },
             ]
         }
-    )->inflate(0)->count;
+    )->raw->count;
 }
 
 sub index_release {
@@ -182,7 +182,7 @@ sub reindex_release {
                 { term => { archive => $info->filename } },
             ]
         }
-    )->inflate(0)->first;
+    )->raw->first;
     return unless ($release);
     log_info {"Moving $release->{_source}->{name} to BackPAN"};
 

--- a/lib/MetaCPAN/Server/Controller/Activity.pm
+++ b/lib/MetaCPAN/Server/Controller/Activity.pm
@@ -11,7 +11,7 @@ with 'MetaCPAN::Server::Role::JSONP';
 
 sub get : Path('') : Args(0) {
     my ( $self, $c ) = @_;
-    my $data = $c->model('CPAN::Release')->raw->activity( $c->req->params );
+    my $data = $c->model('CPAN::Release')->activity( $c->req->params );
 
     $data
         ? $c->stash($data)

--- a/lib/MetaCPAN/Server/Controller/Author.pm
+++ b/lib/MetaCPAN/Server/Controller/Author.pm
@@ -65,7 +65,8 @@ sub get : Path('') : Args(1) {
 sub qsearch : Path('search') : Args(0) {
     my ( $self,  $c )    = @_;
     my ( $query, $from ) = @{ $c->req->params }{qw( q from )};
-    my $data = $self->model($c)->raw->search( $query, $from );
+
+    my $data = $self->model($c)->search( $query, $from );
 
     $data
         ? $c->stash($data)
@@ -76,7 +77,8 @@ sub qsearch : Path('search') : Args(0) {
 # /author/by_ids?id=PAUSE_ID1&id=PAUSE_ID2...
 sub by_ids : Path('by_ids') : Args(0) {
     my ( $self, $c ) = @_;
-    my $data = $self->model($c)->raw->by_ids( $c->read_param('id') );
+
+    my $data = $self->model($c)->by_ids( $c->read_param('id') );
 
     $data
         ? $c->stash($data)
@@ -87,7 +89,8 @@ sub by_ids : Path('by_ids') : Args(0) {
 # /author/by_user/USER_ID
 sub by_user : Path('by_user') : Args(1) {
     my ( $self, $c, $user ) = @_;
-    my $data = $self->model($c)->raw->by_user($user);
+
+    my $data = $self->model($c)->by_user($user);
 
     $data
         ? $c->stash($data)
@@ -98,7 +101,8 @@ sub by_user : Path('by_user') : Args(1) {
 # /author/by_user?user=USER_ID1&user=USER_ID2...
 sub by_users : Path('by_user') : Args(0) {
     my ( $self, $c ) = @_;
-    my $data = $self->model($c)->raw->by_user( $c->read_param('user') );
+
+    my $data = $self->model($c)->by_user( $c->read_param('user') );
 
     $data
         ? $c->stash($data)

--- a/lib/MetaCPAN/Server/Controller/Changes.pm
+++ b/lib/MetaCPAN/Server/Controller/Changes.pm
@@ -107,7 +107,7 @@ sub get : Chained('index') : PathPart('') : Args(2) {
 
 sub find : Chained('index') : PathPart('') : Args(1) {
     my ( $self, $c, $name ) = @_;
-    my $release = eval { $c->model('CPAN::Release')->raw->find($name); }
+    my $release = eval { $c->model('CPAN::Release')->find($name); }
         or $c->detach( '/not_found', [] );
 
     $c->forward( 'get', [ @$release{qw( author name )} ] );

--- a/lib/MetaCPAN/Server/Controller/Contributor.pm
+++ b/lib/MetaCPAN/Server/Controller/Contributor.pm
@@ -12,8 +12,8 @@ with 'MetaCPAN::Server::Role::JSONP';
 
 sub get : Path('') : Args(2) {
     my ( $self, $c, $author, $name ) = @_;
-    my $data
-        = $self->model($c)->raw->find_release_contributors( $author, $name );
+
+    my $data = $self->model($c)->find_release_contributors( $author, $name );
 
     $data
         ? $c->stash($data)
@@ -23,7 +23,8 @@ sub get : Path('') : Args(2) {
 
 sub by_pauseid : Path('by_pauseid') : Args(1) {
     my ( $self, $c, $pauseid ) = @_;
-    my $data = $self->model($c)->raw->find_author_contributions($pauseid);
+
+    my $data = $self->model($c)->find_author_contributions($pauseid);
 
     $data
         ? $c->stash($data)

--- a/lib/MetaCPAN/Server/Controller/Diff.pm
+++ b/lib/MetaCPAN/Server/Controller/Diff.pm
@@ -33,11 +33,9 @@ sub release : Chained('index') : PathPart('release') : Args(1) {
 
     my ( $latest, $previous );
     try {
-        $latest
-            = $c->model('CPAN::Release')->inflate(0)->find($name);
+        $latest = $c->model('CPAN::Release')->raw->find($name);
         $previous
-            = $c->model('CPAN::Release')->inflate(0)->predecessor($name)
-            ->{_source};
+            = $c->model('CPAN::Release')->raw->predecessor($name)->{_source};
     }
     catch {
         $c->detach('/not_found');
@@ -58,7 +56,7 @@ sub file : Chained('index') : PathPart('file') : Args(2) {
         = map { [ @$_{qw(author release path)} ] }
         map {
         my $file = $_;
-        try { $c->model('CPAN::File')->inflate(0)->get($file)->{_source}; }
+        try { $c->model('CPAN::File')->raw->get($file)->{_source}; }
             or $c->detach('/not_found');
         } ( $source, $target );
 

--- a/lib/MetaCPAN/Server/Controller/Favorite.pm
+++ b/lib/MetaCPAN/Server/Controller/Favorite.pm
@@ -31,7 +31,8 @@ sub find : Path('') : Args(2) {
 sub by_user : Path('by_user') : Args(1) {
     my ( $self, $c, $user ) = @_;
     my $size = $c->req->param('size') || 250;
-    my $data = $self->model($c)->raw->by_user( $user, $size );
+
+    my $data = $self->model($c)->by_user( $user, $size );
 
     $data
         ? $c->stash($data)
@@ -41,7 +42,8 @@ sub by_user : Path('by_user') : Args(1) {
 
 sub users_by_distribution : Path('users_by_distribution') : Args(1) {
     my ( $self, $c, $distribution ) = @_;
-    my $data = $self->model($c)->raw->users_by_distribution($distribution);
+
+    my $data = $self->model($c)->users_by_distribution($distribution);
 
     $data
         ? $c->stash($data)
@@ -53,7 +55,8 @@ sub recent : Path('recent') : Args(0) {
     my ( $self, $c ) = @_;
     my $page = $c->req->param('page') || 1;
     my $size = $c->req->param('size') || 100;
-    my $data = $self->model($c)->raw->recent( $page, $size );
+
+    my $data = $self->model($c)->recent( $page, $size );
 
     $data
         ? $c->stash($data)
@@ -63,7 +66,8 @@ sub recent : Path('recent') : Args(0) {
 
 sub leaderboard : Path('leaderboard') : Args(0) {
     my ( $self, $c ) = @_;
-    my $data = $self->model($c)->raw->leaderboard();
+
+    my $data = $self->model($c)->leaderboard();
 
     $data
         ? $c->stash($data)
@@ -73,10 +77,11 @@ sub leaderboard : Path('leaderboard') : Args(0) {
 
 sub agg_by_distributions : Path('agg_by_distributions') : Args(0) {
     my ( $self, $c ) = @_;
+
     my $distributions = $c->read_param('distribution');
     my $user          = $c->read_param('user');
-    my $data          = $self->model($c)
-        ->raw->agg_by_distributions( $distributions, $user );
+    my $data
+        = $self->model($c)->agg_by_distributions( $distributions, $user );
 
     $data
         ? $c->stash($data)

--- a/lib/MetaCPAN/Server/Controller/Mirror.pm
+++ b/lib/MetaCPAN/Server/Controller/Mirror.pm
@@ -11,7 +11,8 @@ with 'MetaCPAN::Server::Role::JSONP';
 
 sub search : Path('search') : Args(0) {
     my ( $self, $c ) = @_;
-    my $data = $self->model($c)->raw->search( $c->req->param('q') );
+
+    my $data = $self->model($c)->search( $c->req->param('q') );
 
     $data
         ? $c->stash($data)

--- a/lib/MetaCPAN/Server/Controller/Package.pm
+++ b/lib/MetaCPAN/Server/Controller/Package.pm
@@ -10,7 +10,8 @@ with 'MetaCPAN::Server::Role::JSONP';
 # https://fastapi.metacpan.org/v1/package/modules/Moose
 sub modules : Path('modules') : Args(1) {
     my ( $self, $c, $dist ) = @_;
-    my $last = $c->model('CPAN::Release')->raw->find($dist);
+
+    my $last = $c->model('CPAN::Release')->find($dist);
     $c->detach( '/not_found', ["Cannot find last release for $dist"] )
         unless $last;
 

--- a/lib/MetaCPAN/Server/Controller/Permission.pm
+++ b/lib/MetaCPAN/Server/Controller/Permission.pm
@@ -9,7 +9,8 @@ with 'MetaCPAN::Server::Role::JSONP';
 
 sub by_author : Path('by_author') : Args(1) {
     my ( $self, $c, $pauseid ) = @_;
-    my $data = $self->model($c)->raw->by_author($pauseid);
+
+    my $data = $self->model($c)->by_author($pauseid);
 
     $data
         ? $c->stash($data)
@@ -19,7 +20,8 @@ sub by_author : Path('by_author') : Args(1) {
 
 sub by_module : Path('by_module') : Args(1) {
     my ( $self, $c, $module ) = @_;
-    my $data = $self->model($c)->raw->by_modules($module);
+
+    my $data = $self->model($c)->by_modules($module);
 
     $data
         ? $c->stash($data)
@@ -29,7 +31,8 @@ sub by_module : Path('by_module') : Args(1) {
 
 sub by_modules : Path('by_module') : Args(0) {
     my ( $self, $c ) = @_;
-    my $data = $self->model($c)->raw->by_modules( $c->read_param('module') );
+
+    my $data = $self->model($c)->by_modules( $c->read_param('module') );
 
     $data
         ? $c->stash($data)

--- a/lib/MetaCPAN/Server/Controller/Rating.pm
+++ b/lib/MetaCPAN/Server/Controller/Rating.pm
@@ -11,8 +11,9 @@ with 'MetaCPAN::Server::Role::JSONP';
 
 sub by_distributions : Path('by_distributions') : Args(0) {
     my ( $self, $c ) = @_;
+
     my $data = $self->model($c)
-        ->raw->by_distributions( $c->read_param('distribution') );
+        ->by_distributions( $c->read_param('distribution') );
 
     $data
         ? $c->stash($data)

--- a/lib/MetaCPAN/Server/Controller/Release.pm
+++ b/lib/MetaCPAN/Server/Controller/Release.pm
@@ -21,7 +21,7 @@ __PACKAGE__->config(
 
 sub find : Path('') : Args(1) {
     my ( $self, $c, $name ) = @_;
-    my $file = $self->model($c)->raw->find($name);
+    my $file = $self->model($c)->find($name);
     $c->detach( '/not_found', [] ) unless $file;
     $c->stash($file);
 }
@@ -49,7 +49,8 @@ sub get : Path('') : Args(2) {
 
 sub contributors : Path('contributors') : Args(2) {
     my ( $self, $c, $author, $release ) = @_;
-    my $data = $self->model($c)->raw->get_contributors( $author, $release );
+
+    my $data = $self->model($c)->get_contributors( $author, $release );
 
     $data
         ? $c->stash($data)
@@ -62,7 +63,8 @@ sub files : Path('files') : Args(1) {
     my $files = $c->req->params->{files};
     $c->detach( '/bad_request', ['No files requested'] ) unless $files;
     my @files = split /,/, $files;
-    my $data = $self->model($c)->raw->get_files( $name, \@files );
+
+    my $data = $self->model($c)->get_files( $name, \@files );
 
     $data
         ? $c->stash($data)
@@ -72,7 +74,8 @@ sub files : Path('files') : Args(1) {
 
 sub modules : Path('modules') : Args(2) {
     my ( $self, $c, $author, $name ) = @_;
-    my $data = $self->model($c)->raw->modules( $author, $name );
+
+    my $data = $self->model($c)->modules( $author, $name );
 
     $data
         ? $c->stash($data)
@@ -83,7 +86,8 @@ sub modules : Path('modules') : Args(2) {
 sub recent : Path('recent') : Args(0) {
     my ( $self, $c ) = @_;
     my @params = @{ $c->req->params }{qw( page page_size type )};
-    my $data   = $self->model($c)->raw->recent(@params);
+
+    my $data = $self->model($c)->recent(@params);
 
     $data
         ? $c->stash($data)
@@ -93,7 +97,8 @@ sub recent : Path('recent') : Args(0) {
 
 sub by_author_and_name : Path('by_author_and_name') : Args(2) {
     my ( $self, $c, $author, $name ) = @_;
-    my $data = $self->model($c)->raw->by_author_and_name( $author, $name );
+
+    my $data = $self->model($c)->by_author_and_name( $author, $name );
 
     $data
         ? $c->stash($data)
@@ -104,7 +109,8 @@ sub by_author_and_name : Path('by_author_and_name') : Args(2) {
 sub by_author : Path('by_author') : Args(1) {
     my ( $self, $c, $pauseid ) = @_;
     my $size = $c->req->param('size');
-    my $data = $self->model($c)->raw->by_author( $pauseid, $size );
+
+    my $data = $self->model($c)->by_author( $pauseid, $size );
 
     $data
         ? $c->stash($data)
@@ -114,7 +120,8 @@ sub by_author : Path('by_author') : Args(1) {
 
 sub latest_by_distribution : Path('latest_by_distribution') : Args(1) {
     my ( $self, $c, $dist ) = @_;
-    my $data = $self->model($c)->raw->latest_by_distribution($dist);
+
+    my $data = $self->model($c)->latest_by_distribution($dist);
 
     $data
         ? $c->stash($data)
@@ -124,7 +131,8 @@ sub latest_by_distribution : Path('latest_by_distribution') : Args(1) {
 
 sub latest_by_author : Path('latest_by_author') : Args(1) {
     my ( $self, $c, $pauseid ) = @_;
-    my $data = $self->model($c)->raw->latest_by_author($pauseid);
+
+    my $data = $self->model($c)->latest_by_author($pauseid);
 
     $data
         ? $c->stash($data)
@@ -135,7 +143,8 @@ sub latest_by_author : Path('latest_by_author') : Args(1) {
 sub all_by_author : Path('all_by_author') : Args(1) {
     my ( $self, $c, $pauseid ) = @_;
     my @params = @{ $c->req->params }{qw( page page_size )};
-    my $data = $self->model($c)->raw->all_by_author( $pauseid, @params );
+
+    my $data = $self->model($c)->all_by_author( $pauseid, @params );
 
     $data
         ? $c->stash($data)
@@ -145,7 +154,8 @@ sub all_by_author : Path('all_by_author') : Args(1) {
 
 sub versions : Path('versions') : Args(1) {
     my ( $self, $c, $dist ) = @_;
-    my $data = $self->model($c)->raw->versions($dist);
+
+    my $data = $self->model($c)->versions($dist);
 
     $data
         ? $c->stash($data)
@@ -156,7 +166,8 @@ sub versions : Path('versions') : Args(1) {
 sub top_uploaders : Path('top_uploaders') : Args() {
     my ( $self, $c ) = @_;
     my $range = $c->req->param('range') || 'weekly';
-    my $data = $self->model($c)->raw->top_uploaders($range);
+
+    my $data = $self->model($c)->top_uploaders($range);
 
     $data
         ? $c->stash($data)

--- a/lib/MetaCPAN/Server/Controller/ReverseDependencies.pm
+++ b/lib/MetaCPAN/Server/Controller/ReverseDependencies.pm
@@ -24,7 +24,8 @@ sub dist : Path('dist') : Args(1) {
 sub module : Path('module') : Args(1) {
     my ( $self, $c, $module ) = @_;
     my @params = @{ $c->req->params }{qw< page page_size sort >};
-    my $data = $c->model('CPAN::Release')->raw->requires( $module, @params );
+
+    my $data = $c->model('CPAN::Release')->requires( $module, @params );
 
     $data
         ? $c->stash($data)

--- a/lib/MetaCPAN/Server/Controller/User.pm
+++ b/lib/MetaCPAN/Server/Controller/User.pm
@@ -70,7 +70,7 @@ sub profile : Local : ActionClass('REST') {
         $self->status_not_found( $c, message => 'Profile doesn\'t exist' );
         $c->detach;
     }
-    my $profile = $c->model('CPAN::Author')->inflate(0)->get( $pause->key );
+    my $profile = $c->model('CPAN::Author')->raw->get( $pause->key );
     $c->stash->{profile} = $profile->{_source};
 }
 

--- a/t/release/pm-PL.t
+++ b/t/release/pm-PL.t
@@ -35,7 +35,7 @@ is( $pm->module->[0]->version,
     my $files
         = $idx->type('file')
         ->filter( { term => { release => 'uncommon-sense-0.01' }, } )
-        ->inflate(0)->size(20)->all->{hits}->{hits};
+        ->raw->size(20)->all->{hits}->{hits};
     $files = [ map { $_->{_source} } @$files ];
 
     is_deeply(


### PR DESCRIPTION
Removed calls to 'raw' (ESX::Model) for the new API endpoints
which don't use the model for querying.

Changed all 'inflate(0)' calls to 'raw' (does the same) for
consistency.

Moved 'raw' calls from controllers back to the document where
possible (some cases will be dealt with later).