### PR TITLE
new search end point with total collapsed entries

### DIFF
--- a/lib/MetaCPAN/Server/Controller/Search/Web.pm
+++ b/lib/MetaCPAN/Server/Controller/Search/Web.pm
@@ -43,6 +43,21 @@ sub web : Chained('/search/index') : PathPart('web') : Args(0) {
     my ( $self, $c ) = @_;
     my $args = $c->req->params;
 
+    my $model = $c->model('Search');
+    my $results
+        = $model->search_web( @{$args}{qw( q from size collapsed )}, 500 );
+
+    for my $result ( @{ $results->{results} } ) {
+        $result = $result->{hits};
+    }
+
+    $c->stash($results);
+}
+
+sub web_v2 : Chained('/search/index') : PathPart('web/v2') : Args(0) {
+    my ( $self, $c ) = @_;
+    my $args = $c->req->params;
+
     my $model   = $c->model('Search');
     my $results = $model->search_web( @{$args}{qw( q from size collapsed )} );
 

--- a/t/model/search.t
+++ b/t/model/search.t
@@ -38,7 +38,7 @@ ok( $search->_not_rogue, '_not_rogue' );
 
 {
     my $collapsed_search = $search->search_web('Foo');
-    is( scalar @{ $collapsed_search->{results}->[0] },
+    is( scalar @{ $collapsed_search->{results}->[0]->{hits} },
         2, 'got results for collapsed search' );
 
     ok( $collapsed_search->{collapsed}, 'results are flagged as collapsed' );
@@ -52,9 +52,9 @@ ok( $search->_not_rogue, '_not_rogue' );
 
     ok( !$expanded->{collapsed}, 'results are flagged as expanded' );
 
-    is( $expanded->{results}->[0]->[0]->{path},
+    is( $expanded->{results}->[0]->{hits}->[0]->{path},
         'lib/Pod/Pm.pm', 'first expanded result is expected' );
-    is( $expanded->{results}->[1]->[0]->{path},
+    is( $expanded->{results}->[1]->{hits}->[0]->{path},
         'lib/Pod/Pm/NoPod.pod', 'second expanded result is expected' );
 }
 


### PR DESCRIPTION
The existing search end points gives an array of arrays.  For collapsed
searches, each inner array represents a dist.  Because these arrays are
stored directly without a wrapping object, there is nowhere to store
additional data about the results.

For collapsed results, there is little reason to include all of the
inner file results.  For the metacpan front end, we only need the first
5 or so, as well as the count.  There isn't anywhere to store the count
without introducing a wrapping object for each search result.

The new end point returns an array of objects.  The objects include the
distribution name, the top five inner hits, and the total amount of
inner hits.