### PR TITLE
File queries shared by path and prefix for category example

### DIFF
--- a/lib/MetaCPAN/Query/File.pm
+++ b/lib/MetaCPAN/Query/File.pm
@@ -142,27 +142,26 @@ my %perl_files = (
     ],
 );
 
+my @shared_path_prefix_examples = qw(
+    example
+    examples
+    Example
+    Examples
+    sample
+    samples
+);
+
 my %path_files = (
     example => [
         qw(
             eg
             ex
-        )
+        ),
+        @shared_path_prefix_examples,
     ],
 );
 
-my %prefix_files = (
-    example => [
-        qw(
-            example
-            examples
-            Example
-            Examples
-            sample
-            samples
-        )
-    ],
-);
+my %prefix_files = ( example => [ @shared_path_prefix_examples, ], );
 
 my %file_to_type;
 my %type_to_regex;

--- a/lib/MetaCPAN/Query/File.pm
+++ b/lib/MetaCPAN/Query/File.pm
@@ -149,6 +149,8 @@ my @shared_path_prefix_examples = qw(
     Examples
     sample
     samples
+    demo
+    demos
 );
 
 my %path_files = (


### PR DESCRIPTION
Otherwise directories that are used by releases such as:

  - <https://metacpan.org/source/SRI/Mojolicious-9.18/examples>
  - <https://metacpan.org/source/ETJ/PDL-2.048/Example>

will not have their examples listed on their release page.

Fixes <https://github.com/metacpan/metacpan-web/issues/2427>.

---

Also:

Add demo/demos as category example

For example, found in the release:

  - <https://metacpan.org/source/DCONWAY/Regexp-Grammars-1.057/demo>
