### PR TITLE
Add more CONTRIBUTING/HACKING docs as interesting files

### DIFF
--- a/lib/MetaCPAN/Query/File.pm
+++ b/lib/MetaCPAN/Query/File.pm
@@ -63,7 +63,6 @@ sub interesting_files {
                                 {
                                     bool => {
                                         must => [
-                                            { term => { level => 0 } },
                                             {
                                                 terms => {
                                                     name => [
@@ -74,6 +73,9 @@ sub interesting_files {
                                                             CHANGES
                                                             CONTRIBUTING
                                                             CONTRIBUTING.md
+                                                            CONTRIBUTING.pod
+                                                            Contributing.pm
+                                                            Contributing.pod
                                                             COPYING
                                                             COPYRIGHT
                                                             CREDITS
@@ -82,6 +84,12 @@ sub interesting_files {
                                                             Changes
                                                             Copying
                                                             FAQ
+                                                            HACKING
+                                                            HACKING.md
+                                                            HACKING.pod
+                                                            Hacking.pm
+                                                            Hacking.pod
+                                                            Hacking
                                                             INSTALL
                                                             INSTALL.md
                                                             LICENCE


### PR DESCRIPTION
This enables https://github.com/metacpan/metacpan-web/issues/1779 by letting `interesting_files` pick up Contributing files as well as Hacking files on older dists, and relaxes the filter to let the function search for these files (and more) throughout the release dist.