### PR TITLE
Clear Unknown Indices

### DIFF
--- a/lib/MetaCPAN/Role/Script.pm
+++ b/lib/MetaCPAN/Role/Script.pm
@@ -364,17 +364,32 @@ sub await {
 
 sub are_you_sure {
     my ( $self, $msg ) = @_;
+    my $iconfirmed = 0;
 
     if (is_interactive) {
-        print colored( ['bold red'], "*** Warning ***: $msg" ), "\n";
-        my $answer = prompt
-            'Are you sure you want to do this (type "YES" to confirm) ? ';
+        my $answer
+            = prompt colored( ['bold red'], "*** Warning ***: $msg" ) . "\n"
+            . 'Are you sure you want to do this (type "YES" to confirm) ? ';
         if ( $answer ne 'YES' ) {
-            print "bye.\n";
-            exit 0;
+            log_error {"Confirmation incorrect: '$answer'"};
+            print "Operation will be interruped!\n";
+
+            #Set System Error: 125 - ECANCELED - Operation canceled
+            $self->exit_code(125);
+            $self->handle_error( 'Operation canceled on User Request', 1 );
         }
-        print "alright then...\n";
+        else {
+            log_info {'Operation confirmed.'};
+            print "alright then...\n";
+            $iconfirmed = 1;
+        }
     }
+    else {
+        print colored( ['bold yellow'], "*** Warning ***: $msg" ) . "\n";
+        $iconfirmed = 1;
+    }
+
+    return $iconfirmed;
 }
 
 1;
@@ -424,7 +439,7 @@ This method uses the
 L<C<Search::Elasticsearch::Client::2_0::Direct::ping()>|https://metacpan.org/pod/Search::Elasticsearch::Client::2_0::Direct#ping()>
 method to verify the service availabilty and wait for C<arg_await_timeout> seconds.
 When the service does not become available within C<arg_await_timeout> seconds it re-throws the
-Exception from the C<Search::Elasticsearch::Client> and sets C< $! > to C< 112 >.
+Exception from the C<Search::Elasticsearch::Client> and sets B<Exit Code> to C< 112 >.
 The C<Search::Elasticsearch::Client> generates a C<"Search::Elasticsearch::Error::NoNodes"> Exception.
 When the service is available it will populate the C<cluster_info> C<HASH> structure with the basic information
 about the cluster.
@@ -461,6 +476,9 @@ See L<Method C<await()>>
 =item C<are_you_sure()>
 
 Requests the user to confirm the operation with "I< YES >"
+
+B<Exceptions:> When the operator input does not match "I< YES >" it will exit the Script
+with Exit Code [125] (C<125 - ECANCELED - Operation canceled>).
 
 =item C<handle_error( error_message[, die_always ] )>
 

--- a/lib/MetaCPAN/Script/Runner.pm
+++ b/lib/MetaCPAN/Script/Runner.pm
@@ -63,7 +63,7 @@ sub run {
 
         # Display Exception Message in red
         print colored( ['bold red'],
-            "*** EXECPTION [ $EXIT_CODE ] ***: " . $ex->{'message'} ),
+            "*** EXCEPTION [ $EXIT_CODE ] ***: " . $ex->{'message'} ),
             "\n";
     };
 

