### PR TITLE
Pass the GitHub access token in the Authorization header

### DIFF
--- a/lib/MetaCPAN/Server/Controller/Login/GitHub.pm
+++ b/lib/MetaCPAN/Server/Controller/Login/GitHub.pm
@@ -33,7 +33,9 @@ sub index : Path {
             unless ($token);
         $token =~ s/&.*$//;
         my $extra_res = $ua->request(
-            GET "https://api.github.com/user?access_token=$token" );
+            GET 'https://api.github.com/user',
+            authorization => "token $token"
+        );
         my $extra = eval { decode_json( $extra_res->content ) } || {};
         $self->update_user( $c, github => $extra->{id}, $extra );
     }


### PR DESCRIPTION
GitHub does no longer accept the access token as a query string. The token needs to be passed in the Authorization header instead. Fixes metacpan/metacpan-web#2595 with regard to GitHub.