### PR TITLE
use perl 5.36 container

### DIFF
--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -6,6 +6,8 @@ on:
 jobs:
     update-dep:
         runs-on: "ubuntu-20.04"
+        container:
+            image: perl:5.36
         steps:
             - uses: actions/checkout@v2
             - name: Install Carton


### PR DESCRIPTION
"Update cpanfile.snapshot" keeps failing, mainly due to permissions.
https://github.com/metacpan/metacpan-api/runs/6745584648?check_suite_focus=true

This problem could be solved by running on a perl container image, as other perl libraries use in their actions.

<https://github.com/skaji/cpm/blob/61df877db9fd6f30f281e51df43a44bf555676ee/.github/workflows/test.yml#L24-L25>
