### PR TITLE
Search fix

### DIFF
--- a/git/hooks/pre-commit
+++ b/git/hooks/pre-commit
@@ -2,8 +2,12 @@
 
 use strict;
 use warnings;
+use Config;
 # Hack to use carton's local::lib.
 use lib 'local/lib/perl5';
+$ENV{PATH} .= $Config{path_sep}.'local/bin';
+$ENV{PERL5LIB} = join $Config{path_sep},
+  grep defined, $ENV{PERL5LIB}, 'local/lib/perl5';
 
 use Code::TidyAll::Git::Precommit;
 Code::TidyAll::Git::Precommit->check( no_stash => 1 );

--- a/lib/MetaCPAN/Model/Search.pm
+++ b/lib/MetaCPAN/Model/Search.pm
@@ -79,18 +79,15 @@ sub search_web {
     $page_size //= 20;
     $from      //= 0;
 
-    $search_term
-        =~ s{([ + - = > < ! & | ( ) { } \[ \] ^ " ~ * ? \ / ])}{\\$1}x;
+    $search_term =~ s{([+=><!&|\(\)\{\}[\]\^"~*?\\/])}{\\$1}g;
 
     # munge the search_term
     # these would be nicer if we had variable-length lookbehinds...
     # Allow q = 'author:LLAP' or 'module:Data::Page' or 'dist:'
-    # We are mapping to correct ES fields here - wonder if ANYONE
-    # uses these?!?!?!
+    # We are mapping to correct ES fields here - relied on by metacpan-web
+    # tests.
     #
     # The exceptions below are used specifically by the front end search.
-    # We've temporarily removed the ":" from the regex above so that the the
-    # author/dist/module searches work again.  The were broken in 225749b6e.
     $search_term    #
         =~ s{(^|\s)author:([a-zA-Z]+)(?=\s|$)}{$1author:\U$2\E}g;
     $search_term

--- a/t/api/controller/admin.t
+++ b/t/api/controller/admin.t
@@ -2,7 +2,6 @@ use strict;
 use warnings;
 use lib 't/lib';
 
-use Test::Fatal qw( exception );
 use Test::Mojo;
 use Test::More;
 

--- a/t/model/search.t
+++ b/t/model/search.t
@@ -60,6 +60,17 @@ ok( $search->_not_rogue, '_not_rogue' );
 }
 
 {
+    my $results = $search->search_web('author:Mo BadPod');
+    isnt( @{ $results->{results} },
+        0, '>0 results on author search with extra' );
+}
+
+{
+    eval { $search->search_web('usr/bin/env') };
+    is( $@, '', 'search term with a / no exception' );
+}
+
+{
     my $long_form  = $search->search_web('distribution:Pod-Pm');
     my $short_form = $search->search_web('dist:Pod-Pm');
 


### PR DESCRIPTION
The previous fix (https://github.com/metacpan/metacpan-api/commit/225749b6e54a29ee7a34b835d01f0918e7448b7f) had two issues:
- it matched spaces, so it quoted them - I was unable to make it not do this, so I removed all the whitespace and the `x` flag
- it only quoted the first character it found, not all

This is hopefully a fix, and hopefully will also fix the -web tests.