### PR TITLE
Script::CPANTestersAPI - increase bulk_helper timeout

### DIFF
--- a/lib/MetaCPAN/Script/CPANTestersAPI.pm
+++ b/lib/MetaCPAN/Script/CPANTestersAPI.pm
@@ -32,8 +32,10 @@ has _bulk => (
     lazy    => 1,
     default => sub {
         $_[0]->es->bulk_helper(
-            index => $_[0]->index->name,
-            type  => 'release'
+            index     => $_[0]->index->name,
+            type      => 'release',
+            max_count => 250,
+            timeout   => '30m',
         );
     },
 );


### PR DESCRIPTION
increase the bulk helper timeout. 

@preaction do you think 30m is enough?