### PR TITLE
Start Mojolicious API application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ USER metacpan-api:users
 
 EXPOSE 5000
 
-CMD ["carton", "exec", "plackup", "-p", "5000", "-r"]
+CMD [ "carton", "exec", "morbo", "-l", "http://*:5000", "-w", "root", "./bin/api.pl"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ USER metacpan-api:users
 
 EXPOSE 5000
 
-CMD [ "carton", "exec", "morbo", "-l", "http://*:5000", "-w", "root", "./bin/api.pl"]
+CMD [ "./wait-for-it.sh", "db:5432", "carton", "exec", "morbo", "-l", "http://*:5000", "-w", "root", "./bin/api.pl"]


### PR DESCRIPTION
When the container is done being built, start the Mojolicious API application instead of starting the Catalyst application (which will start as part of the Mojolicious application). 

This container is using `morbo` in order to allow development of the API along side the running container.

The Mojolicious application waits for the database container to be started and for PostgreSQL to be accessible before starting, otherwise the API throws an error message that the database is inaccessible.