### PR TITLE
Extract ElasticSearch Docker container build from CI config into script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,20 +45,7 @@ before_install:
   - git clone git://github.com/travis-perl/helpers ~/travis-perl-helpers
   - source ~/travis-perl-helpers/init
 
-  - sudo mkdir -p /etc/elasticsearch/scripts/ && sudo mkdir /tmp/es && sudo chmod 777 /tmp/es
-
-  - sudo curl -O -L https://github.com/metacpan/metacpan-puppet/raw/master/modules/metacpan_elasticsearch/files/etc/scripts/prefer_shorter_module_names_100.groovy > /tmp/es/prefer_shorter_module_names_100.groovy
-
-  - sudo curl -O -L https://github.com/metacpan/metacpan-puppet/raw/master/modules/metacpan_elasticsearch/files/etc/scripts/prefer_shorter_module_names_400.groovy > /tmp/es/prefer_shorter_module_names_400.groovy
-
-  - sudo curl -O -L https://github.com/metacpan/metacpan-puppet/raw/master/modules/metacpan_elasticsearch/files/etc/scripts/status_is_latest.groovy > /tmp/es/status_is_latest.groovy
-
-  - sudo curl -O -L https://github.com/metacpan/metacpan-puppet/raw/master/modules/metacpan_elasticsearch/files/etc/scripts/score_version_numified.groovy > /tmp/es/score_version_numified.groovy
-
-  - sudo curl -O -L https://raw.githubusercontent.com/metacpan/metacpan-docker/master/elasticsearch/metacpan.yml > /tmp/metacpan.yml
-
-  - docker pull elasticsearch:2.4-alpine
-  - docker run -d -p 127.0.0.1:9200:9200 -v /tmp/metacpan.yml:/usr/share/elasticsearch/config/metacpan.yml -v /tmp/es:/usr/share/elasticsearch/config/scripts elasticsearch:2.4-alpine
+  - bin/docker-elasticsearch /tmp/metacpan.yml /tmp/es 127.0.0.1:9200
 
   - cpanm -n Carton
   - cpanm -n App::cpm
@@ -71,7 +58,7 @@ install:
   - AUTHOR_TESTING=0 cpm install -L $PERL_CARTON_PATH --resolver $CPAN_RESOLVER --workers $(test-jobs) || (tail -n 500 -f ~/.perl-cpm/build.log; false)
 
 before_script:
-  - bin/wait-for-open http://localhost:9200/
+  - bin/wait-for-open http://$ES_TEST/
   - coverage-setup
 
 script:

--- a/bin/docker-elasticsearch
+++ b/bin/docker-elasticsearch
@@ -9,15 +9,15 @@ ES_PORT="$3"
 # sudo mkdir -p /etc/elasticsearch/scripts/ # believe unnecessary
 sudo mkdir "$ES_CONFIG_DIR" && sudo chmod 777 "$ES_CONFIG_DIR"
 
-sudo curl -O -L https://github.com/metacpan/metacpan-puppet/raw/master/modules/metacpan_elasticsearch/files/etc/scripts/prefer_shorter_module_names_100.groovy > "$ES_CONFIG_DIR"/prefer_shorter_module_names_100.groovy
+sudo curl -L https://github.com/metacpan/metacpan-puppet/raw/master/modules/metacpan_elasticsearch/files/etc/scripts/prefer_shorter_module_names_100.groovy > "$ES_CONFIG_DIR"/prefer_shorter_module_names_100.groovy
 
-sudo curl -O -L https://github.com/metacpan/metacpan-puppet/raw/master/modules/metacpan_elasticsearch/files/etc/scripts/prefer_shorter_module_names_400.groovy > "$ES_CONFIG_DIR"/prefer_shorter_module_names_400.groovy
+sudo curl -L https://github.com/metacpan/metacpan-puppet/raw/master/modules/metacpan_elasticsearch/files/etc/scripts/prefer_shorter_module_names_400.groovy > "$ES_CONFIG_DIR"/prefer_shorter_module_names_400.groovy
 
-sudo curl -O -L https://github.com/metacpan/metacpan-puppet/raw/master/modules/metacpan_elasticsearch/files/etc/scripts/status_is_latest.groovy > "$ES_CONFIG_DIR"/status_is_latest.groovy
+sudo curl -L https://github.com/metacpan/metacpan-puppet/raw/master/modules/metacpan_elasticsearch/files/etc/scripts/status_is_latest.groovy > "$ES_CONFIG_DIR"/status_is_latest.groovy
 
-sudo curl -O -L https://github.com/metacpan/metacpan-puppet/raw/master/modules/metacpan_elasticsearch/files/etc/scripts/score_version_numified.groovy > "$ES_CONFIG_DIR"/score_version_numified.groovy
+sudo curl -L https://github.com/metacpan/metacpan-puppet/raw/master/modules/metacpan_elasticsearch/files/etc/scripts/score_version_numified.groovy > "$ES_CONFIG_DIR"/score_version_numified.groovy
 
