### PR TITLE
Suggester use deprecated field

### DIFF
--- a/lib/MetaCPAN/Document/File/Set.pm
+++ b/lib/MetaCPAN/Document/File/Set.pm
@@ -516,7 +516,7 @@ sub autocomplete_suggester {
     my ( $self, $query ) = @_;
     return $self unless $query;
 
-    my $search_size = 50;
+    my $search_size = 100;
 
     my $suggestions
         = $self->search_type('dfs_query_then_fetch')->es->suggest(

--- a/lib/MetaCPAN/Document/File/Set.pm
+++ b/lib/MetaCPAN/Document/File/Set.pm
@@ -541,7 +541,7 @@ sub autocomplete_suggester {
             ( $docs{ $suggest->{text} }, $suggest->{score} );
     }
 
-    my @fields = (qw(documentation distribution author release));
+    my @fields = (qw(documentation distribution author release deprecated));
     my $data   = $self->es->search(
         {
             index => $self->index->name,
@@ -589,7 +589,8 @@ sub autocomplete_suggester {
     no warnings 'uninitialized';
     my @sorted = map { $valid{$_} }
         sort {
-        $favorites->{ $valid{$b}->{distribution} }
+               $valid{$a}->{deprecated} <=> $valid{$b}->{deprecated}
+            || $favorites->{ $valid{$b}->{distribution} }
             <=> $favorites->{ $valid{$a}->{distribution} }
             || $docs{$b} <=> $docs{$a}
             || length($a) <=> length($b)


### PR DESCRIPTION
Make suggested result take 'deprecated' field into account.
(So for example MetaCPAN::Client will appear before MetaCPAN::API)