### PR TITLE
release/recent: fix warnings + page_size

### DIFF
--- a/lib/MetaCPAN/Query/Release.pm
+++ b/lib/MetaCPAN/Query/Release.pm
@@ -829,6 +829,10 @@ sub _get_depended_releases {
 
 sub recent {
     my ( $self, $page, $page_size, $type ) = @_;
+    $page      //= 1;
+    $page_size //= 10000;
+    $type      //= '';
+
     my $query;
     my $from = ( $page - 1 ) * $page_size;
 


### PR DESCRIPTION
Some internal values are incorrect due to lack of defaults. This caused 'page_size' not to work when not combined with 'page'