### PR TITLE
Added mapping+script+endpoint for collecting CPAN Cover info into MetaCPAN

### DIFF
--- a/lib/MetaCPAN/Document/Cover.pm
+++ b/lib/MetaCPAN/Document/Cover.pm
@@ -1,0 +1,33 @@
+package MetaCPAN::Document::Cover;
+
+use MetaCPAN::Moose;
+
+use ElasticSearchX::Model::Document;
+use MetaCPAN::Types qw( HashRef Str );
+
+has distribution => (
+    is       => 'ro',
+    isa      => Str,
+    required => 1,
+);
+
+has release => (
+    is       => 'ro',
+    isa      => Str,
+    required => 1,
+);
+
+has version => (
+    is       => 'ro',
+    isa      => Str,
+    required => 1,
+);
+
+has criteria => (
+    is       => 'ro',
+    isa      => HashRef,
+    required => 1,
+);
+
+__PACKAGE__->meta->make_immutable;
+1;

--- a/lib/MetaCPAN/Document/Cover/Set.pm
+++ b/lib/MetaCPAN/Document/Cover/Set.pm
@@ -1,0 +1,26 @@
+package MetaCPAN::Document::Cover::Set;
+
+use Moose;
+
+use MetaCPAN::Query::Cover ();
+
+extends 'ElasticSearchX::Model::Document::Set';
+
+has query_cover => (
+    is      => 'ro',
+    isa     => 'MetaCPAN::Query::Cover',
+    lazy    => 1,
+    builder => '_build_query_cover',
+    handles => [qw< find_release_coverage >],
+);
+
+sub _build_query_cover {
+    my $self = shift;
+    return MetaCPAN::Query::Cover->new(
+        es         => $self->es,
+        index_name => 'cover',
+    );
+}
+
+__PACKAGE__->meta->make_immutable;
+1;

--- a/lib/MetaCPAN/Query/Cover.pm
+++ b/lib/MetaCPAN/Query/Cover.pm
@@ -1,0 +1,26 @@
+package MetaCPAN::Query::Cover;
+
+use MetaCPAN::Moose;
+
+with 'MetaCPAN::Query::Role::Common';
+
+sub find_release_coverage {
+    my ( $self, $release ) = @_;
+
+    my $query = +{ term => { release => $release } };
+
+    my $res = $self->es->search(
+        index => $self->index_name,
+        type  => 'cover',
+        body  => {
+            query => $query,
+            size  => 999,
+        }
+    );
+    $res->{hits}{total} or return {};
+
+    return $res->{hits}{hits}[0]{_source};
+}
+
+__PACKAGE__->meta->make_immutable;
+1;

--- a/lib/MetaCPAN/Script/Cover.pm
+++ b/lib/MetaCPAN/Script/Cover.pm
@@ -1,0 +1,132 @@
+package MetaCPAN::Script::Cover;
+
+use Moose;
+use namespace::autoclean;
+
+use Cpanel::JSON::XS qw( decode_json );
+use Log::Contextual qw( :log :dlog );
+use MetaCPAN::Types qw( Bool Uri);
+
+with 'MetaCPAN::Role::Script', 'MooseX::Getopt';
+
+has cover_url => (
+    is      => 'ro',
+    isa     => Uri,
+    coerce  => 1,
+    default => 'http://cpancover.com/latest/cpancover.json',
+);
+
+has cover_dev_url => (
+    is      => 'ro',
+    isa     => Uri,
+    coerce  => 1,
+    default => 'http://cpancover.com/latest/cpancover_dev.json',
+);
+
+has test => (
+    is            => 'ro',
+    isa           => Bool,
+    default       => 0,
+    documentation => 'Test mode (pulls smaller development data set)',
+);
+
+my %valid_keys
+    = map { $_ => 1 } qw< branch condition statement subroutine total >;
+
+sub run {
+    my $self = shift;
+    my $data = $self->retrieve_cover_data;
+    $self->index_cover_data($data);
+    return 1;
+}
+
+sub index_cover_data {
+    my ( $self, $data ) = @_;
+
+    my $bulk = $self->es->bulk_helper(
+        index => 'cover',
+        type  => 'cover',
+    );
+
+    log_info {'Updating the cover index'};
+
+    for my $dist ( sort keys %{$data} ) {
+        for my $version ( keys %{ $data->{$dist} } ) {
+            my $release   = $dist . '-' . $version;
+            my $rel_check = $self->es->search(
+                index => 'cpan',
+                type  => 'release',
+                size  => 0,
+                body  => {
+                    query => { term => { name => $release } },
+                },
+            );
+            if ( $rel_check->{hits}{total} ) {
+                log_info { "Adding release info for '" . $release . "'" };
+            }
+            else {
+                log_warn { "Release '" . $release . "' does not exist." };
+                next;
+            }
+
+            my %doc_data = %{ $data->{$dist}{$version}{coverage}{total} };
+
+            for my $k ( keys %doc_data ) {
+                delete $doc_data{$k} unless exists $valid_keys{$k};
+            }
+
+            $bulk->update(
+                {
+                    id  => $dist,
+                    doc => {
+                        distribution => $dist,
+                        version      => $version,
+                        release      => $release,
+                        criteria     => \%doc_data,
+                    },
+                    doc_as_upsert => 1,
+                }
+            );
+        }
+    }
+
+    $bulk->flush;
+}
+
+sub retrieve_cover_data {
+    my $self = shift;
+
+    my $url = $self->test ? $self->cover_dev_url : $self->cover_url;
+
+    log_info { 'Fetching data from ', $url };
+    my $resp = $self->ua->get($url);
+
+    $self->handle_error( $resp->status_line ) unless $resp->is_success;
+
+    # clean up headers if .json.gz is served as gzip type
+    # rather than json encoded with gzip
+    if ( $resp->header('Content-Type') eq 'application/x-gzip' ) {
+        $resp->header( 'Content-Type'     => 'application/json' );
+        $resp->header( 'Content-Encoding' => 'gzip' );
+    }
+
+    return decode_json( $resp->decoded_content );
+}
+
+__PACKAGE__->meta->make_immutable;
+
+1;
+
+=pod
+
+=head1 SYNOPSIS
+
+ # bin/metacpan cover [--test]
+
+=head1 DESCRIPTION
+
+Retrieves the CPAN cover data from its source and
+updates our ES information.
+
+=cut
+

