### PR TITLE
Create Model, Controller and spec for Cover

### DIFF
--- a/lib/MetaCPAN/API/Controller/Cover.pm
+++ b/lib/MetaCPAN/API/Controller/Cover.pm
@@ -1,0 +1,16 @@
+package MetaCPAN::API::Controller::Cover;
+
+use Mojo::Base 'Mojolicious::Controller';
+
+sub lookup {
+    my $c = shift;
+    return unless $c->openapi->valid_input;
+    my $args = $c->validation->output;
+
+    my $results = $c->model->cover->find_release_coverage( $args->{name} );
+    return $c->render( openapi => $results ) if $results;
+    $c->rendered(404);
+}
+
+1;
+

--- a/lib/MetaCPAN/API/Model/Cover.pm
+++ b/lib/MetaCPAN/API/Model/Cover.pm
@@ -1,0 +1,31 @@
+package MetaCPAN::API::Model::Cover;
+
+use MetaCPAN::Moose;
+
+with 'MetaCPAN::API::Model::Role::ES';
+
+sub find_release_coverage {
+    my ( $self, $release ) = @_;
+
+    my $query = +{ term => { release => $release } };
+
+    my $res = $self->_run_query(
+        index => 'cover',
+        type  => 'cover',
+        body  => {
+            query => $query,
+            size  => 999,
+        }
+    );
+    $res->{hits}{total} or return {};
+
+    return +{
+        %{ $res->{hits}{hits}[0]{_source} },
+        url => "http://cpancover.com/latest/$release/index.html",
+    };
+}
+
+__PACKAGE__->meta->make_immutable;
+
+1;
+

--- a/lib/MetaCPAN/API/Plugin/Model.pm
+++ b/lib/MetaCPAN/API/Plugin/Model.pm
@@ -10,6 +10,7 @@ use MetaCPAN::Model::Search ();
 # New models
 use MetaCPAN::API::Model::User     ();
 use MetaCPAN::API::Model::Download ();
+use MetaCPAN::API::Model::Cover    ();
 
 has app => sub { Carp::croak 'app is required' }, weak => 1;
 
@@ -31,6 +32,11 @@ has user => sub {
     return MetaCPAN::API::Model::User->new( es => $self->app->es );
 };
 
