### PR TITLE
Verify Indices Mappings

### DIFF
--- a/lib/MetaCPAN/Role/Script.pm
+++ b/lib/MetaCPAN/Role/Script.pm
@@ -405,6 +405,9 @@ After C<await> seconds the Application will fail with an Exception and the Exit 
 
     bin/metacpan <script_name> --await 15
 
+B<Exit Code:> If the I<ElasticSearch> service does not become available
+within C<await> seconds it exits the Script with Exit Code C< 112 >.
+
 See L<Method C<await()>>
 
 =back
@@ -425,7 +428,12 @@ Exception from the C<Search::Elasticsearch::Client> and sets C< $! > to C< 112 >
 The C<Search::Elasticsearch::Client> generates a C<"Search::Elasticsearch::Error::NoNodes"> Exception.
 When the service is available it will populate the C<cluster_info> C<HASH> structure with the basic information
 about the cluster.
+
+B<Exceptions:> It will throw an exceptions when the I<ElasticSearch> service does not become available
+within C<arg_await_timeout> seconds (as described above).
+
 See L<Option C<--await 15>>
+
 See L<Method C<check_health()>>
 
 =item C<check_health( [ refresh ] )>
@@ -442,6 +450,13 @@ If the service is unavailable the C<await()> method will produce an exception an
 The method returns C< 1 > when the C<cluster_info> is populated, none of the indices in C<indices_info> has
 the Health State I<red> and at least one alias is created in C<aliases_info>
 otherwise the method returns C< 0 >
+
+B<Parameters:>
+
+C<refresh> - Integer evaluated as boolean when set to C< 1 > the cluster info structures
+will always be updated.
+
+See L<Method C<await()>>
 
 =item C<are_you_sure()>
 

--- a/lib/MetaCPAN/Script/Mapping.pm
+++ b/lib/MetaCPAN/Script/Mapping.pm
@@ -902,24 +902,6 @@ See L<Method C<mappings_valid()>>
 
 See L<Method C<MetaCPAN::Role::Script::check_health()>>
 
-=item Option C<--all>
-
-This option is only effective in combination with Option C<--delete>.
-It uses the information gathered by C<MetaCPAN::Role::Script::check_health()> to delete
-B<ALL> indices in the I<ElasticSearch> Cluster.
-This option is usefull to reconstruct a broken I<ElasticSearch> Cluster
-
-    bin/metacpan mapping --delete --all
-
-B<Exceptions:> It will throw an exceptions when not performed in an development or
-testing environment.
-
-See L<Option C<--delete>>
-
-See L<Method C<deploy_mapping()>>
-
-See L<Method C<MetaCPAN::Role::Script::check_health()>>
-
 =item Option C<--verify>
 
 This option will request the index mappings from the I<ElasticSearch> Cluster and

