### PR TITLE
ElasticSearch Availabilty Check and Mapping Self-Check

### DIFF
--- a/lib/MetaCPAN/Role/Script.pm
+++ b/lib/MetaCPAN/Role/Script.pm
@@ -6,7 +6,7 @@ use ElasticSearchX::Model::Document::Types qw(:all);
 use Git::Helpers qw( checkout_root );
 use Log::Contextual qw( :log :dlog );
 use MetaCPAN::Model ();
-use MetaCPAN::Types::TypeTiny qw( Bool Int Path Str );
+use MetaCPAN::Types::TypeTiny qw( Bool HashRef Int Path Str );
 use Mojo::Server ();
 use Term::ANSIColor qw( colored );
 use IO::Interactive qw( is_interactive );
@@ -33,6 +33,22 @@ has die_on_error => (
     isa           => Bool,
     default       => 0,
     documentation => 'Die on errors instead of simply logging',
+);
+
+has exit_code => (
+    isa           => Int,
+    is            => 'rw',
+    default       => 0,
+    documentation => 'Exit Code to be returned on termination',
+);
+
+has arg_await_timeout => (
+    init_arg      => 'await',
+    is            => 'ro',
+    isa           => Int,
+    default       => 15,
+    documentation =>
+        'seconds before connection is considered failed with timeout',
 );
 
 has ua => (
@@ -69,6 +85,27 @@ has index => (
     default       => 'cpan',
     documentation =>
         'Index to use, defaults to "cpan" (when used: also export ES_SCRIPT_INDEX)',
+);
+
+has cluster_info => (
+    isa     => HashRef,
+    traits  => ['Hash'],
+    is      => 'rw',
+    default => sub { {} },
+);
+
+has indices_info => (
+    isa     => HashRef,
+    traits  => ['Hash'],
+    is      => 'rw',
+    default => sub { {} },
+);
+
+has aliases_info => (
+    isa     => HashRef,
+    traits  => ['Hash'],
+    is      => 'rw',
+    default => sub { {} },
 );
 
 has port => (
@@ -123,13 +160,27 @@ sub BUILDARGS {
 }
 
 sub handle_error {
-    my ( $self, $error ) = @_;
+    my ( $self, $error, $die_always ) = @_;
+
+    # Die if configured (for the test suite).
+    $die_always = $self->die_on_error unless defined $die_always;
 
     # Always log.
     log_fatal {$error};
 
-    # Die if configured (for the test suite).
-    Carp::croak $error if $self->die_on_error;
+    $! = $self->exit_code if ( $self->exit_code != 0 );
+
+    Carp::croak $error if $die_always;
+}
+
+sub print_error {
+    my ( $self, $error ) = @_;
+
+    # Always log.
+    log_error {$error};
+
+    # Display Error in red
+    print colored( ['bold red'], "*** ERROR ***: $error" ), "\n";
 }
 
 sub index {
@@ -195,6 +246,114 @@ before run => sub {
     #Dlog_debug {"Connected to $_"} $self->remote;
 };
 
+sub check_health {
+    my ( $self, $irefresh ) = @_;
+    my $ihealth = 0;
+
+    $irefresh = 0 unless ( defined $irefresh );
+
+    $ihealth = $self->await;
+
+    if ($ihealth) {
+        if ( $irefresh || scalar( keys %{ $self->indices_info } ) == 0 ) {
+            my $sinfo_rs
+                = $self->es->cat->indices( h => [ 'index', 'health' ] );
+
+            $self->indices_info( {} );
+
+            while ( $sinfo_rs =~ /^([^[:space:]]+) +([^[:space:]]+)/gm ) {
+                $self->indices_info->{$1}
+                    = { 'index_name' => $1, 'health' => $2 };
+
+                $ihealth = 0 if ( $2 eq 'red' );
+            }
+        }
+        else {
+            foreach ( keys %{ $self->indices_info } ) {
+                $ihealth = 0
+                    if ( $self->indices_info->{$_}->{'health'} eq 'red' );
+            }
+        }
+    }
+
+    if ($ihealth) {
+        if ( $irefresh || scalar( keys %{ $self->aliases_info } ) == 0 ) {
+            my $sinfo_rs
+                = $self->es->cat->aliases( h => [ 'alias', 'index' ] );
+
+            $self->aliases_info( {} );
+
+            while ( $sinfo_rs =~ /^([^[:space:]]+) +([^[:space:]]+)/gm ) {
+                $self->aliases_info->{$1}
+                    = { 'alias_name' => $1, 'index' => $2 };
+            }
+        }
+
+        $ihealth = 0 if ( scalar( keys %{ $self->aliases_info } ) == 0 );
+    }
+
+    return $ihealth;
+}
+
+sub await {
+    my $self   = $_[0];
+    my $iready = 0;
+
+    if ( scalar( keys %{ $self->cluster_info } ) == 0 ) {
+        my $es       = $self->es;
+        my $iseconds = 0;
+
+        log_info {"Awaiting Elasticsearch ..."};
+
+        do {
+            eval {
+                $iready = $es->ping;
+
+                if ($iready) {
+                    log_info {
+                        "Awaiting $iseconds / "
+                            . $self->arg_await_timeout
+                            . " : ready"
+                    };
+
+                    $self->cluster_info( \%{ $es->info } );
+                }
+            };
+
+            if ($@) {
+                if ( $iseconds < $self->arg_await_timeout ) {
+                    log_info {
+                        "Awaiting $iseconds / "
+                            . $self->arg_await_timeout
+                            . " : unavailable - sleeping ..."
+                    };
+
+                    sleep(1);
+
+                    $iseconds++;
+                }
+                else {
+                    log_error {
+                        "Awaiting $iseconds / "
+                            . $self->arg_await_timeout
+                            . " : unavailable - timeout!"
+                    };
+
+                    #Set System Error: 112 - EHOSTDOWN - Host is down
+                    $self->exit_code(112);
+                    $self->handle_error( $@, 1 );
+                }
+            }
+        } while ( !$iready && $iseconds <= $self->arg_await_timeout );
+    }
+    else {
+        #ElasticSearch Service is available
+        $iready = 1;
+    }
+
+    return $iready;
+}
+
 sub are_you_sure {
     my ( $self, $msg ) = @_;
 
@@ -216,8 +375,82 @@ __END__
 
 =pod
 
+=head1 NAME
+
+MetaCPAN::Role::Script - Base Role which is used by many command line applications
+
 =head1 SYNOPSIS
 
 Roles which should be available to all modules.
+
+=head1 OPTIONS
+
+This Role makes the command line application accept the following options
+
+=over 4
+
+=item Option C<--await 15>
+
+This option will set the I<ElasticSearch Availability Check Timeout>.
+After C<await> seconds the Application will fail with an Exception and the Exit Code [112]
+(C<112 - EHOSTDOWN - Host is down>) will be returned
+
+    bin/metacpan <script_name> --await 15
+
+See L<Method C<await()>>
+
+=back
+
+=head1 METHODS
+
+This Role provides the following methods
+
+=over 4
+
+=item C<await()>
+
+This method uses the
+L<C<Search::Elasticsearch::Client::2_0::Direct::ping()>|https://metacpan.org/pod/Search::Elasticsearch::Client::2_0::Direct#ping()>
+method to verify the service availabilty and wait for C<arg_await_timeout> seconds.
+When the service does not become available within C<arg_await_timeout> seconds it re-throws the
+Exception from the C<Search::Elasticsearch::Client> and sets C< $! > to C< 112 >.
+The C<Search::Elasticsearch::Client> generates a C<"Search::Elasticsearch::Error::NoNodes"> Exception.
+When the service is available it will populate the C<cluster_info> C<HASH> structure with the basic information
+about the cluster.
+See L<Option C<--await 15>>
+See L<Method C<check_health()>>
+
+=item C<check_health( [ refresh ] )>
+
+This method uses the
+L<C<Search::Elasticsearch::Client::2_0::Direct::cat()>|https://metacpan.org/pod/Search::Elasticsearch::Client::2_0::Direct#cat()>
+method to collect basic data about the cluster structure as the general information,
+the health state of the indices and the created aliases.
+This information is stored in C<cluster_info>, C<indices_info> and C<aliases_info> as C<HASH> structures.
+If the parameter C<refresh> is set to C< 1 > the structures C<indices_info> and C<aliases_info> will always
+be updated.
+If the C<cluster_info> structure is empty it calls first the C<await()> method.
+If the service is unavailable the C<await()> method will produce an exception and the structures will be empty
+The method returns C< 1 > when the C<cluster_info> is populated, none of the indices in C<indices_info> has
+the Health State I<red> and at least one alias is created in C<aliases_info>
+otherwise the method returns C< 0 >
+
+=item C<are_you_sure()>
+
+Requests the user to confirm the operation with "I< YES >"
+
+=item C<handle_error( error_message[, die_always ] )>
+
+Logs the string C<error_message> with the log function as fatal error.
+If C<exit_code> is not equel C< 0 > sets its value in C< $! >.
+If the option C<--die_on_error> is enabled it throws an Exception with C<error_message>.
+If the parameter C<die_always> is set it overrides the option C<--die_on_error>.
+
+=item C<print_error( error_message )>
+
+Logs the string C<error_message> with the log function and displays it in red.
+But it does not end the application.
+
+=back
 
 =cut


### PR DESCRIPTION
For the issue detected and documented at
[MetaCPAN API - Indexing failed](https://github.com/metacpan/metacpan-docker/issues/47)
there are several features needed in the `MetaCPAN::Script::Runner` scripts
Seen in this Test Report
[Dependency on _MetaCPAN API_](https://github.com/bodo-hugo-barwich/metacpan-docker/runs/4060036486?check_suite_focus=true#step:5:10)
[_GitHub_ Testing Workflow](https://github.com/bodo-hugo-barwich/metacpan-docker/pull/2)
the successful test depends on a development in _MetaCPAN API_.

This change implements several features:
* in `MetaCPAN::Role::Script`:
  * `exit_code`
  * `cluster_info`
  * `indices_info`
  * `aliases_info`
  * `arg_await_timeout` (triggered with `--await`)
  * `await()` Method
  * `check_health()` Method

The Developer Documentation is also a bit more extended:
```plain
$ perldoc lib/MetaCPAN/Role/Script.pm |more
NAME
    MetaCPAN::Role::Script - Base Role which is used by many command line
    applications

SYNOPSIS
    Roles which should be available to all modules.

OPTIONS
    This Role makes the command line application accept the following
    options

    Option "--await 15"
        This option will set the *ElasticSearch Availability Check Timeout*.
        After "await" seconds the Application will fail with an Exception
        and the Exit Code [112] ("112 - EHOSTDOWN - Host is down") will be
        returned

            bin/metacpan <script_name> --await 15

        See "Method "await()""

METHODS
    This Role provides the following methods

    "await()"
        This method uses the
        "Search::Elasticsearch::Client::2_0::Direct::ping()"
        <https://metacpan.org/pod/Search::Elasticsearch::Client::2_0::Direct
        #ping()> method to verify the service availabilty and wait for
        "arg_await_timeout" seconds. When the service does not become
        available within "arg_await_timeout" seconds it re-throws the
        Exception from the "Search::Elasticsearch::Client" and sets $! to
        112 . The "Search::Elasticsearch::Client" generates a
        "Search::Elasticsearch::Error::NoNodes" Exception. When the service
        is available it will populate the "cluster_info" "HASH" structure
        with the basic information about the cluster. See "Option "--await
        15"" See "Method "check_health()""

    "check_health( [ refresh ] )"
        This method uses the
        "Search::Elasticsearch::Client::2_0::Direct::cat()"
        <https://metacpan.org/pod/Search::Elasticsearch::Client::2_0::Direct
        #cat()> method to collect basic data about the cluster structure as
        the general information, the health state of the indices and the
        created aliases. This information is stored in "cluster_info",
        "indices_info" and "aliases_info" as "HASH" structures. If the
        parameter "refresh" is set to 1 the structures "indices_info" and
        "aliases_info" will always be updated. If the "cluster_info"
        structure is empty it calls first the "await()" method. If the
        service is unavailable the "await()" method will produce an
        exception and the structures will be empty The method returns 1 when
        the "cluster_info" is populated, none of the indices in
        "indices_info" has the Health State *red* and at least one alias is
        created in "aliases_info" otherwise the method returns 0

    "are_you_sure()"
        Requests the user to confirm the operation with "* YES *"

    "handle_error( error_message[, die_always ] )"
        Logs the string "error_message" with the log function as fatal
        error. If "exit_code" is not equel 0 sets its value in $! . If the
        option "--die_on_error" is enabled it throws an Exception with
        "error_message". If the parameter "die_always" is set it overrides
        the option "--die_on_error".

    "print_error( error_message )"
        Logs the string "error_message" with the log function and displays
        it in red. But it does not end the application.
```

* in `MetaCPAN::Script::Mapping` it implements:
  * `arg_cluster_info` (triggered with option `--show_cluster_info`)
  * `verify_mapping()` Method 
which depends on data from `deploy_mapping()` and compares it with information gathered in `indices_info` and `aliases_info` populated through the method `check_health()`
  * `show_info()`
which prints the information gathered by `check_health()` as JSON on the command line.
```plain
$ perldoc lib/MetaCPAN/Script/Mapping.pm|more |grep -iE "(show|\-\-all)"
     # bin/metacpan mapping --show_cluster_info   # show basic info about the cluster, indices and aliases
```  
```plain
$ perldoc src/metacpan-api/lib/MetaCPAN/Script/Mapping.pm |more
NAME
    MetaCPAN::Script::Mapping - Script to set the index and mapping the
    types

SYNOPSIS
     # bin/metacpan mapping --show_cluster_info   # show basic info about the cluster, indices and a
liases
     # bin/metacpan mapping --delete
     # bin/metacpan mapping --list_types
     # bin/metacpan mapping --delete_index xxx
     # bin/metacpan mapping --create_index xxx --reindex
     # bin/metacpan mapping --create_index xxx --reindex --patch_mapping '{"distribution":{"dynamic"
:"false","properties":{"name":{"index":"not_analyzed","ignore_above":2048,"type":"string"},"river":{
"properties":{"total":{"type":"integer"},"immediate":{"type":"integer"},"bucket":{"type":"integer"}}
,"dynamic":"true"},"bugs":{"properties":{"rt":{"dynamic":"true","properties":{"rejected":{"type":"in
teger"},"closed":{"type":"integer"},"open":{"type":"integer"},"active":{"type":"integer"},"patched":
{"type":"integer"},"source":{"type":"string","ignore_above":2048,"index":"not_analyzed"},"resolved":
{"type":"integer"},"stalled":{"type":"integer"},"new":{"type":"integer"}}},"github":{"dynamic":"true
","properties":{"active":{"type":"integer"},"open":{"type":"integer"},"closed":{"type":"integer"},"s
ource":{"type":"string","index":"not_analyzed","ignore_above":2048}}}},"dynamic":"true"}}}}'
     # bin/metacpan mapping --create_index xxx --patch_mapping '{...mapping...}' --skip_existing_map
ping
     # bin/metacpan mapping --update_index xxx --patch_mapping '{...mapping...}'
     # bin/metacpan mapping --copy_to_index xxx --copy_type release
     # bin/metacpan mapping --copy_to_index xxx --copy_type release --copy_query '{"range":{"date":{
"gte":"2016-01","lt":"2017-01"}}}'
     # bin/metacpan mapping --delete_from_type xxx   # empty the type

DESCRIPTION
    This is the index mapping handling script. Used rarely, but carries the
    most important task of setting the index and mapping the types.

OPTIONS
    This Script accepts the following options

    Option "--show_cluster_info"
        This option makes the Script show basic information about the
        *ElasticSearch* Cluster and its indices and aliases. This
        information has to be collected with the
        "MetaCPAN::Role::Script::check_health()" Method. On Script start-up
        it is empty.

            bin/metacpan mapping --show_cluster_info

        See "Method "MetaCPAN::Role::Script::check_health()""

    Option "--delete"
        This option makes the Script delete all indices configured in the
        project and re-create them emtpy. It verifies the index integrity of
        the indices and aliases calling the methods
        "MetaCPAN::Role::Script::check_health()" and "verify_mapping()". If
        the "verify_mapping()" Method fails it exits the Script with Exit
        Code 1 .

            bin/metacpan mapping --delete

        See "Method "deploy_mapping()""

        See "Method "verify_mapping()""

        See "Method "MetaCPAN::Role::Script::check_health()""

METHODS
    This Package provides the following methods

    "deploy_mapping()"
        Deletes and re-creates the indices and aliases defined in the
        Project. The user will be requested for manual confirmation on the
        command line before the elemination. The integrity of the indices
        and aliases will be checked with the "verify_mapping()" Method. On
        successful creation it returns 1 , otherwise it returns 0 .

        Returns: It returns 1 when the indices and aliases are created and
        verified as correct. Otherwise it returns 0 .

        Exceptions: It can throw exceptions when the connection to
        *ElasticSearch* fails or there is any issue in any *ElasticSearch*
        Request run by the Script.

        See "Option "--delete""

        See "Method "verify_mapping()""

        See "Method "MetaCPAN::Role::Script::check_health()""

    "verify_mapping( \%indices, \%aliases )"
        Checks the defined indices and aliases against the actually in the
        *ElasticSearch* Cluster existing indices and aliases which must have
        been requested with the "MetaCPAN::Role::Script::check_health()"
        Method.

        Parameters:

        "\%indices" - Reference to a hash that defines the indices required
        for the Project.

        "\%aliases" - Reference to a hash that defines the aliases required
        for the Project.

        Returns: It returns 1 when the indices and aliases are created and
        verified as correct. Otherwise it returns 0 .

        Exceptions: It can throw exceptions when the connection to
        *ElasticSearch* fails or there is any issue in any *ElasticSearch*
        Request run by the Script.

        See "Option "--delete""

        See "Method "verify_mapping()""

        See "Method "MetaCPAN::Role::Script::check_health()""
```