### PR TITLE
documented_modules should filter for modules with documentation

### DIFF
--- a/lib/MetaCPAN/Document/File/Set.pm
+++ b/lib/MetaCPAN/Document/File/Set.pm
@@ -176,8 +176,9 @@ sub documented_modules {
     return $self->filter(
         {
             and => [
-                { term => { release => $release->{name} } },
-                { term => { author  => $release->{author} } },
+                { term   => { release => $release->{name} } },
+                { term   => { author  => $release->{author} } },
+                { exists => { field   => "documentation" } },
                 {
                     or => [
                         {


### PR DESCRIPTION
The documented_modules method is only used for one thing currently,
which is finding all of the modules that should be used for link
mappings. This immediately filters for modules that have documentation.
This should instead be part of the filter sent to elasticsearch, to
avoid non-documented files overrunning our result size of 999.