### PR TITLE
Added surrogate key for 'dist' for purging in 2 endpoints

### DIFF
--- a/lib/MetaCPAN/Server/Controller/Release.pm
+++ b/lib/MetaCPAN/Server/Controller/Release.pm
@@ -86,6 +86,7 @@ sub by_author : Path('by_author') : Args(1) {
 
 sub latest_by_distribution : Path('latest_by_distribution') : Args(1) {
     my ( $self, $c, $dist ) = @_;
+    $c->add_dist_key($dist);
     $c->stash_or_detach( $self->model($c)->latest_by_distribution($dist) );
 }
 
@@ -103,6 +104,7 @@ sub all_by_author : Path('all_by_author') : Args(1) {
 
 sub versions : Path('versions') : Args(1) {
     my ( $self, $c, $dist ) = @_;
+    $c->add_dist_key($dist);
     $c->stash_or_detach( $self->model($c)->versions($dist) );
 }
 


### PR DESCRIPTION
/release/latest_by_distribution & /release/versions are affected.

This will (hopefully) solve the caching issue we have with
distributions with new releases indexed.