### PR TITLE
Use ES_TEST in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
     # We use a non-standard port to avoid trashing production
     # but travis will have it running on the standard port.
     - ES=localhost:9200
+    - ES_TEST=localhost:9200
 
     # Instantiate Catalyst models using metacpan_server_testing.conf
     - METACPAN_SERVER_CONFIG_LOCAL_SUFFIX=testing

--- a/etc/metacpan_testing.pl
+++ b/etc/metacpan_testing.pl
@@ -1,5 +1,5 @@
 {
-    es => ($ENV{ES} || 'localhost:9900'),
+    es => ($ENV{ES_TEST} || 'localhost:9900'),
     port => '5900',
     die_on_error => 1,
     level => ($ENV{TEST_VERBOSE} ? 'info' : 'warn'),

--- a/t/lib/MetaCPAN/Server/Test.pm
+++ b/t/lib/MetaCPAN/Server/Test.pm
@@ -40,7 +40,7 @@ sub app {
 require MetaCPAN::Model;
 
 sub model {
-    MetaCPAN::Model->new( es => ( $ENV{ES} ||= 'localhost:9900' ) );
+    MetaCPAN::Model->new( es => ( $ENV{ES_TEST} ||= 'localhost:9200' ) );
 }
 
 1;

--- a/t/lib/MetaCPAN/TestServer.pm
+++ b/t/lib/MetaCPAN/TestServer.pm
@@ -79,11 +79,11 @@ sub _build_config {
 sub _build_es_home {
     my $self = shift;
 
-    my $es_home = $ENV{ES};
+    my $es_home = $ENV{ES_TEST};
 
     if ( !$es_home ) {
         my $es_home = $ENV{ES_HOME} or die <<'USAGE';
-Please set $ENV{ES} to a running instance of Elasticsearch, eg
+Please set ${ES_TEST} to a running instance of Elasticsearch, eg
 'localhost:9200' or set $ENV{ES_HOME} to the directory containing
 Elasticsearch
 USAGE
@@ -114,7 +114,7 @@ sub _build_es_server {
     diag 'Connecting to Elasticsearch on ' . $self->_es_home;
 
     try {
-        $ENV{ES} = $server->start->[0];
+        $ENV{ES_TEST} = $server->start->[0];
     }
     catch {
         diag(<<"EOF");


### PR DESCRIPTION
Since moving to the docker env we need to make sure tests don't
clobber data in the dev elasticsearch instance but use the
elasticsearch_test one.
