### PR TITLE
Accept sort param in a URL friendly form

### DIFF
--- a/lib/MetaCPAN/Document/Release/Set.pm
+++ b/lib/MetaCPAN/Document/Release/Set.pm
@@ -722,9 +722,15 @@ sub _get_provided_modules {
 
 sub _get_depended_releases {
     my ( $self, $modules, $page, $page_size, $sort ) = @_;
-    $sort //= { date => 'desc' };
-    $page //= 1;
+    $page      //= 1;
     $page_size //= 50;
+
+    if ( $sort =~ /^(\w+):(asc|desc)$/ ) {
+        $sort = { $1 => $2 };
+    }
+    else {
+        $sort = { date => 'desc' };
+    }
 
     # because 'terms' doesn't work properly
     my $filter_modules = {


### PR DESCRIPTION
'sort' param sent to reverse_dependencies is currently broken as
it gets a structure passed through the URL which gets stringified.

With this change the new form of the param will be like:
?sort=name:desc
?sort=date:asc