### PR TITLE
add pod_render endpoint

### DIFF
--- a/lib/MetaCPAN/Server/Controller/Pod.pm
+++ b/lib/MetaCPAN/Server/Controller/Pod.pm
@@ -80,4 +80,12 @@ sub find_dist_links {
     return $links;
 }
 
+sub render : Path('/pod_render') {
+    my ( $self, $c ) = @_;
+    my $pod = $c->req->parameters->{pod};
+    $c->res->content_type('text/x-pod');
+    $c->res->body($pod);
+    $c->forward( $c->view('Pod') );
+}
+
 1;

--- a/lib/MetaCPAN/Server/View/Pod.pm
+++ b/lib/MetaCPAN/Server/View/Pod.pm
@@ -11,10 +11,12 @@ extends 'Catalyst::View';
 sub process {
     my ( $self, $c ) = @_;
 
-    my $content       = $c->res->body || $c->stash->{source};
+    my $content = $c->res->has_body ? $c->res->body : $c->stash->{source};
     my $link_mappings = $c->stash->{link_mappings};
     my $url_prefix    = $c->stash->{url_prefix};
-    $content = eval { join( q{}, $content->getlines ) };
+    if ( ref $content ) {
+        $content = do { local $/; <$content> };
+    }
 
     my ( $body, $content_type );
     my $accept = eval { $c->req->preferred_content_type } || 'text/html';


### PR DESCRIPTION
Allows converting pod to HTML in the same way MetaCPAN does.