### PR TITLE
fix author indexing

### DIFF
--- a/lib/MetaCPAN/Script/Author.pm
+++ b/lib/MetaCPAN/Script/Author.pm
@@ -103,6 +103,7 @@ sub index_authors {
 
     my $scroll = $self->es->scroll_helper(
         index       => $self->index->name,
+        type        => 'author',
         search_type => 'scan',
         size        => 500,
         body        => {

--- a/lib/MetaCPAN/Script/Author.pm
+++ b/lib/MetaCPAN/Script/Author.pm
@@ -224,8 +224,19 @@ sub update_author {
         return;
     }
 
-    return
-        unless diff_struct( $current_data, $data );
+    if ( my $diff = diff_struct( $current_data, $data ) ) {
+
+        # log a sampling of differences
+        if ( $self->has_surrogate_keys_to_purge % 10 == 9 ) {
+            Dlog_debug {
+                "Found difference in $pauseid: $_"
+            }
+            $diff;
+        }
+    }
+    else {
+        return;
+    }
 
     $data->{updated} = DateTime->now( time_zone => 'UTC' )->iso8601;
 

--- a/lib/MetaCPAN/Util.pm
+++ b/lib/MetaCPAN/Util.pm
@@ -163,34 +163,36 @@ sub single_valued_arrayref_to_scalar {
 }
 
 sub diff_struct {
-    my (@queue) = [@_];
+    my (@queue) = [ @_, '' ];
 
     while ( my $check = shift @queue ) {
-        my ( $old, $new, $allow_extra ) = @$check;
+        my ( $old, $new, $path ) = @$check;
         if ( !defined $new ) {
-            return !!1
+            return [ $path, $old, $new ]
                 if defined $old;
         }
         elsif ( !is_ref($new) ) {
-            return !!1
+            return [ $path, $old, $new ]
                 if is_ref($old)
                 or $new ne $old;
         }
         elsif ( is_plain_arrayref($new) ) {
-            return !!1
+            return [ $path, $old, $new ]
                 if !is_plain_arrayref($old) || @$new != @$old;
-            push @queue, map [ $old->[$_], $new->[$_] ], 0 .. $#$new;
+            push @queue, map [ $old->[$_], $new->[$_], "$path/$_" ],
+                0 .. $#$new;
         }
         elsif ( is_plain_hashref($new) ) {
-            return !!1
+            return [ $path, $old, $new ]
                 if !is_plain_hashref($old) || keys %$new != keys %$old;
-            push @queue, map [ $old->{$_}, $new->{$_} ], keys %$new;
+            push @queue, map [ $old->{$_}, $new->{$_}, "$path/$_" ],
+                keys %$new;
         }
         else {
-            die "can't compare $new type data";
+            die "can't compare $new type data at $path";
         }
     }
-    return !!0;
+    return undef;
 }
 
 1;

--- a/lib/MetaCPAN/Util.pm
+++ b/lib/MetaCPAN/Util.pm
@@ -163,10 +163,11 @@ sub single_valued_arrayref_to_scalar {
 }
 
 sub diff_struct {
-    my (@queue) = [ @_, '' ];
+    my ( $old_root, $new_root, $allow_extra ) = @_;
+    my (@queue) = [ $old_root, $new_root, '', $allow_extra ];
 
     while ( my $check = shift @queue ) {
-        my ( $old, $new, $path ) = @$check;
+        my ( $old, $new, $path, $allow_extra ) = @$check;
         if ( !defined $new ) {
             return [ $path, $old, $new ]
                 if defined $old;
@@ -184,7 +185,8 @@ sub diff_struct {
         }
         elsif ( is_plain_hashref($new) ) {
             return [ $path, $old, $new ]
-                if !is_plain_hashref($old) || keys %$new != keys %$old;
+                if !is_plain_hashref($old)
+                || !$allow_extra && keys %$new != keys %$old;
             push @queue, map [ $old->{$_}, $new->{$_}, "$path/$_" ],
                 keys %$new;
         }


### PR DESCRIPTION
Fixes some issues introduced by my recent author indexing changes.

We need to limit out scroll search to only the author type or it gives us every document and takes forever (even if skipping the other documents).

Also we need to allow extra fields at the top level of the structure when comparing, because some fields can be added by the front end. And since we won't overwrite them, they should be ignored when comparing.

Adds some logging about author differences, since we shouldn't ever have to update all that many authors. Log the difference we found for every 10th change found.