### PR TITLE
Fix reverse_dependency query

### DIFF
--- a/lib/MetaCPAN/Query/Release.pm
+++ b/lib/MetaCPAN/Query/Release.pm
@@ -815,7 +815,18 @@ sub _get_depended_releases {
     my $filter_modules = {
         bool => {
             should => [
-                map +{ term => { 'dependency.module' => $_ } },
+                map +{
+                    bool => {
+                        must => [
+                            { term => { 'dependency.module' => $_ } },
+                            {
+                                term => {
+                                    'dependency.relationship' => 'requires'
+                                }
+                            }
+                        ],
+                    },
+                },
                 @{$modules}
             ]
         }


### PR DESCRIPTION
Added stricter check for type of relationship.

This should (hopefully) address the issue in #957 