### PR TITLE
drop support for metacpan_script

### DIFF
--- a/lib/MetaCPAN/Server/QuerySanitizer.pm
+++ b/lib/MetaCPAN/Server/QuerySanitizer.pm
@@ -37,14 +37,6 @@ sub _scan_hash_tree {
             }
             _scan_hash_tree($v) if ref $v;
         }
-        if ( my $mscript = delete $struct->{metacpan_script} ) {
-            $struct->{script_score} = {
-                script => {
-                    lang => 'groovy',
-                    file => $mscript
-                },
-            };
-        }
     }
     elsif ( $ref eq 'ARRAY' ) {
         foreach my $item (@$struct) {


### PR DESCRIPTION
We no longer need metacpan_script for anything our code uses, and supporting it complicates our query filtering and interactions with Elasticsearch.

We've generally been trying to move away from users interacting via Elasticsearch queries, but if they really need to and need a specific script, they are always welcome to submit a PR to the API adding what they need.