--- a/lib/MetaCPAN/Script/Mapping.pm
+++ b/lib/MetaCPAN/Script/Mapping.pm
@@ -147,9 +147,9 @@ sub run {
     my $self = shift;
 
     if ( $self->await ) {
+        $self->delete_index if $self->arg_delete_index;
         $self->create_index if $self->arg_create_index;
         $self->update_index if $self->arg_update_index;
-        $self->delete_index if $self->arg_delete_index;
         $self->copy_type    if $self->copy_to_index;
         $self->empty_type   if $self->delete_from_type;
         $self->list_types   if $self->arg_list_types;
@@ -489,7 +489,7 @@ sub _build_aliases {
 
 sub deploy_mapping {
     my $self       = shift;
-    my $imappingok = 0;
+    my $is_mapping_ok = 0;
 
     $self->are_you_sure(
         'this will delete EVERYTHING and re-create the (empty) indexes');
@@ -534,12 +534,12 @@ sub deploy_mapping {
     }
 
     $self->check_health(1);
-    $imappingok = $self->mappings_valid( $rmappings, $raliases );
+    $is_mapping_ok = $self->mappings_valid( $rmappings, $raliases );
 
     # done
     log_info {"Done."};
 
-    return $imappingok;
+    return $is_mapping_ok;
 }
 
 sub aliases_valid {

--- a/lib/MetaCPAN/Script/Mapping.pm
+++ b/lib/MetaCPAN/Script/Mapping.pm
@@ -628,7 +628,7 @@ sub _compare_mapping {
                             );
                         }
                         else {    # No Hash nor Array
-                            unless ( ${$deploy_value} eq ${$model_value} ) {
+                            if ( ${$deploy_value} ne ${$model_value} ) {
                                 log_error {
                                     'Mismatch field: '
                                         . $sname . '.'
@@ -641,7 +641,7 @@ sub _compare_mapping {
                         }
                     }
                     else {    # Scalar Value
-                        unless ( $deploy_value eq $model_value ) {
+                        if ( $deploy_value ne $model_value ) {
                             log_error {
                                 'Mismatch field: '
                                     . $sname . '.'
@@ -707,7 +707,7 @@ sub _compare_mapping {
                             );
                         }
                         else {    # No Hash nor Array
-                            unless ( ${$deploy_value} eq ${$model_value} ) {
+                            if ( ${$deploy_value} ne ${$model_value} ) {
                                 log_error {
                                     'Mismatch field: '
                                         . $sname . '['
@@ -720,7 +720,7 @@ sub _compare_mapping {
                         }
                     }
                     else {    # Scalar Value
-                        unless ( $deploy_value eq $model_value ) {
+                        if ( $deploy_value ne $model_value ) {
                             log_error {
                                 'Mismatch field: '
                                     . $sname . '['

--- a/t/00_setup.t
+++ b/t/00_setup.t
@@ -37,6 +37,9 @@ ok( $tmp_dir->stat, "$tmp_dir exists for testing" );
 my $server = MetaCPAN::TestServer->new;
 $server->setup;
 
+# Run the Mappings Tests
+$server->test_mappings;
+
 my $config = get_config();
 $config->{es} = $server->es_client;
 

--- a/t/lib/MetaCPAN/TestServer.pm
+++ b/t/lib/MetaCPAN/TestServer.pm
@@ -10,6 +10,7 @@ use MetaCPAN::Script::Favorite       ();
 use MetaCPAN::Script::First          ();
 use MetaCPAN::Script::Latest         ();
 use MetaCPAN::Script::Mapping        ();
+use MetaCPAN::Script::Mapping::Cover ();
 use MetaCPAN::Script::Mirrors        ();
 use MetaCPAN::Script::Package        ();
 use MetaCPAN::Script::Permission     ();
@@ -62,6 +63,8 @@ sub setup {
     my $self = shift;
 
     $self->es_client;
+
+    # Deploy project mappings
     $self->put_mappings;
 }
 
@@ -161,7 +164,7 @@ sub wait_for_es {
     $self->es_client->indices->refresh;
 }
 
-sub verify_mappings {
+sub check_mappings {
     my $self           = $_[0];
     my %hshtestindices = (
         'cover'       => 'yellow',
@@ -193,7 +196,7 @@ sub verify_mappings {
         ok( defined $hshtestindices{$_}, "indice '$_' is configured" )
             foreach ( keys %{ $mapping->indices_info } );
     };
-    subtest 'verify indix health' => sub {
+    subtest 'verify index health' => sub {
         foreach ( keys %hshtestindices ) {
             ok( defined $mapping->indices_info->{$_},
                 "indice '$_' was created" );
@@ -219,7 +222,7 @@ sub put_mappings {
     local @ARGV = qw(mapping --delete);
     ok( MetaCPAN::Script::Mapping->new_with_options( $self->_config )->run,
         'put mapping' );
-    $self->verify_mappings;
+    $self->check_mappings;
     $self->wait_for_es();
 }
 
@@ -227,9 +230,8 @@ sub index_releases {
     my $self = shift;
     my %args = @_;
 
-    local @ARGV = (
-        'release', $ENV{MC_RELEASE} ? $ENV{MC_RELEASE} : $self->_cpan_dir
-    );
+    local @ARGV = ( 'release',
+        $ENV{MC_RELEASE} ? $ENV{MC_RELEASE} : $self->_cpan_dir );
     ok(
         MetaCPAN::Script::Release->new_with_options( %{ $self->_config },
             %args )->run,
@@ -353,6 +355,117 @@ sub prepare_user_test_data {
         ),
         'put bot user'
     );
+}
+
+sub test_mappings {
+    my $self = $_[0];
+
+    $self->test_index_missing;
+    $self->test_field_mismatch;
+}
+
+sub test_index_missing {
+    my $self = $_[0];
+
+    subtest 'missing index' => sub {
+        my $scoverindexjson = MetaCPAN::Script::Mapping::Cover::mapping;
+
+        subtest 'delete cover index' => sub {
+            local @ARGV = qw(mapping --delete_index cover);
+            my $mapping
+                = MetaCPAN::Script::Mapping->new_with_options(
+                $self->_config );
+
+            ok( $mapping->run, "deletion 'cover' succeeds" );
+            is( $mapping->exit_code, 0, "Exit Code '0' - No Error" );
+        };
+        subtest 'mapping verification fails' => sub {
+            local @ARGV = qw(mapping --verify);
+            my $mapping
+                = MetaCPAN::Script::Mapping->new_with_options(
+                $self->_config );
+
+            is( $mapping->run, 0, "verification execution fails" );
+            is( $mapping->exit_code, 1,
+                "Exit Code '1' - Verification Error" );
+        };
+        subtest 're-create cover index' => sub {
+            local @ARGV = (
+                'mapping', '--create_index',
+                'cover',   '--patch_mapping',
+                qq({ "cover": $scoverindexjson })
+            );
+            my $mapping
+                = MetaCPAN::Script::Mapping->new_with_options(
+                $self->_config );
+
+            ok( $mapping->run, "creation 'cover' succeeds" );
+            is( $mapping->exit_code, 0, "Exit Code '0' - No Error" );
+        };
+    };
+}
+
+sub test_field_mismatch {
+    my $self = $_[0];
+
+    subtest 'field mismatch' => sub {
+        my $sfieldjson = q({
+   "properties" : {
+      "version" : {
+         "index" : "not_analyzed",
+         "ignore_above" : 2048,
+         "type" : "string"
+      }
+   }
+});
+        my $sfieldchangejson = q({
+   "properties" : {
+      "version" : {
+         "type" : "string",
+         "index" : "not_analyzed",
+         "ignore_above" : 1024
+      }
+   }
+});
+
+        subtest 'mapping change field' => sub {
+            local @ARGV = (
+                'mapping', '--update_index',
+                'cover',   '--patch_mapping',
+                qq({ "cover": $sfieldchangejson })
+            );
+            my $mapping
+                = MetaCPAN::Script::Mapping->new_with_options(
+                $self->_config );
+
+            ok( $mapping->run, "change 'cover' succeeds" );
+
+            is( $mapping->exit_code, 0, "Exit Code '0' - No Error" );
+        };
+        subtest 'field verification fails' => sub {
+            local @ARGV = qw(mapping --verify);
+            my $mapping
+                = MetaCPAN::Script::Mapping->new_with_options(
+                $self->_config );
+
+            is( $mapping->run, 0, "verification fails" );
+            is( $mapping->exit_code, 1,
+                "Exit Code '1' - Verification Error" );
+        };
+        subtest 'mapping re-establish field' => sub {
+            local @ARGV = (
+                'mapping', '--update_index',
+                'cover',   '--patch_mapping',
+                qq({ "cover": $sfieldjson })
+            );
+            my $mapping
+                = MetaCPAN::Script::Mapping->new_with_options(
+                $self->_config );
+
+            ok( $mapping->run, "re-establish 'cover' succeeds" );
+            is( $mapping->exit_code, 0, "Exit Code '0' - No Error" );
+        };
+    };
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/t/script/mapping.t
+++ b/t/script/mapping.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+use lib 't/lib';
+
+use Test::More;
+
+use MetaCPAN::Script::Runner qw(build_config);
+use MetaCPAN::Script::Mapping;
+
+my $config = MetaCPAN::Script::Runner::build_config;
+
+subtest 'mapping verification succeeds' => sub {
+    local @ARGV = ( 'mapping', '--verify' );
+    my $mapping = MetaCPAN::Script::Mapping->new_with_options($config);
+
+    ok( $mapping->run, "verification succeeds" );
+    is( $mapping->exit_code, 0, "Exit Code '0' - No Error" );
+};
+
+done_testing();


### PR DESCRIPTION
This implements the deep comparison of the deployed mappings in the _ElasticSearch_ cluster and the definitions in the project.
```
$ bin/metacpan mapping --verify              # compare deployed indices and aliases with project definitions
```
This will show automatic unexpected adjustments made by the _ElasticSearch_ engine which do not correspond to the intended structure.

This feature was requested and defined at:
[Fix Index Corruption](https://github.com/metacpan/metacpan-api/issues/1048)
as a result of the blocking incident documented at:
[MetaCPAN API - Indexing failed](https://github.com/metacpan/metacpan-docker/issues/47)

It introduces some of the same functionality like:
[Clear Unknown Indices](https://github.com/metacpan/metacpan-api/pull/1065)
which is required to create meaningful tests.