### PR TITLE
favorite/agg_by_distributions: 'user' --> optional param

### DIFF
--- a/lib/MetaCPAN/Server/Controller/Favorite.pm
+++ b/lib/MetaCPAN/Server/Controller/Favorite.pm
@@ -79,7 +79,7 @@ sub agg_by_distributions : Path('agg_by_distributions') : Args(0) {
     my ( $self, $c ) = @_;
 
     my $distributions = $c->read_param('distribution');
-    my $user          = $c->read_param('user');
+    my $user          = $c->req->param('user');           # optional
     my $data
         = $self->model($c)->agg_by_distributions( $distributions, $user );
 


### PR DESCRIPTION
read_param is meant for mandatory params as it detaches when
value is not found.

In this case, 'user' is an optional param and always single-value,
so we don't need to use it.

this will solve the problem of ++ count not showing in /pod pages. will merge once tests pass