--- a/lib/MetaCPAN/Script/Mapping.pm
+++ b/lib/MetaCPAN/Script/Mapping.pm
@@ -19,6 +19,7 @@ use MetaCPAN::Script::Mapping::User::Account      ();
 use MetaCPAN::Script::Mapping::User::Identity     ();
 use MetaCPAN::Script::Mapping::User::Session      ();
 use MetaCPAN::Script::Mapping::Contributor        ();
+use MetaCPAN::Script::Mapping::Cover              ();
 use MetaCPAN::Types qw( Bool Str );
 
 use constant {
@@ -416,7 +417,10 @@ sub deploy_mapping {
         contributor => {
             contributor =>
                 decode_json(MetaCPAN::Script::Mapping::Contributor::mapping),
-        }
+        },
+        cover => {
+            cover => decode_json(MetaCPAN::Script::Mapping::Cover::mapping),
+        },
     );
 
     my $deploy_statement

--- a/lib/MetaCPAN/Script/Mapping/Cover.pm
+++ b/lib/MetaCPAN/Script/Mapping/Cover.pm
@@ -1,0 +1,49 @@
+package MetaCPAN::Script::Mapping::Cover;
+
+use strict;
+use warnings;
+
+sub mapping {
+    '{
+        "dynamic" : false,
+        "properties" : {
+           "distribution" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "version" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "release" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "criteria": {
+              "dynamic" : true,
+              "properties" : {
+                 "branch" : {
+                    "type" : "float"
+                 },
+                 "condition" : {
+                    "type" : "float"
+                 },
+                 "statement" : {
+                    "type" : "float"
+                 },
+                 "subroutine" : {
+                    "type" : "float"
+                 },
+                 "total" : {
+                    "type" : "float"
+                 }
+              }
+           }
+        }
+     }';
+}
+
+1;

--- a/lib/MetaCPAN/Server/Controller/Cover.pm
+++ b/lib/MetaCPAN/Server/Controller/Cover.pm
@@ -1,0 +1,18 @@
+package MetaCPAN::Server::Controller::Cover;
+
+use strict;
+use warnings;
+
+use Moose;
+use MetaCPAN::Util qw( digest );
+
+BEGIN { extends 'MetaCPAN::Server::Controller' }
+
+with 'MetaCPAN::Server::Role::JSONP';
+
+sub get : Path('') : Args(1) {
+    my ( $self, $c, $release ) = @_;
+    $c->stash_or_detach( $self->model($c)->find_release_coverage($release) );
+}
+
+1;


### PR DESCRIPTION
This will add the mapping and the script to be used as a cronjob to collect cover data into ES.

The data will be collected into its own index/type (cover/cover)

The second commit adds an API endpoint to support fetching release coverage info.