### PR TITLE
Fix GH dep update workflow

### DIFF
--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   update-dep:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     container:
       image: perl:5.36
     steps:

--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -12,20 +12,17 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.METACPAN_BOT_TOKEN }}
-      - name: Get cpm
-        run: |
-          curl -sL -o $RUNNER_TEMP/cpm https://git.io/cpm
-          chmod +x $RUNNER_TEMP/cpm
       - name: Install deps
-        run: >
-          $RUNNER_TEMP/cpm
-          install
-          --cpanfile cpanfile
-          --resolver metacpan
-          --show-build-log-on-failure
-          --local-lib-contained=local
+        uses: perl-actions/install-with-cpm@stable
+        with:
+          cpanfile: cpanfile
+          sudo: false
+          args: >
+            --resolver metacpan
+            --show-build-log-on-failure
+            --local-lib-contained=local
       - name: Maybe update cpanfile.snapshot
-        run: perl -Ilocal/lib/perl5 local/bin/carton
+        run: carton
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:


### PR DESCRIPTION
- Bump CI Ubuntu from 20.04 to 22.04
- Use perl-actions/install-with-cpm for GH action install
