### PR TITLE
Switch CircleCI resource class from medium to large

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ workflows:
 jobs:
   build-and-test:
     machine: true
-    resource_class: medium
+    resource_class: large
     steps:
       - run:
           name: docker-compose version


### PR DESCRIPTION
This decreases build time from 20 minutes to 14 minutes. We're not even close to our maximum build minutes for April and we have been running a lot of builds this week, so we should be safe with this setting.