### PR TITLE
Log::Any via Log::Log4perl

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -87,6 +87,8 @@ requires 'LWP::UserAgent::Paranoid';
 requires 'List::AllUtils', '0.09';
 requires 'List::MoreUtils', '0.413';
 requires 'List::Util', '1.45';
+requires 'Log::Any::Adapter';
+requires 'Log::Any::Adapter::Log4perl';
 requires 'Log::Contextual';
 requires 'Log::Log4perl';
 requires 'Log::Log4perl::Appender::ScreenColoredLevels';

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -4061,6 +4061,19 @@ DISTRIBUTIONS
       constant 0
       strict 0
       warnings 0
+  Log-Any-Adapter-Log4perl-0.09
+    pathname: P/PR/PREACTION/Log-Any-Adapter-Log4perl-0.09.tar.gz
+    provides:
+      Log::Any::Adapter::Log4perl 0.09
+    requirements:
+      ExtUtils::MakeMaker 6.17
+      Log::Any::Adapter::Base 0
+      Log::Any::Adapter::Util 1.03
+      Log::Log4perl 1.32
+      base 0
+      perl 5.006
+      strict 0
+      warnings 0
   Log-Contextual-0.007001
     pathname: F/FR/FREW/Log-Contextual-0.007001.tar.gz
     provides:

--- a/lib/MetaCPAN/Model.pm
+++ b/lib/MetaCPAN/Model.pm
@@ -4,6 +4,9 @@ package MetaCPAN::Model;
 use Moose;
 
 use ElasticSearchX::Model;
+use Log::Any::Adapter;
+
+Log::Any::Adapter->set('Log4perl');
 
 analyzer lowercase => (
     tokenizer => 'keyword',


### PR DESCRIPTION
Log::Any is used by Search::Elasticsearch, so we should connect it to
our standard logger.