### PR TITLE
Increase alarm for modules extraction from files

### DIFF
--- a/lib/MetaCPAN/Model/Release.pm
+++ b/lib/MetaCPAN/Model/Release.pm
@@ -540,7 +540,7 @@ sub _modules_from_files {
                     log_error {'Call to Module::Metadata timed out '};
                     die;
                 };
-                alarm(5);
+                alarm(50);
                 my $info;
                 {
                     local $SIG{__WARN__} = sub { };


### PR DESCRIPTION
In some cases (see #812) release have many files and no provides
this timeout is simply not enough in those cases and it's timing
out is silenced in try/catch which causes a partial indexing with
missing 'modules' section which causes no 'latest' bit marking
which makes the release not discoverable.