### PR TITLE
No longer need this boolean re-cast; ES indexes return proper bools now.

### DIFF
--- a/lib/MetaCPAN/Document/File/Set.pm
+++ b/lib/MetaCPAN/Document/File/Set.pm
@@ -628,12 +628,6 @@ sub autocomplete_suggester {
         ( $_->{fields}{documentation}[0] => \%record );
     } @{ $data->{hits}{hits} };
 
-    # normalize 'deprecated' field values to boolean (1/0) values (because ES)
-    for my $v ( values %valid ) {
-        $v->{deprecated} = 1 if $v->{deprecated} eq 'true';
-        $v->{deprecated} = 0 if $v->{deprecated} eq 'false';
-    }
-
     # remove any exact match, it will be added later
     my $exact = delete $valid{$query};
 


### PR DESCRIPTION
As per discussion in metacpan/metacpan-web#2438, the ElasticSearch indices that back the MetaCPAN API have been updated to now consistently return Boolean values for the `deprecated` field.

Thus, no longer need this check for string `"true"` or `"false"` values, which would then be cast accordingly to a proper boolean.

**Unfortunately**, this is one of those things that I am unable to test from here (as the ElasticSearch indices spun up locally by `metacpan-docker` have only ever returned proper booleans and not boolean strings).

Thus, I **highly encourage** someone w/access to the underlying Production ElasticSearch indices to test this out themselves prior to merging.

The function impacted here is the "search autocomplete", and the `deprecated` attribute is used to help sort the results such that deprecated modules end up farther down the list.  One example I have used for manual testing is to search for `Alien`, and to ensure that `Alien::IE7` is down close to the bottom of the list (as it has been marked as Deprecated, as have my other `Alien::*` modules on MetaCPAN).  This **is** what I see currently on MetaCPAN (that `Alien::IE7` is close to if not at the bottom of that auto-complete list), and I would expect that if _this_ patch works successfully that it should continue to stay close to the bottom of the list.