### PR TITLE
use inline expression script for preferring short module names

### DIFF
--- a/lib/MetaCPAN/Model/Search.pm
+++ b/lib/MetaCPAN/Model/Search.pm
@@ -297,8 +297,9 @@ sub build_query {
                             # prefer shorter module names
                             script_score => {
                                 script => {
-                                    lang => 'groovy',
-                                    file => 'prefer_shorter_module_names_400',
+                                    lang   => 'expression',
+                                    inline =>
+                                        "_score - (doc['documentation_length'].value == 0 ? 26 : doc['documentation_length'].value)/400",
                                 },
                             },
                             query => {


### PR DESCRIPTION
The 'expression' language is faster, more secure, and supported on modern versions of Elasticsearch. It requires numeric fields. Now that we have the numeric `documentation_length` field, we can use it to prefer shorter names rather than needing to put files onto the ES servers.