-sudo curl -O -L https://raw.githubusercontent.com/metacpan/metacpan-docker/master/elasticsearch/metacpan.yml > "$ES_CONFIG_FILE"
+sudo curl -L https://raw.githubusercontent.com/metacpan/metacpan-docker/master/elasticsearch/metacpan.yml > "$ES_CONFIG_FILE"
 
 docker pull elasticsearch:2.4-alpine
 docker run -d -p "$ES_PORT":9200 -v "$ES_CONFIG_FILE":/usr/share/elasticsearch/config/metacpan.yml -v "$ES_CONFIG_DIR":/usr/share/elasticsearch/config/scripts elasticsearch:2.4-alpine

--- a/bin/docker-elasticsearch
+++ b/bin/docker-elasticsearch
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# bin/docker-elasticsearch /tmp/metacpan.yml /tmp/es 127.0.0.1:9200
+
+ES_CONFIG_FILE="$1"
+ES_CONFIG_DIR="$2"
+ES_PORT="$3"
+
+# sudo mkdir -p /etc/elasticsearch/scripts/ # believe unnecessary
+sudo mkdir "$ES_CONFIG_DIR" && sudo chmod 777 "$ES_CONFIG_DIR"
+
+sudo curl -O -L https://github.com/metacpan/metacpan-puppet/raw/master/modules/metacpan_elasticsearch/files/etc/scripts/prefer_shorter_module_names_100.groovy > "$ES_CONFIG_DIR"/prefer_shorter_module_names_100.groovy
+
+sudo curl -O -L https://github.com/metacpan/metacpan-puppet/raw/master/modules/metacpan_elasticsearch/files/etc/scripts/prefer_shorter_module_names_400.groovy > "$ES_CONFIG_DIR"/prefer_shorter_module_names_400.groovy
+
+sudo curl -O -L https://github.com/metacpan/metacpan-puppet/raw/master/modules/metacpan_elasticsearch/files/etc/scripts/status_is_latest.groovy > "$ES_CONFIG_DIR"/status_is_latest.groovy
+
+sudo curl -O -L https://github.com/metacpan/metacpan-puppet/raw/master/modules/metacpan_elasticsearch/files/etc/scripts/score_version_numified.groovy > "$ES_CONFIG_DIR"/score_version_numified.groovy
+
+sudo curl -O -L https://raw.githubusercontent.com/metacpan/metacpan-docker/master/elasticsearch/metacpan.yml > "$ES_CONFIG_FILE"
+
+docker pull elasticsearch:2.4-alpine
+docker run -d -p "$ES_PORT":9200 -v "$ES_CONFIG_FILE":/usr/share/elasticsearch/config/metacpan.yml -v "$ES_CONFIG_DIR":/usr/share/elasticsearch/config/scripts elasticsearch:2.4-alpine

--- a/bin/docker-elasticsearch
+++ b/bin/docker-elasticsearch
@@ -6,7 +6,6 @@ ES_CONFIG_FILE="$1"
 ES_CONFIG_DIR="$2"
 ES_PORT="$3"
 
-# sudo mkdir -p /etc/elasticsearch/scripts/ # believe unnecessary
 sudo mkdir "$ES_CONFIG_DIR" && sudo chmod 777 "$ES_CONFIG_DIR"
 
 sudo curl -L https://github.com/metacpan/metacpan-puppet/raw/master/modules/metacpan_elasticsearch/files/etc/scripts/prefer_shorter_module_names_100.groovy > "$ES_CONFIG_DIR"/prefer_shorter_module_names_100.groovy

--- a/t/00_setup.t
+++ b/t/00_setup.t
@@ -30,7 +30,7 @@ BEGIN {
 
 # Ensure we're starting fresh
 my $tmp_dir = tmp_dir();
-$tmp_dir->remove_tree;
+$tmp_dir->remove_tree( { safe => 0 } );
 $tmp_dir->mkpath;
 
 ok( $tmp_dir->stat, "$tmp_dir exists for testing" );


### PR DESCRIPTION
Extracting this script from `.travis.yml` has allowed me to get a locally-running Docker container with ES, that together with setting environment variables from there, to run the tests successfully:

```sh
bin/docker-elasticsearch /tmp/metacpan.yml /tmp/es 127.0.0.1:9200
ES=localhost:9200 ES_TEST=localhost:9200 METACPAN_SERVER_CONFIG_LOCAL_SUFFIX=testing prove -lr t
```

Notes: I've removed what looks like an unnecessary `mkdir`, and taken `-O` off `curl`. Also, `t/00_setup.t` was doing `remove_tree` to ensure clean start, but in the default safe mode, that fails, so I've made it not be "safe".