### PR TITLE
Improve autocomplete when using suggester

### DIFF
--- a/lib/MetaCPAN/Document/File/Set.pm
+++ b/lib/MetaCPAN/Document/File/Set.pm
@@ -498,8 +498,7 @@ sub autocomplete {
 # mapping + data is fully deployed.
 # -- Mickey
 sub autocomplete_using_suggester {
-    my ( $self, @terms ) = @_;
-    my $query = join( q{ }, @terms );
+    my ( $self, $query ) = @_;
     return $self unless $query;
 
     my $result_size = 10;

--- a/lib/MetaCPAN/Document/File/Set.pm
+++ b/lib/MetaCPAN/Document/File/Set.pm
@@ -501,7 +501,6 @@ sub autocomplete_using_suggester {
     my ( $self, $query ) = @_;
     return $self unless $query;
 
-    my $result_size = 10;
     my $search_size = 50;
 
     my $suggestions
@@ -572,8 +571,8 @@ sub autocomplete_using_suggester {
             || $a cmp $b
         }
         keys %valid;
-    return +{ suggestions =>
-            [ grep {defined} ( $exact, @sorted[ 0 .. $result_size ] ) ] };
+
+    return +{ suggestions => [ grep {defined} ( $exact, @sorted ) ] };
 }
 
 sub dir {

--- a/lib/MetaCPAN/Document/File/Set.pm
+++ b/lib/MetaCPAN/Document/File/Set.pm
@@ -560,6 +560,8 @@ sub autocomplete_using_suggester {
         ( $_->{fields}{documentation}[0] => $_->{fields}{distribution}[0] )
     } @{ $data->{hits}{hits} };
 
+    my $exact = delete $valid{$query};
+
     my $favorites
         = $self->agg_by_distributions( [ values %valid ] )->{favorites};
 
@@ -570,9 +572,8 @@ sub autocomplete_using_suggester {
             || $a cmp $b
         }
         keys %valid;
-    return +{
-        suggestions => [ grep {defined} @sorted[ 0 .. $result_size ] ]
-    };
+    return +{ suggestions =>
+            [ grep {defined} ( $exact, @sorted[ 0 .. $result_size ] ) ] };
 }
 
 sub dir {


### PR DESCRIPTION
Returned results are first queried from the suggester, filtered for relevance (authorized etc) and then sorted as:

* exact match
* by ++
* by suggester score
* by length
* by ascii

in descending importance.