### PR TITLE
Check if distribution exists before creating

### DIFF
--- a/lib/MetaCPAN/Script/Release.pm
+++ b/lib/MetaCPAN/Script/Release.pm
@@ -228,6 +228,7 @@ sub _get_release_model {
     my $d = CPAN::DistnameInfo->new($archive_path);
 
     my $model = MetaCPAN::Model::Release->new(
+        es       => $self->es,
         bulk     => $bulk,
         distinfo => $d,
         file     => $archive_path,


### PR DESCRIPTION
This is fixing the flood of errors exposed by the Log4Perl change.