### PR TITLE
Capture Exit Code in MetaCPAN::Script::Runner

### DIFF
--- a/bin/metacpan
+++ b/bin/metacpan
@@ -6,7 +6,7 @@
 
     bin/metacpan release /path/to/cpan/authors/id/
     bin/metacpan release /path/to/cpan/authors/id/{A,B}
-    bin/metacpan release /path/to/cpan/authors/id/D/DO/DOY/Try-Tiny-0.09.tar.gz  
+    bin/metacpan release /path/to/cpan/authors/id/D/DO/DOY/Try-Tiny-0.09.tar.gz
     bin/metacpan latest
     bin/metacpan server --cpan /path/to/cpan/
 
@@ -19,3 +19,5 @@ use lib "$FindBin::RealBin/../lib";
 use MetaCPAN::Script::Runner;
 
 MetaCPAN::Script::Runner->run;
+
+exit $MetaCPAN::Script::Runner::EXIT_CODE;

--- a/lib/MetaCPAN/Script/Mapping.pm
+++ b/lib/MetaCPAN/Script/Mapping.pm
@@ -129,7 +129,7 @@ has delete_from_type => (
 );
 
 sub run {
-    my $self   = shift;
+    my $self = shift;
 
     if ( $self->await ) {
         $self->delete_index if $self->arg_delete_index;
@@ -151,9 +151,8 @@ sub run {
         }
     }
 
-    # Correctly reaching this point it will end the application
-    # with the set MetaCPAN::Role::Script::exit_code
-    exit $self->exit_code;
+# The run() method is expected to communicate Success to the superior execution level
+    return ( $self->exit_code == 0 );
 }
 
 sub _check_index_exists {

--- a/lib/MetaCPAN/Script/Runner.pm
+++ b/lib/MetaCPAN/Script/Runner.pm
@@ -9,6 +9,10 @@ use Hash::Merge::Simple qw(merge);
 use IO::Interactive qw(is_interactive);
 use Module::Pluggable search_path => ['MetaCPAN::Script'];
 use Module::Runtime ();
+use Try::Tiny qw( catch try );
+use Term::ANSIColor qw( colored );
+
+our $EXIT_CODE = 0;
 
 sub run {
     my ( $class, @actions ) = @ARGV;
@@ -27,8 +31,49 @@ sub run {
             or File::Path::mkpath($path);
     }
 
-    my $obj = $plugins{$class}->new_with_options($config);
-    $obj->run;
+    my $obj = undef;
+    my $ex  = undef;
+    try {
+        $obj = $plugins{$class}->new_with_options($config);
+
+        $obj->run;
+    }
+    catch {
+        $ex = $_;
+
+        $ex = { 'message' => $ex } unless ( ref $ex );
+
+        unless ( defined $ex->{'message'} ) {
+            $ex->{'message'} = $ex->{'msg'}   if ( defined $ex->{'msg'} );
+            $ex->{'message'} = $ex->{'error'} if ( defined $ex->{'error'} );
+        }
+
+        if ( defined $obj
+            && $obj->exit_code != 0 )
+        {
+            # Copying the Exit Code to propagate it to the superior level
+            $EXIT_CODE = $obj->exit_code;
+        }
+        elsif ( $! != 0 ) {
+            $EXIT_CODE = 0 + $!;
+        }
+        else {
+            $EXIT_CODE = 1;
+        }
+
+        # Display Exception Message in red
+        print colored( ['bold red'],
+            "*** EXECPTION [ $EXIT_CODE ] ***: " . $ex->{'message'} ),
+            "\n";
+    };
+
+    unless ( defined $ex ) {
+
+        # Copying the Exit Code to propagate it to the superior level
+        $EXIT_CODE = $obj->exit_code;
+    }
+
+    return ( $EXIT_CODE == 0 );
 }
 
 sub build_config {

--- a/t/lib/MetaCPAN/Script/MockError.pm
+++ b/t/lib/MetaCPAN/Script/MockError.pm
@@ -1,0 +1,101 @@
+package MetaCPAN::Script::MockError;
+
+use Moose;
+use Exception::Class ('MockException');
+
+with 'MetaCPAN::Role::Script', 'MooseX::Getopt';
+
+has arg_error_message => (
+    init_arg      => 'message',
+    is            => 'ro',
+    isa           => 'Str',
+    default       => "",
+    documentation => 'mock an Error Message',
+);
+
+has arg_error_code => (
+    init_arg      => 'error',
+    is            => 'ro',
+    isa           => 'Int',
+    default       => -1,
+    documentation => 'mock an Exit Code',
+);
+
+has arg_die => (
+    init_arg      => 'die',
+    is            => 'ro',
+    isa           => 'Bool',
+    default       => 0,
+    documentation => 'mock an Exception',
+);
+
+has arg_handle_error => (
+    init_arg      => 'handle_error',
+    is            => 'ro',
+    isa           => 'Bool',
+    default       => 0,
+    documentation => 'mock a handled error',
+);
+
+has arg_exception => (
+    init_arg      => 'exception',
+    is            => 'ro',
+    isa           => 'Bool',
+    default       => 0,
+    documentation => 'mock an Exception Class',
+);
+
+sub exit_with_die {
+    my $self = $_[0];
+
+    if ( $self->arg_error_message ne '' ) {
+        die( $self->arg_error_message );
+    }
+    else {
+        die "mock bare die() call";
+    }
+}
+
+sub exit_with_error {
+    my $self = $_[0];
+
+    if ( $self->arg_error_message ne '' ) {
+        $self->handle_error( $self->arg_error_message, 1 );
+    }
+    else {
+        $self->handle_error( "mock bare die() call", 1 );
+    }
+}
+
+sub throw_exception {
+    my $self = $_[0];
+
+    if ( $self->arg_error_message ne '' ) {
+        MockException->throw( error => $self->arg_error_message );
+    }
+    else {
+        MockException->throw( error => "mock an Execption Class" );
+    }
+}
+
+sub run {
+    my $self = shift;
+
+    $self->exit_code( $self->arg_error_code )
+        if ( $self->arg_error_code != -1 );
+
+    $self->exit_with_error
+        if ( $self->arg_handle_error );
+
+    $self->exit_with_die if ( $self->arg_die );
+
+    $self->throw_exception if ( $self->arg_exception );
+
+    $self->print_error( $self->arg_error_message )
+        if ( $self->arg_error_message ne '' );
+
+# The run() method is expected to communicate Success to the superior execution level
+    return ( $self->exit_code == 0 );
+}
+
+1;

--- a/t/script/runner.t
+++ b/t/script/runner.t
@@ -1,0 +1,60 @@
+use strict;
+use warnings;
+use lib 't/lib';
+
+use MetaCPAN::Script::Runner;
+use Module::Pluggable search_dirs => ['t/lib'];
+use Test::More;
+
+subtest 'runner succeeds' => sub {
+    local @ARGV = ('mockerror');
+
+    ok( MetaCPAN::Script::Runner::run, 'succeeds' );
+
+    is( $MetaCPAN::Script::Runner::EXIT_CODE, 0, "Exit Code '0' - No Error" );
+};
+
+subtest 'runner fails' => sub {
+    local @ARGV
+        = ( 'mockerror', '--error', 11, '--message', 'mock error message' );
+
+    ok( !MetaCPAN::Script::Runner::run, 'fails as expected' );
+
+    is( $MetaCPAN::Script::Runner::EXIT_CODE,
+        11, "Exit Code '11' as expected" );
+};
+
+subtest 'runner dies' => sub {
+    local @ARGV = ( 'mockerror', '--die', '--message', 'mock die message' );
+
+    ok( !MetaCPAN::Script::Runner::run, 'fails as expected' );
+
+    is( $MetaCPAN::Script::Runner::EXIT_CODE, 1,
+        "Exit Code '1' as expected" );
+};
+
+subtest 'runner exits with error' => sub {
+    local @ARGV = (
+        'mockerror', '--handle_error', '--error', 17, '--message',
+        'mock handled error message'
+    );
+
+    ok( !MetaCPAN::Script::Runner::run, 'fails as expected' );
+
+    is( $MetaCPAN::Script::Runner::EXIT_CODE,
+        17, "Exit Code '17' as expected" );
+};
+
+subtest 'runner throws exception' => sub {
+    local @ARGV = (
+        'mockerror', '--exception', '--error', 19, '--message',
+        'mock exception message'
+    );
+
+    ok( !MetaCPAN::Script::Runner::run, 'fails as expected' );
+
+    is( $MetaCPAN::Script::Runner::EXIT_CODE,
+        19, "Exit Code '19' as expected" );
+};
+
+done_testing();


### PR DESCRIPTION
To satisfy the requirement for `MetaCPAN::Script::Runner::run()` to return a ` TRUE ` value but also keep track of the Exit Code of the Plugin Modules and probable exceptions that happened in the execution the return value was changed:
```
$ git diff master lib/MetaCPAN/Script/Mapping.pm
diff --git a/lib/MetaCPAN/Script/Mapping.pm b/lib/MetaCPAN/Script/Mapping.pm
index 7e4f47f2..f709aef7 100644
--- a/lib/MetaCPAN/Script/Mapping.pm
+++ b/lib/MetaCPAN/Script/Mapping.pm
@@ -129,7 +129,7 @@ has delete_from_type => (
 );
 
 sub run {
-    my $self   = shift;
+    my $self = shift;
 
     if ( $self->await ) {
         $self->delete_index if $self->arg_delete_index;
@@ -151,9 +151,8 @@ sub run {
         }
     }
 
-    # Correctly reaching this point it will end the application
-    # with the set MetaCPAN::Role::Script::exit_code
-    exit $self->exit_code;
+# The run() method is expected to communicate Success to the superior execution level
+    return ( $self->exit_code == 0 );
 }
``` 
But to communicate the exit code to the main application the `MetaCPAN::Script::Runner::run()` populates a global value `MetaCPAN::Script::Runner::EXIT_CODE` which then can be read by the main application.

To be able to test all this error capturing a _Mock Script_ module was created and a test that checks different error that could happen.