+has cover => sub {
+    my $self = shift;
+    return MetaCPAN::API::Model::Cover->new( es => $self->app->es );
+};
+
 sub register {
     my ( $plugin, $app, $conf ) = @_;
     $plugin->app($app);
@@ -39,6 +45,7 @@ sub register {
     $app->helper( 'model.download' => sub { $plugin->download } );
     $app->helper( 'model.search'   => sub { $plugin->search } );
     $app->helper( 'model.user'     => sub { $plugin->user } );
+    $app->helper( 'model.cover'    => sub { $plugin->cover } );
 }
 
 1;

--- a/lib/MetaCPAN/Script/Cover.pm
+++ b/lib/MetaCPAN/Script/Cover.pm
@@ -5,7 +5,8 @@ use namespace::autoclean;
 
 use Cpanel::JSON::XS qw( decode_json );
 use Log::Contextual qw( :log :dlog );
-use MetaCPAN::Types qw( Bool Uri);
+use MetaCPAN::Types qw( Bool Str Uri);
+use Path::Class qw( file );
 
 with 'MetaCPAN::Role::Script', 'MooseX::Getopt';
 
@@ -28,6 +29,14 @@ has test => (
     isa           => Bool,
     default       => 0,
     documentation => 'Test mode (pulls smaller development data set)',
+);
+
+has json_file => (
+    is      => 'ro',
+    isa     => Str,
+    default => 0,
+    documentation =>
+        'Path to JSON file to be read instead of URL (for testing)',
 );
 
 my %valid_keys
@@ -96,6 +105,11 @@ sub index_cover_data {
 sub retrieve_cover_data {
     my $self = shift;
 
+    if ( $self->json_file ) {
+        my $file = file( $self->json_file );
+        return decode_json( $file->slurp );
+    }
+
     my $url = $self->test ? $self->cover_dev_url : $self->cover_url;
 
     log_info { 'Fetching data from ', $url };
@@ -129,4 +143,3 @@ Retrieves the CPAN cover data from its source and
 updates our ES information.
 
 =cut
-

--- a/root/static/definitions/common.yml
+++ b/root/static/definitions/common.yml
@@ -1,0 +1,13 @@
+---
+
+ErrorModel:
+  type: "object"
+  required:
+    - "code"
+    - "message"
+  properties:
+    code:
+      type: "integer"
+      format: "int32"
+    message:
+      type: "string"

--- a/root/static/requests/cover.yml
+++ b/root/static/requests/cover.yml
@@ -14,6 +14,9 @@ cover:
           The name of the Release
         type: string
         required: true
+        # tell Mojolicious to use relaxed placeholders when
+        # parsing this parameter (dots are allowed)
+        x-mojo-placeholder: "#"
     responses:
       200:
         description: Release response

--- a/root/static/requests/cover.yml
+++ b/root/static/requests/cover.yml
@@ -1,0 +1,28 @@
+---
+
+cover:
+  get:
+    tags:
+      - Coverage
+    operationId: cover
+    x-mojo-to: Cover#lookup
+    summary: Get coverage details about a release
+    parameters:
+      - name: name
+        in: path
+        description: |
+          The name of the Release
+        type: string
+        required: true
+    responses:
+      200:
+        description: Release response
+        schema:
+          type: object
+          properties:
+            name:
+              type: string
+      default:
+        description: "unexpected error"
+        schema:
+          $ref: "../definitions/common.yml#/ErrorModel"

--- a/root/static/v1.yml
+++ b/root/static/v1.yml
@@ -22,3 +22,5 @@ paths:
     $ref: "requests/search.yml#/search_web"
   /search/first:
     $ref: "requests/search.yml#/search_first"
+  /cover/{name}:
+    $ref: "requests/cover.yml#/cover"

--- a/t/00_setup.t
+++ b/t/00_setup.t
@@ -105,6 +105,7 @@ $server->prepare_user_test_data;
 $server->index_cpantesters;
 $server->index_mirrors;
 $server->index_favorite;
+$server->index_cover;
 
 ok(
     MetaCPAN::Script::Tickets->new_with_options(

--- a/t/api/controller/cover.t
+++ b/t/api/controller/cover.t
@@ -17,7 +17,7 @@ my $t = Test::Mojo->new(
 );
 
 my %expect = (
-    'Devel-GoFaster-0.000' => {
+    'MetaFile-Both-1.1' => {
         criteria => {
             branch     => '12.50',
             condition  => '0.00',
@@ -25,12 +25,12 @@ my %expect = (
             subroutine => '71.43',
             total      => '46.51',
         },
-        distribution => 'Devel-GoFaster',
-        release      => 'Devel-GoFaster-0.000',
-        url => 'http://cpancover.com/latest/Devel-GoFaster-0.000/index.html',
-        version => '0.000',
+        distribution => 'MetaFile-Both',
+        release      => 'MetaFile-Both-1.1',
+        url     => 'http://cpancover.com/latest/MetaFile-Both-1.1/index.html',
+        version => '1.1',
     },
-    'Try-Tiny-0.27' => {
+    'Pod-With-Generator-1' => {
         criteria => {
             branch     => '78.95',
             condition  => '46.67',
@@ -38,10 +38,10 @@ my %expect = (
             subroutine => '100.00',
             total      => '86.58',
         },
-        distribution => 'Try-Tiny',
-        release      => 'Try-Tiny-0.27',
-        url     => 'http://cpancover.com/latest/Try-Tiny-0.27/index.html',
-        version => '0.27',
+        distribution => 'Pod-With-Generator',
+        release      => 'Pod-With-Generator-1',
+        url => 'http://cpancover.com/latest/Pod-With-Generator-1/index.html',
+        version => '1',
     },
 );
 

--- a/t/api/controller/cover.t
+++ b/t/api/controller/cover.t
@@ -1,10 +1,21 @@
 use Mojo::Base -strict;
+use lib 't/lib';
 
 use Test::More;
 use Test::Mojo;
 use Mojo::JSON qw(true false);
 
-my $t      = Test::Mojo->new('MetaCPAN::API');
+use MetaCPAN::Model::Search ();
+use MetaCPAN::TestServer    ();
+my $server = MetaCPAN::TestServer->new;
+
+my $t = Test::Mojo->new(
+    'MetaCPAN::API' => {
+        es     => $server->es_client,
+        secret => 'just a test',
+    }
+);
+
 my %expect = (
     'Devel-GoFaster-0.000' => {
         criteria => {

--- a/t/api/controller/cover.t
+++ b/t/api/controller/cover.t
@@ -1,0 +1,46 @@
+use Mojo::Base -strict;
+
+use Test::More;
+use Test::Mojo;
+use Mojo::JSON qw(true false);
+
+my $t      = Test::Mojo->new('MetaCPAN::API');
+my %expect = (
+    'Devel-GoFaster-0.000' => {
+        criteria => {
+            branch     => '12.50',
+            condition  => '0.00',
+            statement  => '63.64',
+            subroutine => '71.43',
+            total      => '46.51',
+        },
+        distribution => 'Devel-GoFaster',
+        release      => 'Devel-GoFaster-0.000',
+        url => 'http://cpancover.com/latest/Devel-GoFaster-0.000/index.html',
+        version => '0.000',
+    },
+    'Try-Tiny-0.27' => {
+        criteria => {
+            branch     => '78.95',
+            condition  => '46.67',
+            statement  => '95.06',
+            subroutine => '100.00',
+            total      => '86.58',
+        },
+        distribution => 'Try-Tiny',
+        release      => 'Try-Tiny-0.27',
+        url     => 'http://cpancover.com/latest/Try-Tiny-0.27/index.html',
+        version => '0.27',
+    },
+);
+
+for my $release ( keys %expect ) {
+    my $expected = $expect{$release};
+    subtest "Check $release" => sub {
+
+        $t->get_ok("/v1/cover/$release")->status_is(200)->json_is($expected)
+            ->or( sub { diag $t->tx->res->dom } );
+
+    };
+}
+done_testing;

--- a/t/lib/MetaCPAN/TestServer.pm
+++ b/t/lib/MetaCPAN/TestServer.pm
@@ -4,6 +4,7 @@ use MetaCPAN::Moose;
 
 use MetaCPAN::DarkPAN                ();
 use MetaCPAN::Script::Author         ();
+use MetaCPAN::Script::Cover          ();
 use MetaCPAN::Script::CPANTestersAPI ();
 use MetaCPAN::Script::Favorite       ();
 use MetaCPAN::Script::First          ();
@@ -224,6 +225,14 @@ sub index_mirrors {
     local @ARGV = ('mirrors');
     ok( MetaCPAN::Script::Mirrors->new_with_options( $self->_config )->run,
         'index mirrors' );
+}
+
+sub index_cover {
+    my $self = shift;
+
+    local @ARGV = ( 'cover', '--json_file', 't/var/cover.json' );
+    ok( MetaCPAN::Script::Cover->new_with_options( $self->_config )->run,
+        'index cover' );
 }
 
 sub index_permissions {

--- a/t/server/controller/cover.t
+++ b/t/server/controller/cover.t
@@ -7,7 +7,7 @@ use MetaCPAN::TestHelpers qw( decode_json_ok );
 use Test::More;
 
 my %expect = (
-    'Devel-GoFaster-0.000' => {
+    'MetaFile-Both-1.1' => {
         criteria => {
             branch     => '12.50',
             condition  => '0.00',
@@ -15,12 +15,12 @@ my %expect = (
             subroutine => '71.43',
             total      => '46.51',
         },
-        distribution => 'Devel-GoFaster',
-        release      => 'Devel-GoFaster-0.000',
-        url => 'http://cpancover.com/latest/Devel-GoFaster-0.000/index.html',
-        version => '0.000',
+        distribution => 'MetaFile-Both',
+        release      => 'MetaFile-Both-1.1',
+        url     => 'http://cpancover.com/latest/MetaFile-Both-1.1/index.html',
+        version => '1.1',
     },
-    'Try-Tiny-0.27' => {
+    'Pod-With-Generator-1' => {
         criteria => {
             branch     => '78.95',
             condition  => '46.67',
@@ -28,10 +28,10 @@ my %expect = (
             subroutine => '100.00',
             total      => '86.58',
         },
-        distribution => 'Try-Tiny',
-        release      => 'Try-Tiny-0.27',
-        url     => 'http://cpancover.com/latest/Try-Tiny-0.27/index.html',
-        version => '0.27',
+        distribution => 'Pod-With-Generator',
+        release      => 'Pod-With-Generator-1',
+        url => 'http://cpancover.com/latest/Pod-With-Generator-1/index.html',
+        version => '1',
     },
 );
 

--- a/t/var/cover.json
+++ b/t/var/cover.json
@@ -1,6 +1,6 @@
 {
-   "Devel-GoFaster" : {
-      "0.000" : {
+   "MetaFile-Both" : {
+      "1.1" : {
          "coverage" : {
             "total" : {
                "branch" : "12.50",
@@ -10,36 +10,10 @@
                "total" : "46.51"
             }
          }
-      },
-      "0.001" : {
-         "coverage" : {
-            "total" : {
-               "branch" : "12.50",
-               "condition" : "0.00",
-               "statement" : "61.90",
-               "subroutine" : "71.43",
-               "total" : "45.24"
-            }
-         }
       }
    },
-   "Try-Tiny" : {
-      "0.22" : {
-         "coverage" : {
-            "total" : {}
-         }
-      },
-      "0.23" : {
-         "coverage" : {
-            "total" : {}
-         }
-      },
-      "0.24" : {
-         "coverage" : {
-            "total" : {}
-         }
-      },
-      "0.27" : {
+   "Pod-With-Generator" : {
+      "1" : {
          "coverage" : {
             "total" : {
                "branch" : "78.95",
@@ -48,30 +22,6 @@
                "statement" : "95.06",
                "subroutine" : "100.00",
                "total" : "86.58"
-            }
-         }
-      },
-      "0.28" : {
-         "coverage" : {
-            "total" : {
-               "branch" : "78.95",
-               "condition" : "46.67",
-               "pod" : "100.00",
-               "statement" : "95.06",
-               "subroutine" : "100.00",
-               "total" : "86.58"
-            }
-         }
-      },
-      "0.30" : {
-         "coverage" : {
-            "total" : {
-               "branch" : "78.95",
-               "condition" : "46.67",
-               "pod" : "100.00",
-               "statement" : "94.87",
-               "subroutine" : "100.00",
-               "total" : "86.30"
             }
          }
       }


### PR DESCRIPTION
Using `MetaCPAN::Model::User` and `MetaCPAN::Model::Download` as examples, convert `MetaCPAN::Query::Cover` into a model, add the plugin, controller, and tests, and create the OpenAPI spec to drive it.