### PR TITLE
Verify Indices Mappings and Clear all Indices

### DIFF
--- a/lib/MetaCPAN/Role/Script.pm
+++ b/lib/MetaCPAN/Role/Script.pm
@@ -364,17 +364,32 @@ sub await {
 
 sub are_you_sure {
     my ( $self, $msg ) = @_;
+    my $iconfirmed = 0;
 
     if (is_interactive) {
-        print colored( ['bold red'], "*** Warning ***: $msg" ), "\n";
-        my $answer = prompt
-            'Are you sure you want to do this (type "YES" to confirm) ? ';
+        my $answer
+            = prompt colored( ['bold red'], "*** Warning ***: $msg" ) . "\n"
+            . 'Are you sure you want to do this (type "YES" to confirm) ? ';
         if ( $answer ne 'YES' ) {
-            print "bye.\n";
-            exit 0;
+            log_error {"Confirmation incorrect: '$answer'"};
+            print "Operation will be interruped!\n";
+
+            #Set System Error: 125 - ECANCELED - Operation canceled
+            $self->exit_code(125);
+            $self->handle_error( 'Operation canceled on User Request', 1 );
         }
-        print "alright then...\n";
+        else {
+            log_info {'Operation confirmed.'};
+            print "alright then...\n";
+            $iconfirmed = 1;
+        }
     }
+    else {
+        print colored( ['bold yellow'], "*** Warning ***: $msg" ) . "\n";
+        $iconfirmed = 1;
+    }
+
+    return $iconfirmed;
 }
 
 1;

--- a/lib/MetaCPAN/Role/Script.pm
+++ b/lib/MetaCPAN/Role/Script.pm
@@ -420,6 +420,9 @@ After C<await> seconds the Application will fail with an Exception and the Exit 
 
     bin/metacpan <script_name> --await 15
 
+B<Exit Code:> If the I<ElasticSearch> service does not become available
+within C<await> seconds it exits the Script with Exit Code C< 112 >.
+
 See L<Method C<await()>>
 
 =back
@@ -436,11 +439,16 @@ This method uses the
 L<C<Search::Elasticsearch::Client::2_0::Direct::ping()>|https://metacpan.org/pod/Search::Elasticsearch::Client::2_0::Direct#ping()>
 method to verify the service availabilty and wait for C<arg_await_timeout> seconds.
 When the service does not become available within C<arg_await_timeout> seconds it re-throws the
-Exception from the C<Search::Elasticsearch::Client> and sets C< $! > to C< 112 >.
+Exception from the C<Search::Elasticsearch::Client> and sets B<Exit Code> to C< 112 >.
 The C<Search::Elasticsearch::Client> generates a C<"Search::Elasticsearch::Error::NoNodes"> Exception.
 When the service is available it will populate the C<cluster_info> C<HASH> structure with the basic information
 about the cluster.
+
+B<Exceptions:> It will throw an exceptions when the I<ElasticSearch> service does not become available
+within C<arg_await_timeout> seconds (as described above).
+
 See L<Option C<--await 15>>
+
 See L<Method C<check_health()>>
 
 =item C<check_health( [ refresh ] )>
@@ -458,9 +466,19 @@ The method returns C< 1 > when the C<cluster_info> is populated, none of the ind
 the Health State I<red> and at least one alias is created in C<aliases_info>
 otherwise the method returns C< 0 >
 
+B<Parameters:>
+
+C<refresh> - Integer evaluated as boolean when set to C< 1 > the cluster info structures
+will always be updated.
+
+See L<Method C<await()>>
+
 =item C<are_you_sure()>
 
 Requests the user to confirm the operation with "I< YES >"
+
+B<Exceptions:> When the operator input does not match "I< YES >" it will exit the Script
+with Exit Code [125] (C<125 - ECANCELED - Operation canceled>).
 
 =item C<handle_error( error_message[, die_always ] )>
 

--- a/lib/MetaCPAN/Script/Mapping.pm
+++ b/lib/MetaCPAN/Script/Mapping.pm
@@ -987,30 +987,22 @@ See L<Method C<check_mapping()>>
 
 See L<Method C<MetaCPAN::Role::Script::check_health()>>
 
+=item Option C<--all>
+
+This option is only effective in combination with Option C<--delete>.
+It uses the information gathered by C<MetaCPAN::Role::Script::check_health()> to delete
+B<ALL> indices in the I<ElasticSearch> Cluster.
+This option is usefull to reconstruct a broken I<ElasticSearch> Cluster
+
+    bin/metacpan mapping --delete --all
+
+See L<Option C<--delete>>
+
+See L<Method C<deploy_mapping()>>
+
+See L<Method C<MetaCPAN::Role::Script::check_health()>>
+
 =back
-
-=cut
-
-#<<<<<<< HEAD
-#=item Option C<--all>
-
-#This option is only effective in combination with Option C<--delete>.
-#It uses the information gathered by C<MetaCPAN::Role::Script::check_health()> to delete
-#B<ALL> indices in the I<ElasticSearch> Cluster.
-#This option is usefull to reconstruct a broken I<ElasticSearch> Cluster
-
-#    bin/metacpan mapping --delete --all
-
-#See L<Option C<--delete>>
-
-#See L<Method C<deploy_mapping()>>
-
-#See L<Method C<MetaCPAN::Role::Script::check_health()>>
-
-#=======
-#>>>>>>> master
-
-=pod
 
 =head1 METHODS
 

--- a/lib/MetaCPAN/Script/Runner.pm
+++ b/lib/MetaCPAN/Script/Runner.pm
@@ -63,7 +63,7 @@ sub run {
 
         # Display Exception Message in red
         print colored( ['bold red'],
-            "*** EXECPTION [ $EXIT_CODE ] ***: " . $ex->{'message'} ),
+            "*** EXCEPTION [ $EXIT_CODE ] ***: " . $ex->{'message'} ),
             "\n";
     };
 

