### PR TITLE
provide scrolled search for ratings with a fake id

### DIFF
--- a/lib/MetaCPAN/Server/Controller/Scroll.pm
+++ b/lib/MetaCPAN/Server/Controller/Scroll.pm
@@ -34,6 +34,25 @@ sub index : Path('/_search/scroll') : Args {
         };
     }
 
+    if ( $scroll_id eq 'FAKE_SCROLL_ID' ) {
+        $c->stash( {
+            _scroll_id => $scroll_id,
+            _shards    => {
+                failed     => 0,
+                successful => 0,
+                total      => 0,
+            },
+            hits => {
+                hits      => [],
+                max_score => undef,
+                total     => 0,
+            },
+            timed_out => \0,
+            took      => 0,
+        } );
+        return;
+    }
+
     my $res = eval {
         $c->model('CPAN')->es->scroll( {
             scroll_id => $scroll_id,

--- a/t/server/controller/rating.t
+++ b/t/server/controller/rating.t
@@ -4,6 +4,7 @@ use lib 't/lib';
 
 use MetaCPAN::Server::Test;
 use MetaCPAN::TestHelpers qw( decode_json_ok test_cache_headers );
+use Cpanel::JSON::XS      qw(encode_json);
 use Test::More;
 
 test_psgi app, sub {
@@ -44,8 +45,8 @@ test_psgi app, sub {
 
     ok(
         $res = $cb->(
-            POST '/rating/_search',
-            Content => '{"query":{"term":{"distribution":"Moose"}}}'
+            POST '/rating',
+            Content => '{"query":{"term":{"distribution":"Moose"}}}',
         ),
         'POST /rating'
     );
@@ -55,6 +56,62 @@ test_psgi app, sub {
     $ratings = decode_json_ok($res);
 
     is_deeply $ratings->{hits}{hits}, [], 'no hits';
+
+    ok(
+        $res = $cb->(
+            POST '/rating/_search?scroll=5m',
+            Content => '{"query":{"term":{"distribution":"Moose"}}}',
+        ),
+        'POST /rating'
+    );
+
+    is $res->code, 200, 'found';
+
+    $ratings = decode_json_ok($res);
+
+    is_deeply $ratings->{hits}{hits}, [], 'no hits';
+
+    is_deeply $ratings->{_scroll_id}, 'FAKE_SCROLL_ID',
+        'gives fake scroll id';
+
+    ok(
+        $res
+            = $cb->( POST "/_search/scroll/$ratings->{_scroll_id}?scroll=5m",
+            ),
+        'POST /_search/scroll/$id',
+    );
+
+    is $res->code, 200, 'found'
+        or diag $res->as_string;
+
+    $ratings = decode_json_ok($res);
+
+    is_deeply $ratings->{hits}{hits}, [], 'working with no hits';
+    is $ratings->{_shards}{total}, 0, 'results are fake';
+
+    ok(
+        $res = $cb->(
+            POST '/rating/_search',
+            'User-Agent' => 'MetaCPAN::Client-testing/2.031001',
+            Content      => '{"query":{"term":{"distribution":"Moose"}}}',
+        ),
+        'POST /rating with MetaCPAN::Client test UA'
+    );
+
+    is $res->code, 200, 'found';
+
+    $ratings = decode_json_ok($res);
+
+    is_deeply $ratings->{hits}{hits},
+        [
+        {
+            _source => {
+                distribution => 'Moose',
+            },
+        },
+        ],
+        'no hits';
+
 };
 
 done_testing;


### PR DESCRIPTION
MetaCPAN::Client still expects this to work, so provide some fake results.