### PR TITLE
Revert "Revert "Bug fix: fix param order (GH#1126)""

### DIFF
--- a/lib/MetaCPAN/Server/Controller/Release.pm
+++ b/lib/MetaCPAN/Server/Controller/Release.pm
@@ -79,7 +79,7 @@ sub latest_by_author : Path('latest_by_author') : Args(1) {
 
 sub all_by_author : Path('all_by_author') : Args(1) {
     my ( $self, $c, $pauseid ) = @_;
-    my @params = @{ $c->req->params }{qw( page page_size )};
+    my @params = @{ $c->req->params }{qw( page_size page )};
     $c->stash_or_detach(
         $self->model($c)->all_by_author( $pauseid, @params ) );
 }


### PR DESCRIPTION
This reverts commit 781f2141c08ccdb25e7ddc29a34940df9a3e0074.

The front end had been supplying the parameters incorrectly, and the API was accepting them incorrectly. So the front end was displaying correctly, but the API was incorrect. Fixing the API broke the pagination, which led to the original revert. The front end has now been fixed, so the API fix needs to be re-applied.