### PR TITLE
[DO NOT MERGE YET] Reverse dependencies: read sort option from body

### DIFF
--- a/lib/MetaCPAN/Server/Controller/ReverseDependencies.pm
+++ b/lib/MetaCPAN/Server/Controller/ReverseDependencies.pm
@@ -15,7 +15,9 @@ sub dist : Path('dist') : Args(1) {
     my ( $self, $c, $dist ) = @_;
     $c->stash_or_detach(
         $c->model('CPAN::Release')->reverse_dependencies(
-            $dist, @{ $c->req->params }{qw< page page_size sort >}
+            $dist,
+            @{ $c->req->params }{qw< page page_size >},
+            $c->read_param('sort')->[0]
         )
     );
 }
@@ -24,7 +26,9 @@ sub module : Path('module') : Args(1) {
     my ( $self, $c, $module ) = @_;
     $c->stash_or_detach(
         $c->model('CPAN::Release')->requires(
-            $module, @{ $c->req->params }{qw< page page_size sort >}
+            $module,
+            @{ $c->req->params }{qw< page page_size >},
+            $c->read_param('sort')->[0]
         )
     );
 }


### PR DESCRIPTION
The 'sort' parameter is passed from WEB as JSON in a POST request
as it is a complex structure (hash).

This change requires this merge in WEB first: https://github.com/metacpan/metacpan-web/pull/1981
