### PR TITLE
Search::Web - removed web_v2

### DIFF
--- a/lib/MetaCPAN/Server/Controller/Search/Web.pm
+++ b/lib/MetaCPAN/Server/Controller/Search/Web.pm
@@ -36,14 +36,4 @@ sub web : Chained('/search/index') : PathPart('web') : Args(0) {
     $c->stash($results);
 }
 
-sub web_v2 : Chained('/search/index') : PathPart('web/v2') : Args(0) {
-    my ( $self, $c ) = @_;
-    my $args = $c->req->params;
-
-    my $model   = $c->model('Search');
-    my $results = $model->search_web( @{$args}{qw( q from size collapsed )} );
-
-    $c->stash($results);
-}
-
 1;


### PR DESCRIPTION
The code was consolidated with 'sub web'
it's no longer in use by Web as well.