### PR TITLE
Revert "Bug fix: fix param order (GH#1126)"

### DIFF
--- a/lib/MetaCPAN/Server/Controller/Release.pm
+++ b/lib/MetaCPAN/Server/Controller/Release.pm
@@ -79,7 +79,7 @@ sub latest_by_author : Path('latest_by_author') : Args(1) {
 
 sub all_by_author : Path('all_by_author') : Args(1) {
     my ( $self, $c, $pauseid ) = @_;
-    my @params = @{ $c->req->params }{qw( page_size page )};
+    my @params = @{ $c->req->params }{qw( page page_size )};
     $c->stash_or_detach(
         $self->model($c)->all_by_author( $pauseid, @params ) );
 }


### PR DESCRIPTION
This reverts commit 7ae412956ee7acecf5203c9149508cc0daa10053.

This change is not working properly - the params are now received in the wrong order.

Need to check why the names of the params in the URL are reversed (page and size) when read inside the handler.