### PR TITLE
Added 'deprecated' field

### DIFF
--- a/lib/MetaCPAN/Document/File.pm
+++ b/lib/MetaCPAN/Document/File.pm
@@ -32,6 +32,21 @@ sub BUILD {
 
 =head1 PROPERTIES
 
+=head2 deprecated
+
+Indicates file deprecation (the abstract contains "DEPRECATED" or "DEPRECIATED",
+or the x_deprecated flag is included in the corresponding "provides" entry in distribution metadata);
+it is also set if the entire release is marked deprecated (see L<MetaCPAN::Document::Release#deprecated>).
+
+=cut
+
+has deprecated => (
+    is      => 'ro',
+    isa     => Bool,
+    default => 0,
+    writer  => '_set_deprecated',
+);
+
 =head2 abstract
 
 Abstract of the documentation (if any). This is built by parsing the

--- a/lib/MetaCPAN/Document/Release.pm
+++ b/lib/MetaCPAN/Document/Release.pm
@@ -104,6 +104,14 @@ This is an ArrayRef of modules that are included in this release.
 
 =cut
 
+=head2 deprecated
+
+This is a boolean indicating whether the release is marked as deprecated
+(the main module's ABSTRACT contains "DEPRECATED" or "DEPRECIATED",
+or the x_deprecated flag is set in metadata)
+
+=cut
+
 has provides => (
     is     => 'ro',
     isa    => ArrayRef [Str],
@@ -241,6 +249,13 @@ has changes_file => (
     is     => 'ro',
     isa    => Str,
     writer => '_set_changes_file',
+);
+
+has deprecated => (
+    is      => 'ro',
+    isa     => Bool,
+    default => sub {0},
+    writer  => '_set_deprecated',
 );
 
 sub _build_download_url {

--- a/lib/MetaCPAN/Script/Mapping/CPAN/File.pm
+++ b/lib/MetaCPAN/Script/Mapping/CPAN/File.pm
@@ -37,6 +37,9 @@ sub mapping {
             "type" : "date",
             "format" : "strict_date_optional_time||epoch_millis"
           },
+          "deprecated" : {
+            "type" : "boolean"
+          },
           "description" : {
             "type" : "string",
             "index" : "not_analyzed",

--- a/lib/MetaCPAN/Script/Mapping/CPAN/Release.pm
+++ b/lib/MetaCPAN/Script/Mapping/CPAN/Release.pm
@@ -71,6 +71,9 @@ sub mapping {
               },
               "type" : "nested"
            },
+           "deprecated" : {
+              "type" : "boolean"
+           },
            "distribution" : {
               "fields" : {
                  "analyzed" : {


### PR DESCRIPTION
Added to both release and file types (which is also /module in API)
Field will be set by the 'release' script.

This PR is to address #572 

Note: after merge - need to run a one-off run to update field for existing releases