### PR TITLE
escape reserved chars in search term

### DIFF
--- a/lib/MetaCPAN/Model/Search.pm
+++ b/lib/MetaCPAN/Model/Search.pm
@@ -79,7 +79,8 @@ sub search_web {
     $page_size //= 20;
     $from      //= 0;
 
-    $search_term =~ s{([ + - = > < ! & | ( ) { } \[ \] ^ " ~ * ? : \ / ])}{\\$1}x;
+    $search_term
+        =~ s{([ + - = > < ! & | ( ) { } \[ \] ^ " ~ * ? : \ / ])}{\\$1}x;
 
     # munge the search_term
     # these would be nicer if we had variable-length lookbehinds...

--- a/lib/MetaCPAN/Model/Search.pm
+++ b/lib/MetaCPAN/Model/Search.pm
@@ -79,6 +79,8 @@ sub search_web {
     $page_size //= 20;
     $from      //= 0;
 
+    $search_term =~ s{([ + - = > < ! & | ( ) { } \[ \] ^ " ~ * ? : \ / ])}{\\$1}x;
+
     # munge the search_term
     # these would be nicer if we had variable-length lookbehinds...
     # Allow q = 'author:LLAP' or 'module:Data::Page' or 'dist:'


### PR DESCRIPTION
fixes #952 - ES reserved chars in non-simple string search require escaping.

(needs tidy)