### PR TITLE
Added checksums (md5/sha256) to release archives + download_url endpoint

### DIFF
--- a/lib/MetaCPAN/Document/Release.pm
+++ b/lib/MetaCPAN/Document/Release.pm
@@ -146,6 +146,11 @@ has download_url => (
     builder => '_build_download_url',
 );
 
+has [qw(checksum_md5 checksum_sha256)] => (
+    is  => 'ro',
+    isa => Str,
+);
+
 has [qw(distribution name)] => (
     is       => 'ro',
     required => 1,

--- a/lib/MetaCPAN/Model/Archive.pm
+++ b/lib/MetaCPAN/Model/Archive.pm
@@ -3,12 +3,13 @@ package MetaCPAN::Model::Archive;
 use v5.10;
 use Moose;
 use MooseX::StrictConstructor;
-use MetaCPAN::Types qw(AbsFile AbsDir ArrayRef Bool);
+use MetaCPAN::Types qw(AbsFile AbsDir ArrayRef Bool Str);
 
 use Archive::Any;
 use Carp;
 use File::Temp  ();
 use Path::Class ();
+use Digest::file qw( digest_file_hex );
 
 =head1 NAME
 
@@ -65,6 +66,28 @@ has _extractor => (
         my $self = shift;
         croak $self->file . ' does not exist' unless -e $self->file;
         return Archive::Any->new( $self->file );
+    },
+);
+
+# MD5 digest for the archive file
+has file_digest_md5 => (
+    is      => 'ro',
+    isa     => Str,
+    lazy    => 1,
+    default => sub {
+        my $self = shift;
+        digest_file_hex( $self->file, 'MD5' );
+    },
+);
+
+# SHA256 digest for the archive file
+has file_digest_sha256 => (
+    is      => 'ro',
+    isa     => Str,
+    lazy    => 1,
+    default => sub {
+        my $self = shift;
+        digest_file_hex( $self->file, 'SHA-256' );
     },
 );
 

--- a/lib/MetaCPAN/Model/Release.pm
+++ b/lib/MetaCPAN/Model/Release.pm
@@ -194,12 +194,14 @@ sub _build_document {
     my $dependencies = $self->dependencies;
 
     my $document = DlogS_trace {"adding release $_"} +{
-        abstract     => MetaCPAN::Util::strip_pod( $meta->abstract ),
-        archive      => $self->filename,
-        author       => $self->author,
-        date         => $self->date . q{},
-        dependency   => $dependencies,
-        distribution => $self->distribution,
+        abstract        => MetaCPAN::Util::strip_pod( $meta->abstract ),
+        archive         => $self->filename,
+        author          => $self->author,
+        checksum_md5    => $self->archive->file_digest_md5,
+        checksum_sha256 => $self->archive->file_digest_sha256,
+        date            => $self->date . q{},
+        dependency      => $dependencies,
+        distribution    => $self->distribution,
 
         # CPAN::Meta->license *must* be called in list context
         # (and *may* return multiple strings).

--- a/lib/MetaCPAN/Query/Release.pm
+++ b/lib/MetaCPAN/Query/Release.pm
@@ -254,6 +254,25 @@ sub get_files {
     return { files => [ map { $_->{_source} } @{ $ret->{hits}{hits} } ] };
 }
 
+sub get_checksums {
+    my ( $self, $release ) = @_;
+
+    my $query = +{ query => { term => { name => $release } } };
+
+    my $ret = $self->es->search(
+        index => $self->index_name,
+        type  => 'release',
+        body  => {
+            query   => $query,
+            size    => 1,
+            _source => [qw< checksum_md5 checksum_sha256 >],
+        }
+    );
+
+    return {} unless @{ $ret->{hits}{hits} };
+    return $ret->{hits}{hits}[0]{_source};
+}
+
 sub _activity_filters {
     my ( $self, $params, $start ) = @_;
     my ( $author, $distribution, $module, $new_dists )

--- a/lib/MetaCPAN/Script/Mapping/CPAN/Release.pm
+++ b/lib/MetaCPAN/Script/Mapping/CPAN/Release.pm
@@ -40,6 +40,16 @@ sub mapping {
               "index" : "not_analyzed",
               "type" : "string"
            },
+           "checksum_md5" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
+           "checksum_sha256" : {
+              "ignore_above" : 2048,
+              "index" : "not_analyzed",
+              "type" : "string"
+           },
            "date" : {
               "format" : "strict_date_optional_time||epoch_millis",
               "type" : "date"

--- a/t/server/controller/download_url.t
+++ b/t/server/controller/download_url.t
@@ -14,7 +14,12 @@ my $app  = MetaCPAN::Server->new->to_app();
 my $test = Plack::Test->create($app);
 
 my @tests = (
-    [ 'no parameters', '/download_url/Moose', 'latest', '0.02' ],
+    [
+        'no parameters',
+        '/download_url/Moose',
+        'latest',
+        '0.02',
+    ],
     [
         'version == (1)', '/download_url/Moose?version===0.01',
         'cpan',           '0.01'
@@ -42,7 +47,9 @@ my @tests = (
     [ 'version >=', '/download_url/Moose?version=>=0.01', 'latest', '0.02' ],
     [
         'range >, <', '/download_url/Try::Tiny?version=>0.21,<0.27',
-        'cpan',       '0.24'
+        'cpan',       '0.24',
+        '1a12a51cfeb7e2c301e4ae093c7ecdfb',
+        '9b7a1af24c0256973d175369ebbdc25ec01e2452a97f2d3ab61481c826f38d81',
     ],
     [
         'range >, <, !',
@@ -62,7 +69,8 @@ my @tests = (
 );
 
 for (@tests) {
-    my ( $title, $url, $status, $version ) = @$_;
+    my ( $title, $url, $status, $version, $checksum_md5, $checksum_sha256 )
+        = @$_;
 
     subtest $title => sub {
         my $res = $test->request( GET $url );
@@ -88,6 +96,15 @@ for (@tests) {
         ok( is_hashref($content), 'content is a JSON object' );
         is( $content->{status},  $status,  "correct status ($status)" );
         is( $content->{version}, $version, "correct version ($version)" );
+        if ($checksum_md5) {
+            is( $content->{checksum_md5},
+                $checksum_md5, "correct checksum_md5 ($checksum_md5)" );
+        }
+        if ($checksum_sha256) {
+            is( $content->{checksum_sha256},
+                $checksum_sha256,
+                "correct checksum_sha256 ($checksum_sha256)" );
+        }
     };
 }
 


### PR DESCRIPTION
Relates to #327 

This will add `checksum_md5` & `checksum_sha1` mappings *definitions* (will require manually adding the mappings in production - I can take care of that once approved) to the `release` type (I don't think the `file` type level is the right place to hold it though it has the `download_url` copy as it may confuse people to think these are the checksums of the files).

Is `Digest::file` the right module to use? any other suggestions?