### PR TITLE
Consolidate /search/web & /search/web/v2

### DIFF
--- a/lib/MetaCPAN/Server/Controller/Search/Web.pm
+++ b/lib/MetaCPAN/Server/Controller/Search/Web.pm
@@ -30,13 +30,8 @@ sub web : Chained('/search/index') : PathPart('web') : Args(0) {
     my ( $self, $c ) = @_;
     my $args = $c->req->params;
 
-    my $model = $c->model('Search');
-    my $results
-        = $model->search_web( @{$args}{qw( q from size collapsed )}, 500 );
-
-    for my $result ( @{ $results->{results} } ) {
-        $result = $result->{hits};
-    }
+    my $model   = $c->model('Search');
+    my $results = $model->search_web( @{$args}{qw( q from size collapsed )} );
 
     $c->stash($results);
 }


### PR DESCRIPTION
/search/web is not used anymore (since June 2018)
This is first step for removing v2 after Web starts
using /search/web again.