### PR TITLE
Do not refresh morbo app when log is updated

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
 PGDB=db:5432
-API_SERVER=morbo -l http://*:5000 -w . --verbose
+API_SERVER=morbo -l http://*:5000 -w app.psgi -w bin -w lib -w templates --verbose


### PR DESCRIPTION
We do not need to restart the webapp every time there
is a log entry in var/log/metacpan.log otherwise
we will end up always restarting in development.

This is similar to the fix applied to the docker repo
Upstream-URL:
https://github.com/metacpan/metacpan-docker/pull/51