### PR TITLE
Pass missing params to reverse_dependencies

### DIFF
--- a/lib/MetaCPAN/Server/Controller/ReverseDependencies.pm
+++ b/lib/MetaCPAN/Server/Controller/ReverseDependencies.pm
@@ -14,7 +14,10 @@ with 'MetaCPAN::Server::Role::JSONP';
 sub dist : Path('dist') : Args(1) {
     my ( $self, $c, $dist ) = @_;
     $c->stash_or_detach(
-        $c->model('CPAN::Release')->reverse_dependencies($dist) );
+        $c->model('CPAN::Release')->reverse_dependencies(
+            $dist, @{ $c->req->params }{qw< page page_size sort >}
+        )
+    );
 }
 
 sub module : Path('module') : Args(1) {


### PR DESCRIPTION
Added the missing page, page_size & sort params passed from the
endpoint to the querying method.

fixes #736