### PR TITLE
Map values of 'deprecated' to 0,1 to ensure correct sorting

### DIFF
--- a/lib/MetaCPAN/Document/File/Set.pm
+++ b/lib/MetaCPAN/Document/File/Set.pm
@@ -580,6 +580,12 @@ sub autocomplete_suggester {
         ( $_->{fields}{documentation}[0] => \%record );
     } @{ $data->{hits}{hits} };
 
+    # normalize 'deprecated' field values to boolean (1/0) values (because ES)
+    for my $v ( values %valid ) {
+        $v->{deprecated} = 1 if $v->{deprecated} eq 'true';
+        $v->{deprecated} = 0 if $v->{deprecated} eq 'false';
+    }
+
     # remove any exact match, it will be added later
     my $exact = delete $valid{$query};
 


### PR DESCRIPTION
This is because I've seen cases where ES returns the quoted
strings "true" & "false" where in others the JSON true & false.

Normalizing to 0 & 1 ensures the correct sorting we do based
on this field in the results from the autocomplete suggester.