### PR TITLE
add files_by_category end point

### DIFF
--- a/lib/MetaCPAN/Server.pm
+++ b/lib/MetaCPAN/Server.pm
@@ -131,7 +131,7 @@ sub app {
 # request body (not both, 'body' parameters take precedence).
 # the returned output is an arrayref containing the parameter values.
 sub read_param {
-    my ( $c, $key ) = @_;
+    my ( $c, $key, $optional ) = @_;
 
     my $body_data = $c->req->body_data;
     my $params
@@ -139,10 +139,10 @@ sub read_param {
         ? $body_data->{$key}
         : [ $c->req->param($key) ];
 
-    $params = [$params] unless is_arrayref($params);
+    $params = [ $params // () ] unless is_arrayref($params);
 
     $c->detach( '/bad_request', ["Missing param: $key"] )
-        unless $params and @{$params};
+        if !$optional && !@$params;
 
     return $params;
 }

--- a/lib/MetaCPAN/Server/Controller/Release.pm
+++ b/lib/MetaCPAN/Server/Controller/Release.pm
@@ -99,8 +99,16 @@ sub top_uploaders : Path('top_uploaders') : Args() {
 
 sub interesting_files : Path('interesting_files') : Args(2) {
     my ( $self, $c, $author, $release ) = @_;
-    $c->stash_or_detach(
-        $c->model('CPAN::File')->interesting_files( $author, $release ) );
+    my $categories = $c->read_param( 'category', 1 );
+    $c->stash_or_detach( $c->model('CPAN::File')
+            ->interesting_files( $author, $release, $categories ) );
+}
+
+sub files_by_category : Path('files_by_category') : Args(2) {
+    my ( $self, $c, $author, $release ) = @_;
+    my $categories = $c->read_param( 'category', 1 );
+    $c->stash_or_detach( $c->model('CPAN::File')
+            ->files_by_category( $author, $release, $categories ) );
 }
 
 __PACKAGE__->meta->make_immutable;


### PR DESCRIPTION
The existing interesting_files end point had a long list of files to
include, with inconsistent rules for what file extensions and
capitalization would be allowed.  It also would just give the files back
in a single list.  The code for finding change logs partly reproduced
this.

Unify the logic for the files we search for, with consistent rules for
file extensions, capitalization, and handling of special dists like
"perl".  Keep the different types of files categorized so that
interesting_files can both filter the files it is querying for, and
adding a new end point files_by_category to easily find the files of a
specific type, like was previously possible for change logs.  Install
files and contributing docs are now listed on the front end, so this
should make it easier for them to find the files.