### PR TITLE
Standalone API/endpoint for finding a release's CONTRIBUTING/HACKING file

### DIFF
--- a/lib/MetaCPAN/Document/File/Set.pm
+++ b/lib/MetaCPAN/Document/File/Set.pm
@@ -667,5 +667,42 @@ sub find_changes_files {
     return $file->{_source};
 }
 
+sub find_contributing_files {
+    my ( $self, $author, $release ) = @_;
+
+    my @candidates = qw(
+        CONTRIBUTING CONTRIBUTING.md Contributing.pod Contributing
+        HACKING HACKING.md HACKING.pod Hacking.pod Hacking
+    );
+
+    my $file = $self->raw->filter(
+        {
+            and => [
+                { term => { release => $release } },
+                { term => { author  => $author } },
+                {
+                    or => [
+                        {
+                            and => [
+                                { term => { distribution => 'perl' } },
+                                { term => { name         => 'perlhack.pod' } }
+                            ]
+                        },
+                        {
+                            or => [
+                                map { { term => { name => $_ } } }
+                                    @candidates
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    )->size(1)->first;
+
+    return unless is_hashref($file);
+    return $file->{_source};
+}
+
 __PACKAGE__->meta->make_immutable;
 1;

--- a/lib/MetaCPAN/Server/Controller/ContributingDoc.pm
+++ b/lib/MetaCPAN/Server/Controller/ContributingDoc.pm
@@ -25,4 +25,6 @@ sub get : Chained('index') : PathPart('') : Args(2) {
     $c->stash($file);
 }
 
+__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/MetaCPAN/Server/Controller/ContributingDoc.pm
+++ b/lib/MetaCPAN/Server/Controller/ContributingDoc.pm
@@ -3,9 +3,6 @@ package MetaCPAN::Server::Controller::ContributingDoc;
 use Moose;
 use namespace::autoclean;
 
-use Encode ();
-use Try::Tiny;
-
 BEGIN { extends 'MetaCPAN::Server::Controller' }
 
 with 'MetaCPAN::Server::Role::JSONP';

--- a/lib/MetaCPAN/Server/Controller/ContributingDoc.pm
+++ b/lib/MetaCPAN/Server/Controller/ContributingDoc.pm
@@ -1,0 +1,31 @@
+package MetaCPAN::Server::Controller::ContributingDoc;
+
+use Moose;
+use namespace::autoclean;
+
+use Encode ();
+use Try::Tiny;
+
+BEGIN { extends 'MetaCPAN::Server::Controller' }
+
+with 'MetaCPAN::Server::Role::JSONP';
+
+has '+type' => ( default => 'file' );
+
+sub index : Chained('/') : PathPart('contributing_doc') : CaptureArgs(0) {
+}
+
+sub get : Chained('index') : PathPart('') : Args(2) {
+    my ( $self, $c, $author, $release ) = @_;
+
+    $c->add_author_key($author);
+    $c->cdn_max_age('1y');
+
+    my $file = $c->model('CPAN::File')
+        ->find_contributing_files( $author, $release );
+    $file or $c->detach( '/not_found', [] );
+
+    $c->stash($file);
+}
+
+1;


### PR DESCRIPTION
This implements a function and endpoint similar to the current Changes API, but for searching a release's CONTRIBUTING file, if available.  This also searches for HACKING files (which serve a similar purpose, especially on older releases,) and `perlhack.pod` for Perl releases.

Needed to support https://github.com/metacpan/metacpan-web/issues/1779.