### PR TITLE
GH#927 Add plain mode + version filter to release/versions endpoint

### DIFF
--- a/lib/MetaCPAN/Query/Release.pm
+++ b/lib/MetaCPAN/Query/Release.pm
@@ -560,11 +560,28 @@ sub all_by_author {
 }
 
 sub versions {
-    my ( $self, $dist ) = @_;
+    my ( $self, $dist, $versions ) = @_;
 
     my $size = $dist eq 'perl' ? 1000 : 250;
+
+    my $query;
+
+    if ( @{$versions} ) {
+        $query = {
+            bool => {
+                must => [
+                    { term  => { distribution => $dist } },
+                    { terms => { version      => $versions } },
+                ]
+            }
+        };
+    }
+    else {
+        $query = { term => { distribution => $dist } };
+    }
+
     my $body = {
-        query  => { term => { distribution => $dist } },
+        query  => $query,
         size   => $size,
         sort   => [ { date => 'desc' } ],
         fields => [


### PR DESCRIPTION
This PR is addressing #927 

---

This commit adds support for two new parameters to the release/versions endpoint.

Examples:

https://fastapi.metacpan.org/v1/release/versions/perl?plain=1
https://fastapi.metacpan.org/v1/release/versions/perl?versions=5.26.0,5.30.1
https://fastapi.metacpan.org/v1/release/versions/perl?plain=1&versions=5.26.0,5.30.1