### PR TITLE
Fix author/dist/module searches

### DIFF
--- a/lib/MetaCPAN/Model/Search.pm
+++ b/lib/MetaCPAN/Model/Search.pm
@@ -80,13 +80,17 @@ sub search_web {
     $from      //= 0;
 
     $search_term
-        =~ s{([ + - = > < ! & | ( ) { } \[ \] ^ " ~ * ? : \ / ])}{\\$1}x;
+        =~ s{([ + - = > < ! & | ( ) { } \[ \] ^ " ~ * ? \ / ])}{\\$1}x;
 
     # munge the search_term
     # these would be nicer if we had variable-length lookbehinds...
     # Allow q = 'author:LLAP' or 'module:Data::Page' or 'dist:'
     # We are mapping to correct ES fields here - wonder if ANYONE
     # uses these?!?!?!
+    #
+    # The exceptions below are used specifically by the front end search.
+    # We've temporarily removed the ":" from the regex above so that the the
+    # author/dist/module searches work again.  The were broken in 225749b6e.
     $search_term    #
         =~ s{(^|\s)author:([a-zA-Z]+)(?=\s|$)}{$1author:\U$2\E}g;
     $search_term


### PR DESCRIPTION
This is a quick fix for now.  It might be helpful to have a larger discussion about how to treat colons, but this would restore the status quo while keeping the fix for slashes in searches in place.