### PR TITLE
Replace git.io shortener links to full address

### DIFF
--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -10,12 +10,12 @@ jobs:
             - uses: actions/checkout@v2
             - name: Install Carton
               run: >
-                  curl -sL https://git.io/cpm | perl -
+                  curl -fsSL --compressed https://raw.githubusercontent.com/skaji/cpm/main/cpm | perl -
                   install -g Carton
                   --show-build-log-on-failure
             - name: Install deps
               run: >
-                  curl -sL https://git.io/cpm | perl -
+                  curl -fsSL --compressed https://raw.githubusercontent.com/skaji/cpm/main/cpm | perl -
                   install
                   --cpanfile cpanfile
                   --resolver metacpan


### PR DESCRIPTION
See also: https://github.com/skaji/cpm/pull/219

On April 29th, git.io url redirection service was read-only.

https://github.blog/changelog/2022-04-25-git-io-deprecation/

cpm recommends changing the URL to install, so I followed the recommendation.
https://github.com/skaji/cpm/blob/61df877db9fd6f30f281e51df43a44bf555676ee/Changes#L7