--- a/t/lib/MetaCPAN/TestServer.pm
+++ b/t/lib/MetaCPAN/TestServer.pm
@@ -374,6 +374,9 @@ sub test_delete_fails {
             local @ARGV = qw(mapping --delete --all);
             local %ENV  = (%ENV);
 
+            print STDERR "test_delete_fails - PLACK_ENV: '" . $ENV{'PLACK_ENV'} . "'\n";
+            print STDERR "test_delete_fails - MOJO_MODE: '" . $ENV{'MOJO_MODE'} . "'\n";
+
             delete $ENV{'PLACK_ENV'};
             delete $ENV{'MOJO_MODE'};
 
@@ -431,8 +434,8 @@ sub test_delete_all {
         subtest 'delete all succeeds' => sub {
             local @ARGV = qw(mapping --delete --all);
 
-				    print STDERR "PLACK_ENV: '" . $ENV{'PLACK_ENV'} . "'\n";
-				    print STDERR "MOJO_MODE: '" . $ENV{'MOJO_MODE'} . "'\n";
+				    print STDERR "test_delete_all - PLACK_ENV: '" . $ENV{'PLACK_ENV'} . "'\n";
+				    print STDERR "test_delete_all - MOJO_MODE: '" . $ENV{'MOJO_MODE'} . "'\n";
 
             ok( MetaCPAN::Script::Runner::run, "delete all succeeds" );
             is( $MetaCPAN::Script::Runner::EXIT_CODE,

--- a/t/lib/MetaCPAN/TestServer.pm
+++ b/t/lib/MetaCPAN/TestServer.pm
@@ -64,6 +64,9 @@ sub setup {
 
     $self->es_client;
 
+    # Run the Delete Index Tests before mapping deployment
+    $self->test_delete_mappings;
+
     # Deploy project mappings
     $self->put_mappings;
 }
@@ -349,6 +352,102 @@ sub prepare_user_test_data {
         ),
         'put bot user'
     );
+}
+
+sub test_delete_mappings {
+    my $self = $_[0];
+
+    $self->test_delete_fails;
+    $self->test_delete_all;
+}
+
+sub test_delete_fails {
+    my $self = $_[0];
+
+    my $iexitcode;
+    my $irunok;
+
+    subtest 'delete all not permitted' => sub {
+
+        # mapping script - delete indices
+        {
+            local @ARGV = qw(mapping --delete --all);
+            local %ENV  = (%ENV);
+
+            delete $ENV{'PLACK_ENV'};
+            delete $ENV{'MOJO_MODE'};
+
+            $irunok    = MetaCPAN::Script::Runner::run;
+            $iexitcode = $MetaCPAN::Script::Runner::EXIT_CODE;
+        }
+
+        ok( !$irunok, "delete all fails" );
+        is( $iexitcode, 1, "Exit Code '1' - Permission Error" );
+    };
+}
+
+sub test_delete_all {
+    my $self = $_[0];
+
+    subtest 'delete all deletes unknown index' => sub {
+        subtest 'create index' => sub {
+            my $smockindexjson = q({
+   "mock_index" : {
+      "properties" : {
+         "mock_field" : {
+            "index" : "not_analyzed",
+            "ignore_above" : 2048,
+            "type" : "string"
+         }
+      }
+   }
+});
+
+            local @ARGV = (
+                'mapping',    '--create_index',
+                'mock_index', '--patch_mapping',
+                $smockindexjson
+            );
+
+            ok(
+                MetaCPAN::Script::Runner::run,
+                "creation 'mock_index' succeeds"
+            );
+            is( $MetaCPAN::Script::Runner::EXIT_CODE,
+                0, "Exit Code '0' - No Error" );
+        };
+        subtest 'info shows unknonwn index' => sub {
+            local @ARGV = ( 'mapping', '--show_cluster_info' );
+            my $mapping = MetaCPAN::Script::Mapping->new_with_options(
+                $self->_config );
+
+            ok( $mapping->run, "show info succeeds" );
+            is( $mapping->exit_code, 0, "Exit Code '0' - No Error" );
+
+            ok( defined $mapping->indices_info, 'Index Info built' );
+            ok( defined $mapping->indices_info->{'mock_index'},
+                'Unknown Index printed' );
+        };
+        subtest 'delete all succeeds' => sub {
+            local @ARGV = qw(mapping --delete --all);
+
+            ok( MetaCPAN::Script::Runner::run, "delete all succeeds" );
+            is( $MetaCPAN::Script::Runner::EXIT_CODE,
+                0, "Exit Code '0' - No Error" );
+        };
+        subtest 'info does not show unknown index' => sub {
+            local @ARGV = ( 'mapping', '--show_cluster_info' );
+            my $mapping = MetaCPAN::Script::Mapping->new_with_options(
+                $self->_config );
+
+            ok( $mapping->run, "show info succeeds" );
+            is( $mapping->exit_code, 0, "Exit Code '0' - No Error" );
+
+            ok( defined $mapping->indices_info, 'Index Info built' );
+            ok( !defined $mapping->indices_info->{'mock_index'},
+                'Unknown Index printed' );
+        };
+    };
 }
 
 sub test_mappings {

--- a/t/lib/MetaCPAN/TestServer.pm
+++ b/t/lib/MetaCPAN/TestServer.pm
@@ -431,6 +431,9 @@ sub test_delete_all {
         subtest 'delete all succeeds' => sub {
             local @ARGV = qw(mapping --delete --all);
 
+				    print STDERR "PLACK_ENV: '" . $ENV{'PLACK_ENV'} . "'\n";
+				    print STDERR "MOJO_MODE: '" . $ENV{'MOJO_MODE'} . "'\n";
+
             ok( MetaCPAN::Script::Runner::run, "delete all succeeds" );
             is( $MetaCPAN::Script::Runner::EXIT_CODE,
                 0, "Exit Code '0' - No Error" );

--- a/t/script/mapping.t
+++ b/t/script/mapping.t
@@ -9,6 +9,60 @@ use MetaCPAN::Script::Mapping;
 
 my $config = MetaCPAN::Script::Runner::build_config;
 
+subtest 'create, delete index' => sub {
+    subtest 'create index' => sub {
+        my $smockindexjson = q({
+   "mock_index" : {
+      "properties" : {
+         "mock_field" : {
+            "type" : "string",
+            "ignore_above" : 2048,
+            "index" : "not_analyzed"
+         }
+      }
+   }
+});
+        local @ARGV = (
+            'mapping',    '--create_index',
+            'mock_index', '--patch_mapping',
+            $smockindexjson
+        );
+        my $mapping = MetaCPAN::Script::Mapping->new_with_options($config);
+
+        ok( $mapping->run, "creation 'mock_index' succeeds" );
+        is( $mapping->exit_code, 0, "Exit Code '0' - No Error" );
+    };
+    subtest 'info shows new index' => sub {
+        local @ARGV = ( 'mapping', '--show_cluster_info' );
+        my $mapping = MetaCPAN::Script::Mapping->new_with_options($config);
+
+        ok( $mapping->run, "show info succeeds" );
+        is( $mapping->exit_code, 0, "Exit Code '0' - No Error" );
+
+        ok( defined $mapping->indices_info, 'Index Info built' );
+        ok( defined $mapping->indices_info->{'mock_index'},
+            'Created Index printed' );
+    };
+    subtest 'delete index' => sub {
+        local @ARGV = ( 'mapping', '--delete_index', 'mock_index' );
+        my $mapping = MetaCPAN::Script::Mapping->new_with_options($config);
+
+        ok( $mapping->run, "deletion 'mock_index' succeeds" );
+        is( $mapping->exit_code, 0, "Exit Code '0' - No Error" );
+    };
+    subtest 'info does not show deleted index' => sub {
+        local @ARGV = ( 'mapping', '--show_cluster_info' );
+        my $mapping = MetaCPAN::Script::Mapping->new_with_options($config);
+
+        ok( $mapping->run, "show info succeeds" );
+        is( $mapping->exit_code, 0, "Exit Code '0' - No Error" );
+
+        ok( defined $mapping->indices_info, 'Index Info printed' );
+        ok( !defined $mapping->indices_info->{'mock_index'},
+            'Deleted Index not printed' );
+    };
+};
+
 subtest 'mapping verification succeeds' => sub {
     local @ARGV = ( 'mapping', '--verify' );
     my $mapping = MetaCPAN::Script::Mapping->new_with_options($config);


### PR DESCRIPTION
This implements the `--delete --all` functionality discussed at:
[Fix Corrupted Indices](https://github.com/metacpan/metacpan-api/issues/1048)
which is needed to close definitely the issue of Index Corruption
[Unexpected Index Corruption](https://github.com/metacpan/metacpan-docker/issues/47)
by
1) Preventing the Index Corruption
2) Recovering from Index Corruption with "_Clear All Indices_" option

Additionally it implements Exit with Error Code for unconfirmed Operations
as mentioned at:
[ElasticSearch Availabilty Check](https://github.com/metacpan/metacpan-api/pull/1045)
This is also part of the logic to **prevent** accidental Indices Corruption

To test the functionality it introduces several Mapping Script Tests.

These tests are required to check the "_Verify Mappings_" functionality developed at:
[Verify Indices Mappings](https://github.com/metacpan/metacpan-api/pull/1064)