### PR TITLE
fix installing rsync by specifying a minimum rather than exact version

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,4 +1,0 @@
----
-ignored:
-    # PDL3007 asks you to pin the FROM version explicitly to a release tag.
-    - DL3007

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# hadolint ignore=DL3007
 FROM metacpan/metacpan-base:latest
 
 COPY cpanfile cpanfile.snapshot /metacpan-api/
@@ -9,7 +10,7 @@ WORKDIR /metacpan-api
 # size of the images.
 RUN mkdir /CPAN \
     && apt-get update \
-    && apt-get install -y --no-install-recommends rsync=3.2.3-4+deb11u1 jq \
+    && apt-get satisfy -y --no-install-recommends 'rsync (>= 3.2.3)' 'jq (>= 1.6)' \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && cpm install --global \


### PR DESCRIPTION
hadolint complains about installing apt packages without specifying a version. For rsync, this is exceedingly unlikely to be a problem, but still in spirit it makes sense to be more explicit. Specifying the version explicitly has caused problems several times because our base image has changed, and the given versions are no longer available.

Instead of specifying an exact package, we can use apt-get satisfy, which accepts a version string that can specify a minimum version.

I'm not sure if hadolint understands apt-get satisfy, but this stops it from complaining. And it already wasn't complaining about not specifying jq's version.

Also move the ignore rule about using a latest tag to an inline comment rather than in a separate file. This means it explicitly only covers the metacpan-base image, rather than any other image that could be in the file. Currently, there aren't any targets, but they could be added in the future and if they are using images that we don't control, we shouldn't be using latest.