### PR TITLE
Fixes to CVE data and end points

### DIFF
--- a/lib/MetaCPAN/Document/CVE/Set.pm
+++ b/lib/MetaCPAN/Document/CVE/Set.pm
@@ -11,7 +11,11 @@ has query_cve => (
     isa     => 'MetaCPAN::Query::CVE',
     lazy    => 1,
     builder => '_build_query_cve',
-    handles => [qw< find_cves_by_cpansa find_cves_by_release >],
+    handles => [ qw<
+        find_cves_by_cpansa
+        find_cves_by_release
+        find_cves_by_dist
+    > ],
 );
 
 sub _build_query_cve {

--- a/lib/MetaCPAN/Query/CVE.pm
+++ b/lib/MetaCPAN/Query/CVE.pm
@@ -22,9 +22,9 @@ sub find_cves_by_cpansa {
 }
 
 sub find_cves_by_release {
-    my ( $self, $release_id ) = @_;
+    my ( $self, $author, $release ) = @_;
 
-    my $query = +{ match => { releases => $release_id } };
+    my $query = +{ match => { releases => "$author/$release" } };
 
     my $res = $self->es->search(
         index => $self->index_name,

--- a/lib/MetaCPAN/Query/CVE.pm
+++ b/lib/MetaCPAN/Query/CVE.pm
@@ -38,5 +38,27 @@ sub find_cves_by_release {
     return +{ cve => [ map { $_->{_source} } @{ $res->{hits}{hits} } ] };
 }
 
+sub find_cves_by_dist {
+    my ( $self, $dist, $version ) = @_;
+
+    my $query = +{
+        match => {
+            dist => $dist,
+            ( defined $version ? ( versions => $version ) : () ),
+        }
+    };
+
+    my $res = $self->es->search(
+        index => $self->index_name,
+        type  => 'cve',
+        body  => {
+            query => $query,
+            size  => 999,
+        }
+    );
+
+    return +{ cve => [ map { $_->{_source} } @{ $res->{hits}{hits} } ] };
+}
+
 __PACKAGE__->meta->make_immutable;
 1;

--- a/lib/MetaCPAN/Query/CVE.pm
+++ b/lib/MetaCPAN/Query/CVE.pm
@@ -17,7 +17,6 @@ sub find_cves_by_cpansa {
             size  => 999,
         }
     );
-    $res->{hits}{total} or return {};
 
     return +{ cve => [ map { $_->{_source} } @{ $res->{hits}{hits} } ] };
 }
@@ -35,7 +34,6 @@ sub find_cves_by_release {
             size  => 999,
         }
     );
-    $res->{hits}{total} or return {};
 
     return +{ cve => [ map { $_->{_source} } @{ $res->{hits}{hits} } ] };
 }

--- a/lib/MetaCPAN/Script/Mapping/CVE.pm
+++ b/lib/MetaCPAN/Script/Mapping/CVE.pm
@@ -22,13 +22,15 @@ sub mapping {
             "type" : "string"
           },
           "distribution" : {
-            "type" : "string"
+            "type" : "string",
+            "index" : "not_analyzed"
           },
           "references" : {
             "type" : "string"
           },
           "releases" : {
-            "type" : "string"
+            "type" : "string",
+            "index" : "not_analyzed"
           },
           "reported" : {
             "type" : "date",
@@ -38,7 +40,8 @@ sub mapping {
             "type" : "string"
           },
           "versions" : {
-            "type" : "string"
+            "type" : "string",
+            "index" : "not_analyzed"
           }
         }
       }';

--- a/lib/MetaCPAN/Server/Controller/CVE.pm
+++ b/lib/MetaCPAN/Server/Controller/CVE.pm
@@ -21,4 +21,11 @@ sub release : Path('release') : Args(2) {
         $self->model($c)->find_cves_by_release( $author, $release ) );
 }
 
+sub dist : Path('dist') : Args(1) {
+    my ( $self, $c, $dist ) = @_;
+    my $version = $c->req->query_params->{version};
+    $c->stash_or_detach(
+        $self->model($c)->find_cves_by_dist( $dist, $version ) );
+}
+
 1;

--- a/lib/MetaCPAN/Server/Controller/CVE.pm
+++ b/lib/MetaCPAN/Server/Controller/CVE.pm
@@ -15,10 +15,10 @@ sub get : Path('') : Args(1) {
     $c->stash_or_detach( $self->model($c)->find_cves_by_cpansa($cpansa_id) );
 }
 
-sub release : Path('release') : Args(1) {
-    my ( $self, $c, $release_id ) = @_;
+sub release : Path('release') : Args(2) {
+    my ( $self, $c, $author, $release ) = @_;
     $c->stash_or_detach(
-        $self->model($c)->find_cves_by_release($release_id) );
+        $self->model($c)->find_cves_by_release( $author, $release ) );
 }
 
 1;


### PR DESCRIPTION
The `distribution`, `versions`, and `releases` fields need to be set to `"not_analyzed"` so they are matched exactly rather than as full text searches. This fixes #1103.

The `releases` field should be have `"$author/$release"`, not just `"$release"`. Together, they uniquely identify a release.

Returning an empty array is generally more friendly than returning a not found or empty result.