### PR TITLE
Apply coercion to allow round-trip of boolean through JSON

### DIFF
--- a/lib/MetaCPAN/Document/Author.pm
+++ b/lib/MetaCPAN/Document/Author.pm
@@ -106,6 +106,7 @@ has updated => (
 has is_pause_custodial_account => (
     is      => 'ro',
     isa     => Bool,
+    coerce  => 1,
     default => 0,
 );
 


### PR DESCRIPTION
The field is_pause_custodial_account is declared as a Bool, but this type restricts values to empty string, zero or one.  When served as a JSON document, this gets converted to a JSON boolean 'true' or 'false'.  When parsed back to Perl, this becomes a JSON::Boolean object.  JSON::Boolean objects do not match the type constraint of Bool, and cannot be used to construct ..Document::Author. In particular, this is breaking the ability to update the profiles of metacpan in metacpan/metacpan-web/issues/2694

Adding `coerce => 1` allows the JSON::Boolean to get transformed to '' or 1, permitting a round trip without changing any representation of the boolean publicly or internally.

Other possible solutions:
  - Change the 'Bool' type constraint to allow JSON::Boolean.  This has a side effect of letting the attribute value continue to be a JSON::Boolean object after construction, which could break other perl code if it does things like test whether the input is a reference, or other non-boolean behavior.
  - Update the JSON serializer to emit the field without converting to a JSON native boolean.  This is probably undesirable for any client other than Perl.
  - Update the JSON deserializer to flatten JSON::Boolean objects to '' or 1 before passing them to the object constructor.  That is probably the best solution, but is more work and more invasive.

If people decide that this `coerce => 1` is the desired fix, the other Bool fields of the project should probably be updated to match.