--- a/t/00_setup.t
+++ b/t/00_setup.t
@@ -37,6 +37,9 @@ ok( $tmp_dir->stat, "$tmp_dir exists for testing" );
 my $server = MetaCPAN::TestServer->new;
 $server->setup;
 
+# Run the Mappings Tests
+$server->test_mappings;
+
 my $config = get_config();
 $config->{es} = $server->es_client;
 

--- a/t/lib/MetaCPAN/TestServer.pm
+++ b/t/lib/MetaCPAN/TestServer.pm
@@ -2,7 +2,6 @@ package MetaCPAN::TestServer;
 
 use MetaCPAN::Moose;
 
-use Cpanel::JSON::XS qw( decode_json encode_json );
 use MetaCPAN::DarkPAN                ();
 use MetaCPAN::Script::Author         ();
 use MetaCPAN::Script::Cover          ();
@@ -415,23 +414,23 @@ sub test_field_mismatch {
 
     subtest 'field mismatch' => sub {
         my $sfieldjson = q({
-	        "properties" : {
+          "properties" : {
             "version" : {
               "ignore_above" : 2048,
               "index" : "not_analyzed",
               "type" : "string"
             }
-	        }
-	      });
+	  }
+	});
         my $sfieldchangejson = q({
-	        "properties" : {
+          "properties" : {
             "version" : {
               "ignore_above" : 1024,
               "index" : "not_analyzed",
               "type" : "string"
             }
-	        }
-	      });
+	  }
+	});
 
         subtest 'mapping change field' => sub {
             local @ARGV = (
@@ -511,16 +510,16 @@ sub test_delete_all {
     subtest 'delete all deletes unknown index' => sub {
         subtest 'create index' => sub {
             my $smockindexjson = q({
-            	"mock_index": {
-					      "properties": {
-					          "mock_field" : {
-					            "type" : "string",
-					            "index" : "not_analyzed",
-					            "ignore_above" : 2048
-					          }
-					        }
-					      }
-					    });
+              "mock_index": {
+                "properties": {
+		  "mock_field" : {
+		    "type" : "string",
+		    "index" : "not_analyzed",
+		    "ignore_above" : 2048
+                  }
+		}
+	      }
+	    });
 
             local @ARGV = (
                 'mapping',    '--create_index',

--- a/t/script/mapping.t
+++ b/t/script/mapping.t
@@ -1,0 +1,74 @@
+use strict;
+use warnings;
+use lib 't/lib';
+
+use Test::More;
+
+use MetaCPAN::Script::Runner;
+use MetaCPAN::Script::Mapping;
+
+my $config = MetaCPAN::Script::Runner::build_config;
+
+subtest 'mapping verification succeeds' => sub {
+    local @ARGV = ( 'mapping', '--verify' );
+    my $mapping = MetaCPAN::Script::Mapping->new_with_options($config);
+
+    ok( $mapping->run, "verification succeeds" );
+    is( $mapping->exit_code, 0, "Exit Code '0' - No Error" );
+};
+
+subtest 'create, delete index' => sub {
+    subtest 'create index' => sub {
+        my $smockindexjson = q({
+			    "mock_index": {
+						"properties": {
+			          "mock_field": {
+			            "type": "string",
+			            "index": "not_analyzed",
+			            "ignore_above": 2048
+			          }
+					    }
+					  }
+					});
+        local @ARGV = (
+            'mapping',    '--create_index',
+            'mock_index', '--patch_mapping',
+            $smockindexjson
+        );
+        my $mapping = MetaCPAN::Script::Mapping->new_with_options($config);
+
+        ok( $mapping->run, "creation 'mock_index' succeeds" );
+        is( $mapping->exit_code, 0, "Exit Code '0' - No Error" );
+    };
+    subtest 'info shows new index' => sub {
+        local @ARGV = ( 'mapping', '--show_cluster_info' );
+        my $mapping = MetaCPAN::Script::Mapping->new_with_options($config);
+
+        ok( $mapping->run, "show info succeeds" );
+        is( $mapping->exit_code, 0, "Exit Code '0' - No Error" );
+
+        ok( defined $mapping->indices_info, 'Index Info built' );
+        ok( defined $mapping->indices_info->{'mock_index'},
+            'Created Index printed' );
+    };
+    subtest 'delete index' => sub {
+        local @ARGV = ( 'mapping', '--delete_index', 'mock_index' );
+        my $mapping = MetaCPAN::Script::Mapping->new_with_options($config);
+
+        ok( $mapping->run, "deletion 'mock_index' succeeds" );
+        is( $mapping->exit_code, 0, "Exit Code '0' - No Error" );
+    };
+    subtest 'info does not show deleted index' => sub {
+        local @ARGV = ( 'mapping', '--show_cluster_info' );
+        my $mapping = MetaCPAN::Script::Mapping->new_with_options($config);
+
+        ok( $mapping->run, "show info succeeds" );
+        is( $mapping->exit_code, 0, "Exit Code '0' - No Error" );
+
+        ok( defined $mapping->indices_info, 'Index Info printed' );
+        ok( !defined $mapping->indices_info->{'mock_index'},
+            'Deleted Index not printed' );
+    };
+};
+
+done_testing();

--- a/t/script/mapping.t
+++ b/t/script/mapping.t
@@ -20,16 +20,16 @@ subtest 'mapping verification succeeds' => sub {
 subtest 'create, delete index' => sub {
     subtest 'create index' => sub {
         my $smockindexjson = q({
-			    "mock_index": {
-						"properties": {
-			          "mock_field": {
-			            "type": "string",
-			            "index": "not_analyzed",
-			            "ignore_above": 2048
-			          }
-					    }
-					  }
-					});
+          "mock_index": {
+	    "properties": {
+	      "mock_field": {
+		"type": "string",
+		"index": "not_analyzed",
+		"ignore_above": 2048
+              }
+	    }
+          }
+	});
         local @ARGV = (
             'mapping',    '--create_index',
             'mock_index', '--patch_mapping',


### PR DESCRIPTION
This implements the functionality discussed at:
[Fix Corrupted Indices and Verify Mappings](https://github.com/metacpan/metacpan-api/issues/1048)
It is also able to fix difficulties and corruptions as documented at
[Unexpected Index Corruption](https://github.com/metacpan/metacpan-docker/issues/47)

Additionally it implements Exit with Error Code for unconfirmed Operations.

To test all the functionality it features several Mapping Script Tests.