### PR TITLE
Increase release limit for perl versions endpoint

### DIFF
--- a/lib/MetaCPAN/Query/Release.pm
+++ b/lib/MetaCPAN/Query/Release.pm
@@ -549,9 +549,10 @@ sub all_by_author {
 sub versions {
     my ( $self, $dist ) = @_;
 
+    my $size = $dist eq 'perl' ? 1000 : 250;
     my $body = {
         query  => { term => { distribution => $dist } },
-        size   => 250,
+        size   => $size,
         sort   => [ { date => 'desc' } ],
         fields => [
             qw( name date author version status maturity authorized download_url)


### PR DESCRIPTION
This hardcoded limit of 250 releases appears to be preventing https://www.cpan.org/src/README.html from displaying older versions of the perl distribution. It is using http://search.cpan.org/api/dist/perl which then queries https://fastapi.metacpan.org/v1/release/versions/perl, which is missing many older versions. This also affects `perlbrew available` which uses this page to display available releases. This is a shot in the dark so please verify this is the correct location to change.