### PR TITLE
Add a negative boost to Deprecated modules, when searching MetaCPAN.

### DIFF
--- a/lib/MetaCPAN/Model/Search.pm
+++ b/lib/MetaCPAN/Model/Search.pm
@@ -222,8 +222,14 @@ sub build_query {
     $params //= {};
     ( my $clean = $search_term ) =~ s/::/ /g;
 
-    my $negative
-        = { term => { 'mime' => { value => 'text/x-script.perl' } } };
+    my $negative = {
+        bool => {
+            should => [
+                { term => { 'mime' => { value => 'text/x-script.perl' } } },
+                { term => { 'deprecated' => { value => 1, boost => -100 } } },
+            ],
+        },
+    };
 
     my $positive = {
         bool => {


### PR DESCRIPTION
Matches modules that are marked as `deprecated: true` in ElasticSearch, and gives them a negative boost in the search results.

Relates to metacpan/metacpan-web#1435