### PR TITLE
Take several (delayed) passes at setting the "latest" flag

### DIFF
--- a/lib/MetaCPAN/Script/Latest.pm
+++ b/lib/MetaCPAN/Script/Latest.pm
@@ -47,8 +47,11 @@ sub _queue_latest {
     my $dist = shift || $self->distribution;
 
     log_info { "queueing " . $dist };
-    $self->_add_to_queue( index_latest =>
-            [ ( $self->force ? '--force' : () ), '--distribution', $dist ] );
+    $self->_add_to_queue(
+        index_latest =>
+            [ ( $self->force ? '--force' : () ), '--distribution', $dist ],
+        { attempts => 3 }
+    );
 }
 
 sub run {

--- a/lib/MetaCPAN/Script/Queue.pm
+++ b/lib/MetaCPAN/Script/Queue.pm
@@ -32,12 +32,18 @@ sub run {
 
         my $next = $rule->iter( $self->dir );
         while ( defined( my $file = $next->() ) ) {
-            $self->_add_to_queue( index_release => [$file] );
+            $self->_add_to_queue(
+                index_release => [$file],
+                { attempts => 3 }
+            );
         }
     }
 
     if ( $self->_has_file ) {
-        $self->_add_to_queue( index_release => [ $self->file->stringify ] );
+        $self->_add_to_queue(
+            index_release => [ $self->file->stringify ],
+            { attempts => 3 }
+        );
     }
 }
 

--- a/lib/MetaCPAN/Script/Release.pm
+++ b/lib/MetaCPAN/Script/Release.pm
@@ -179,11 +179,25 @@ sub run {
             my $job_id = $self->_add_to_queue(
                 index_release => [$file] => { priority => 3 } );
 
+           # This is a hack to deal with the fact that we don't know exactly
+           # when 02packages gets updated.  It should be about every 5
+           # minutes.  We could stop trying once something is already
+           # "latest", but some uploads will never be "latest".  Trying this X
+           # times should be fairly cheap.  If this doesn't work, there is a
+           # cleanup cron which can set the "latest" flag, if necessary.
+
             if ( $self->latest ) {
-                $self->_add_to_queue(
-                    index_latest => [ '--distribution', $d->dist ] =>
-                        { priority => 2, parents => [$job_id] } );
+                for my $delay ( 150, 330, 600 ) {
+                    $self->_add_to_queue(
+                        index_latest => [ '--distribution', $d->dist ] => {
+                            delay    => $delay,
+                            parents  => [$job_id],
+                            priority => 2,
+                        }
+                    );
+                }
             }
+
         }
         else {
             try { $self->import_archive($file) }

--- a/lib/MetaCPAN/Script/Release.pm
+++ b/lib/MetaCPAN/Script/Release.pm
@@ -177,7 +177,9 @@ sub run {
 
         if ( $self->queue ) {
             my $job_id = $self->_add_to_queue(
-                index_release => [$file] => { priority => 3 } );
+                index_release => [$file],
+                { attempts => 3, priority => 3 }
+            );
 
            # This is a hack to deal with the fact that we don't know exactly
            # when 02packages gets updated.  It should be about every 5
@@ -190,6 +192,7 @@ sub run {
                 for my $delay ( 150, 330, 600 ) {
                     $self->_add_to_queue(
                         index_latest => [ '--distribution', $d->dist ] => {
+                            attempts => 3,
                             delay    => $delay,
                             parents  => [$job_id],
                             priority => 2,


### PR DESCRIPTION
The previous behaviour was to run this job immediately after the
indexing job finished, but this was proabably too early in almost all
cases.  Here we wait for a while and then try setting the flag.