### PR TITLE
Set th "size" of resultset to be the same as input size.

### DIFF
--- a/lib/MetaCPAN/Query/Release.pm
+++ b/lib/MetaCPAN/Query/Release.pm
@@ -363,6 +363,7 @@ sub by_author_and_names {
     # $releases: ArrayRef[ Dict[ author => Str, name => Str ] ]
 
     my $body = {
+        size  => (0+ @$releases),
         query => {
             bool => {
                 should => [


### PR DESCRIPTION
Otherwise Elasticsearch returns 10 hits by default.  Since this
'by_author_and_names' routine is the backend of '/feed/recent' and
responds up to 100 hits, this tweak can reduce the amount of roundtrip
bteewn frontend and backend.

I wish to utilize this together with https://github.com/metacpan/metacpan-web/pull/2157