### PR TITLE
log CDN purges

### DIFF
--- a/lib/MetaCPAN/Role/Script.pm
+++ b/lib/MetaCPAN/Role/Script.pm
@@ -392,6 +392,15 @@ sub are_you_sure {
     return $iconfirmed;
 }
 
+before perform_purges => sub {
+    my ($self) = @_;
+    if ( $self->has_surrogate_keys_to_purge ) {
+        log_info {
+            "CDN Purge: " . join ', ', $self->surrogate_keys_to_purge;
+        };
+    }
+};
+
 1;
 
 __END__

--- a/lib/MetaCPAN/Server.pm
+++ b/lib/MetaCPAN/Server.pm
@@ -150,6 +150,17 @@ sub stash_or_detach {
         ['The requested info could not be found'] );
 }
 
+before perform_purges => sub {
+    my ($self) = @_;
+    if ( $self->has_surrogate_keys_to_purge ) {
+        my $log = $self->log;
+        return
+            unless $log->is_info;
+        $log->info( "CDN Purge: " . join ', ',
+            $self->surrogate_keys_to_purge );
+    }
+};
+
 1;
 
 __END__


### PR DESCRIPTION
The number of purges at Fastly seems very large. Logging the purges should help track down why.