### PR TITLE
Add rsync to container for index updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ WORKDIR /metacpan-api
 # modules is tested by the test suite. Removing the tests, reduces the overall
 # size of the images.
 RUN mkdir /CPAN \
+    && apt-get update \
+    && apt-get install -y rsync \
     && cpm install --global --without-test \
     && rm -fr /root/.cpanm /root/.perl-cpm /var/cache/apt/lists/* /tmp/*
 


### PR DESCRIPTION
Running `index-cpan.sh` requires that `rsync` is installed within the
container. It was previously removed from the `metacpan-base` image, and
as the api is the container that will make use of it (or a container
based on its image), adding it into the image.