### PR TITLE
Add a new API: /changes/by_releases

### DIFF
--- a/lib/MetaCPAN/Document/Release/Set.pm
+++ b/lib/MetaCPAN/Document/Release/Set.pm
@@ -20,6 +20,7 @@ has query_release => (
             author_status
             by_author
             by_author_and_name
+            by_author_and_names
             get_contributors
             get_files
             latest_by_author

--- a/lib/MetaCPAN/Query/Release.pm
+++ b/lib/MetaCPAN/Query/Release.pm
@@ -366,16 +366,22 @@ sub by_author_and_names {
         query => {
             bool => {
                 should => [
-                    map { +{
-                        query => {
-                            bool => {
-                                must => [
-                                    { term => { author => uc($_->{author}) } },
-                                    { term => { 'name' => $_->{name} } },
-                                ]
+                    map {
+                        +{
+                            query => {
+                                bool => {
+                                    must => [
+                                        {
+                                            term => {
+                                                author => uc( $_->{author} )
+                                            }
+                                        },
+                                        { term => { 'name' => $_->{name} } },
+                                    ]
+                                }
                             }
                         }
-                    } } @$releases
+                    } @$releases
                 ]
             }
         }
@@ -389,15 +395,15 @@ sub by_author_and_names {
     return unless $ret->{hits}{total};
 
     my @releases;
-    for my $hit (@{ $ret->{hits}{hits} }) {
+    for my $hit ( @{ $ret->{hits}{hits} } ) {
         my $src = $hit->{_source};
         single_valued_arrayref_to_scalar($src);
         push @releases, $src;
     }
 
     return {
-        took    => $ret->{took},
-        total   => $ret->{hits}{total},
+        took     => $ret->{took},
+        total    => $ret->{hits}{total},
         releases => \@releases,
     };
 }

--- a/lib/MetaCPAN/Server/Controller/Changes.pm
+++ b/lib/MetaCPAN/Server/Controller/Changes.pm
@@ -76,20 +76,15 @@ sub by_releases : Path('by_releases') : Args(0) {
     for my $release ( @{ $ret->{releases} } ) {
         my ( $author, $name, $path )
             = @{$release}{qw(author name changes_file)};
-        my $source = $c->model('Source')->path( $author, $name, $path ) // '';
+        my $source = $c->model('Source')->path( $author, $name, $path ) or next;
 
-        my $content;
-        try {
-            local $/;
-            $content = Encode::decode(
+        my $content = try {
+            Encode::decode(
                 'UTF-8',
-                ( scalar $source->openr->getline ),
+                ( scalar $source->slurp ),
                 Encode::FB_CROAK | Encode::LEAVE_SRC
             );
-        }
-        catch {
-            $content = undef;
-        };
+        } or next;
 
         push @changes,
             {

--- a/lib/MetaCPAN/Server/Controller/Changes.pm
+++ b/lib/MetaCPAN/Server/Controller/Changes.pm
@@ -76,7 +76,8 @@ sub by_releases : Path('by_releases') : Args(0) {
     for my $release ( @{ $ret->{releases} } ) {
         my ( $author, $name, $path )
             = @{$release}{qw(author name changes_file)};
-        my $source = $c->model('Source')->path( $author, $name, $path ) or next;
+        my $source = $c->model('Source')->path( $author, $name, $path )
+            or next;
 
         my $content = try {
             Encode::decode(

--- a/lib/MetaCPAN/Server/Controller/Changes.pm
+++ b/lib/MetaCPAN/Server/Controller/Changes.pm
@@ -68,16 +68,17 @@ sub all : Chained('index') : PathPart('') : Args(0) {
 sub by_releases : Path('by_releases') : Args(0) {
     my ( $self, $c ) = @_;
 
-    my $ret = $c->model('CPAN::Release')->by_author_and_names([
-        map {
-            my @o = split('/', $_, 2);
-            @o != 2 ? () : (+{
-                author => $o[0],
-                name   => $o[1],
-            })
-        }
-        @{ $c->read_param("release") }
-    ]);
+    my @releases = map {
+        my @o = split( '/', $_, 2 );
+        @o == 2 ? { author => $o[0], name => $o[1] } : ();
+    } @{ $c->read_param("release") };
+
+    unless (@releases) {
+        $c->stash( { changes => [] } );
+        return;
+    }
+
+    my $ret = $c->model('CPAN::Release')->by_author_and_names( \@releases );
 
     my @changes;
     for my $release ( @{ $ret->{releases} } ) {

--- a/lib/MetaCPAN/Server/Controller/Changes.pm
+++ b/lib/MetaCPAN/Server/Controller/Changes.pm
@@ -68,9 +68,16 @@ sub all : Chained('index') : PathPart('') : Args(0) {
 sub by_releases : Path('by_releases') : Args(0) {
     my ( $self, $c ) = @_;
 
-    # ArrayRef[ Dict[ author => Str, name => Str ] ]
-    my $arg = $c->read_param("releases");
-    my $ret = $c->model('CPAN::Release')->by_author_and_names($arg);
+    my $ret = $c->model('CPAN::Release')->by_author_and_names([
+        map {
+            my @o = split('/', $_, 2);
+            @o != 2 ? () : (+{
+                author => $o[0],
+                name   => $o[1],
+            })
+        }
+        @{ $c->read_param("release") }
+    ]);
 
     my @changes;
     for my $release ( @{ $ret->{releases} } ) {

--- a/lib/MetaCPAN/Server/Controller/Changes.pm
+++ b/lib/MetaCPAN/Server/Controller/Changes.pm
@@ -70,11 +70,12 @@ sub by_releases : Path('by_releases') : Args(0) {
 
     # ArrayRef[ Dict[ author => Str, name => Str ] ]
     my $arg = $c->read_param("releases");
-    my $ret = $c->model('CPAN::Release')->by_author_and_names( $arg );
+    my $ret = $c->model('CPAN::Release')->by_author_and_names($arg);
 
     my @changes;
-    for my $release (@{$ret->{releases}}) {
-        my ($author, $name, $path) = @{$release}{ qw(author name changes_file) };
+    for my $release ( @{ $ret->{releases} } ) {
+        my ( $author, $name, $path )
+            = @{$release}{qw(author name changes_file)};
         my $source = $c->model('Source')->path( $author, $name, $path ) // '';
 
         my $content;
@@ -82,21 +83,23 @@ sub by_releases : Path('by_releases') : Args(0) {
             local $/;
             $content = Encode::decode(
                 'UTF-8',
-                (scalar $source->openr->getline),
+                ( scalar $source->openr->getline ),
                 Encode::FB_CROAK | Encode::LEAVE_SRC
             );
-        } catch {
+        }
+        catch {
             $content = undef;
         };
 
-        push @changes, {
-            author => $author,
-            release => $name,
+        push @changes,
+            {
+            author       => $author,
+            release      => $name,
             changes_text => $content,
-        }
+            };
     }
 
-    $c->stash({ changes => \@changes });
+    $c->stash( { changes => \@changes } );
 }
 
 1;

--- a/lib/MetaCPAN/Server/Controller/Changes.pm
+++ b/lib/MetaCPAN/Server/Controller/Changes.pm
@@ -91,6 +91,7 @@ sub by_releases : Path('by_releases') : Args(0) {
             author       => $author,
             release      => $name,
             changes_text => $content,
+            changes_file => $path,
             };
     }
 


### PR DESCRIPTION
Context: https://github.com/metacpan/metacpan-web/issues/2142

I wished to mixin the latest changelog for each recent releases in `/feed/recent`, but with existing APIs it'd take N requests in order to do that.

In order to minimize the number of round-trips betwenn API and Web, I added this API endpoint to retrieve the changelog content of the given list o "release" parameter. This still maps to N Elasticsearch queries but I'm guessing that's OK.... if not I can improve that as well.

Here's how it looks like:

```
curl 'http://localhost:5000/changes/by_releases?release=GUGOD/Hijk-0.28&release=GETTY/AnyEvent-ITM-0.003'

{
   "changes" : [
      {
         "changes_file" : "Changes",
         "changes_text" : "==================================================\nChanges from 1745-02-09 00:00:00 +0000 to present.\n==================================================\n\n------------------------------------------\nversion 0.003 at 2018-11-24 23:39:23 +0000\n------------------------------------------\n\n  Change: e2f314fc6d53baa88bb42eff86560a27987f6095\n  Author: Torsten Raudssus <torsten@raudss.us>\n  Date : 2018-11-25 00:39:12 +0000\n\n    Updated travis.yml \n\n  Change: 706e119c99b1a06725db53947016cf0b7195f15e\n  Author: Torsten Raudssus <torsten@raudss.us>\n  Date : 2018-11-25 00:36:26 +0000\n\n    Updated travis config, no color tool, Win32 bundle batch \n\n  Change: 8369d0b3fc22531c4c5ac6a10d282d222935b4f4\n  Author: Torsten Raudssus <torsten@raudss.us>\n  Date : 2015-03-08 04:37:31 +0000\n\n    More doc \n\n  Change: 9d7dbff3a79545277edf34cb46226c355c7e7253\n  Author: Torsten Raudssus <torsten@raudss.us>\n  Date : 2015-03-08 04:34:01 +0000\n\n    A bit of pot for the bin \n\n------------------------------------------\nversion 0.002 at 2015-03-08 03:27:40 +0000\n------------------------------------------\n\n  Change: 3bdac75a969168f0292d63f51051bcafe63834a8\n  Author: Torsten Raudssus <torsten@raudss.us>\n  Date : 2015-03-08 04:27:40 +0000\n\n    Fixed rights \n\n  Change: 6f49af89fe5917e499d73992aade2a5a55b6465a\n  Author: Torsten Raudssus <torsten@raudss.us>\n  Date : 2015-03-08 04:27:30 +0000\n\n    Now colored \n\n------------------------------------------\nversion 0.001 at 2015-03-07 16:59:08 +0000\n------------------------------------------\n\n  Change: f7fc35732195ead6ad4af751a27254113ce26406\n  Author: Torsten Raudssus <torsten@raudss.us>\n  Date : 2015-03-07 17:59:08 +0000\n\n    Fixed rights \n\n  Change: fb5468fd55a3be5cb4894f208cbc40cb5cc18b0a\n  Author: Torsten Raudssus <torsten@raudss.us>\n  Date : 2015-03-07 17:55:34 +0000\n\n    Added simple reader, added tests, finished implementation, added\n    travis.yml \n\n  Change: 1f3472cc5a8a8901e253cf8ede9fc2be7018a007\n  Author: Torsten Raudssus <torsten@raudss.us>\n  Date : 2015-03-06 21:58:37 +0000\n\n    initial commit \n\n================\nEnd of releases.\n================\n",
         "release" : "AnyEvent-ITM-0.003",
         "author" : "GETTY"
      },
      {
         "author" : "GUGOD",
         "changes_text" : "0.28\n\n\t- Released at 2019-01-11T16:25:00+0900\n\t- Now the distribution is made with mbtiny.\n\t- Various improvements of the test suite.\n\t- Rewrite the internally-used testing-purpose HTTP server to allow the control of 'Content-Length' request header.\n\n0.27: # 2016-10-28T12:59:00+0100\n\n- Unbreak with Elasticeasrch 5.0. See https://rt.cpan.org/Public/Bug/Display.html?id=118425\n\n0.26: # 2015-11-25T12:30:00+0100\n\n- No functional changes since 0.25, but we had some Travis-specific\n  changes in the repo, releasing just so we have the latest code there\n  on the CPAN.\n\n0.25: # 2015-11-25T12:20:00+0100\n\n- Make the t/select-timeout.t test which fails on various odd\n  CPANtesters platforms a TODO. Maybe some OS-specific issue, maybe an\n  issue with kill() in the CPANtesters sandboxes not behaving as we\n  expect.\n\n0.24: # 2015-07-05T13:40:00+0200\n\n- Minor copyediting and formatting changes to the documentation. No\n  code changes at all.\n\n0.23: # 2015-07-03T17:00:00+0200\n\n- The \"Host\" header can now be overriden by supplying a new\n  `no_default_host_header` option along with a `Host` header in `head\n  => []` to request().\n\n  Before this we'd always send \"Host: $host\" over, where $host was the\n  host we were connecting to, now you can customize this.\n\n- Fixed a bug where if passed passed `head => []` to request() we'd\n  emit a \":\" header, i.e. just an empty header name with an empty\n  value.\n\n  You could have just not passed the `head => ` value if the array was\n  empty, but no we won't screw up and emit a single line consisting of\n  \":\" if given an empty array.\n\n0.22: # 2015-05-27T07:54:17+0200\n\n- No feature change. Re-package due to a missing file in the tarball:\n  https://rt.cpan.org/Ticket/Display.html?id=104624\n\n0.21: # 2015-05-22T15:26:23+0200\n\n- Fix \"Too many CRLF\" issue. Hijk has been always generating HTTP\n  request with an extra CRLF at the end. While many HTTP servers are\n  ignoring those, some treat it as errors. We now eliminate the extra\n  CRLF at the end of every request.\n  See also http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html\n\n- Handle better when select() is interrupted by signals.\n\n0.20: # 2015-03-20-T15:10:00+0000\n- Fix a regression in 0.14. When the chunked encoding support was\n  introduced we accidentally stopped supporting \"Content-Length: 0\",\n  treat those responses as the zero-body again. This broke e.g. PUT\n  requests that would return no payload.\n\n- Add support for 204 No Content responses. According to the HTTP\n  standard we must try to consume the body if there's no\n  Content-Length, but not if the server returns a 204 response, then\n  it MUST NOT include a body (see\n  http://tools.ietf.org/html/rfc2616#page-60).\n\n  This re-adds support for e.g. 204 No Content response, in practice\n  this \"worked\" before 0.14, but only accidentally and other types of\n  responses wouldn't work.\n\n- We now handle our system calls returning EINTR.\n\n0.19: # 2015-01-10-T18:30:00+0000\n- Fix a major regression in 0.16. The introduction of \"head_as_array\"\n  completely broke the disconnection logic when the socket_cache was\n  enabled (which is the default). When talking to a webserver that\n  would disconnect us after N requests request N+1 would always fail\n  with a 0 byte response error.\n\n  This issue was reported as RT #101424\n  (https://rt.cpan.org/Public/Bug/Display.html?id=101424)\n\n- Fix a minor regression in 0.16: The introduction of \"head_as_array\"\n  broke the \"proto\" part of the return value in a relatively obscure\n  edge case where we'd read the header & had no Content-Length and\n  couldn't read() anything.\n\n- Fix an edge case in the Trailer support. It would only kick in if we\n  got the Transfer-Encoding header before the \"Trailer\" header, not\n  the other way around.\n\n0.18: # 2014-12-10T14:00:00+000\n- We now do the right thing on \"method => 'HEAD'\". I.e. ignore the\n  Content-Length parameter, previously we'd just hang trying to slurp\n  up the body.\n- Fix an edge case with some of the live tests leaving around a HTTP\n  server if they died, these don't run by default.\n\n0.17: # 2014-08-31T18:30:00+000\n- Minor documentation changes, no functional changes.\n- The version number for the last release was incorrect in this\n  changelog, fixed in this release.\n\n0.16: # 2014-08-31T00:10:00+000\n- Major Change: There are several new Hijk::Error::* constants for\n  common issues that happened during normal requests in the face of\n  regular exceptions out of the control of this library, such as\n  network blips.\n\n  Existing code that checks $res->{error} should be\n  forwards-compatible with this change, but anything that was doing\n  e.g. regex checks against regular errors thrown by this library\n  should be updated to check the new Hijk::Error::* constants instead.\n\n- It's now possible to specify \"head_as_array\" to get the returned\n  headers as an array (with potential duplicated headers), rather than\n  the default behavior of lossily returning them as a hash.\n\n- There's now a \"read_length\" option to control how much we\n  POSIX::read($fd, $buf, $read_length) at a time. We don't expect this\n  to be useful, it's mainly configurable on general principle so we\n  don't have arbitrary unconfigurable hardcoded constants in the\n  source.\n\n0.15: # 2014-08-30T10:00:00+000\n- The new code to support chunked transfer encoding would return a\n  nonexisting Hijk::Error::* value of \"0\" when it encountered a read\n  timeout. This meant that not only was the error reporting broken,\n  but anything checking if there were errors via the simple idiom of\n  \"if ($res->{error}) {...}\" wouldn't properly report errors.\n\n  We'll now correctly report these errors as\n  Hijk::Error::READ_TIMEOUT.\n\n- Since there may still be other bugs like that in this new parsing\n  mode it's disabled by default, if you know you want to parse chunked\n  responses you have to pass parse_chunked => 1 for now. Usually you\n  probably just want to disable chunked encoding on the other end, see\n  the note about how to do that with nginx in the docs.\n\n0.14: # 2014-08-29T15:40:36+0900\n- Start support chunked transfer encoding.\n\n0.13: # 2014-04-27T20:00:43+0200\n- Switch to use non-blocknig fd to avoid a rare deadlock situation\n  when select() is successful and the following read() blocks forever\n  because there are really nothing to read.\n\n0.12: # 2014-01-31T18:20:00+0100\n- Instead of dying on e.g. \"Bad arg length for\n  Socket::pack_sockaddr_in, length is 0, should be 4\" when given a\n  host we can't resolve we'll now return a $res with the error value\n  set to Hijk::Error::CANNOT_RESOLVEif we can't gethostbyname() the\n  provided hostname. Makes it easier to handle DNS resolution\n  failures.\n\n0.11: # 2014-01-06T13:20:00+0100\n- Fixed broken HTTP header parsing for servers that didn't return the\n  entire header all at the same time, but in chunks.\n- We now return \"proto\" as well as \"status\" etc. in the response, so\n  you can see what the protocol the server was using to speak to\n  us. Also we pro-actively connections to servers that claim they're\n  speaking HTTP/1.0.\n- Document that what the socket_cache is keyed on, for anyone wanting\n  to implement a tied hash or whatever.\n- Fix a minor bug causing redundant work under \"socket_cache => undef\"\n\n0.10: # 2013-12-19T16:50:00+0100\n- We can now talk HTTP/1.0 an addition to HTTP/1.1, have a way to\n  disable the socket cache, and can specify connect and read timeouts\n  independently.\n- Fix a really nasty bug with mixings up requests after encountering a\n  timeout. See\n  http://lists.unbit.it/pipermail/uwsgi/2013-December/006802.html for\n  details.\n- Remove spurious requirenment on perl v5.14.2\n- First stab at https://github.com/gugod/Hijk/issues/3 we'll now\n  return an error key in the response with\n  Hijk::Error::{CONNECT_TIMEOUT,READ_TIMEOUT} instead of dying.\n- Nuked the Hijk::HTTP::XS support from the repo, we've decided it was\n  too complex for its own good.\n- Add support for an on_connect callback for seeing how long the\n  connect/reads take.\n\n0.09: # 2013-12-13T07:38:25+0100\n- KEEP CALM AND REMOVE FETCH OPTION\n- Hijk::request will use XS parser only if Hijk::HTTP::XS is loaded\n\n0.08: # 2013-12-12T20:10:00+0100\n- We only checked for undefined return codes from POSIX::read(), not\n  0, resulting in an infinite select/read loop when a server with\n  keep-alive enabled cut off our connection.\n\n0.07: # 2013-12-09T12:50:00+0100\n- Skip the live connect timeout test by default, it will fail making\n  live connections on various firewalled/locked down hosts.\n\n0.06: # 2013-12-09T12:20:00+0100\n- Declare missing test dependency on Test::Exception\n- Declare test dependency on Net::Ping 2.41\n- Various POD improvements describing more limitations in the API and\n  providing examples.\n- Don't unconditionally load the yet-to-be-released Hijk::HTTP::XS\n  module, instead provide a \"fetch\" option.\n- Shutdown and delete the cached connection in case of read error.\n- Handle syswrite() returning undef without spewing an uninitialized\n  comparison error\n- Various work on the test suite.\n\n0.05: # 2013-12-04T22:33:31+0100\n- Properly invalidate connection cache when seeing 'Connection: close' in the response.\n\n0.04: # 2013-12-04T00:06:16+0100\n- Implement 'connect timeout' and 'read timeout'\n\n0.02: # 2013-11-24T16:14:20+0100\n- Passthrug extra HTTP header with the 'head' request arg.\n\n0.01: # 2013-11-24T01:49:08+0100\n- Initial Release, with all wanted features are implemented.\n\n",
         "release" : "Hijk-0.28",
         "changes_file" : "Changes"
      }
   ]
}

```

In the event that a value from "release" parameter does not map to anything due to, say, being invalid or being something that's not yet indxed, it is silently ignored. The caller of this API should accomodate such property. (IOW, querying for 3 modules may recall only 1 result, or 0.)

The schema of request and response might be inconventional since it's an arbitrary choice of mine. and I'd like to hear some suggestions. Thank you.

