### PR TITLE
fix parsing of rating end points

### DIFF
--- a/lib/MetaCPAN/Server/Controller/Rating.pm
+++ b/lib/MetaCPAN/Server/Controller/Rating.pm
@@ -28,21 +28,18 @@ sub _mapping : Path('_mapping') : Args(0) {
     $c->detach('/not_found');
 }
 
-sub find : Path('_search') : Args(0) {
+sub find : Path('_search') : Args(0) : ActionClass('~Deserialize') {
     my ( $self, $c, $scroll ) = @_;
 
     my @hits;
 
     # fake results for MetaCPAN::Client so it doesn't fail its tests
-    if ( ( $c->req->user_agent // '' )
-        =~ m{^MetaCPAN::Client-testing/([0-9.]+)} )
-    {
+    if ( ( $c->req->user_agent // '' ) =~ m{^MetaCPAN::Client/([0-9.]+)} ) {
         if ( $1 <= 2.031001 ) {
-            my $query = $c->read_param('query');
+            my $query = $c->req->data->{'query'};
             if (   $query
-                && $query->[0]
-                && $query->[0]{term}
-                && ( $query->[0]{term}{distribution} // '' ) eq 'Moose' )
+                && $query->{term}
+                && ( $query->{term}{distribution} // '' ) eq 'Moose' )
             {
 
                 push @hits,
@@ -72,7 +69,7 @@ sub find : Path('_search') : Args(0) {
     } );
 }
 
-sub all : Path('') : Args(0) {
+sub all : Path('') : Args(0) : ActionClass('~Deserialize') {
     my ( $self, $c ) = @_;
     $c->forward('find');
 }

--- a/t/server/controller/rating.t
+++ b/t/server/controller/rating.t
@@ -92,7 +92,7 @@ test_psgi app, sub {
     ok(
         $res = $cb->(
             POST '/rating/_search',
-            'User-Agent' => 'MetaCPAN::Client-testing/2.031001',
+            'User-Agent' => 'MetaCPAN::Client/2.031001',
             Content      => '{"query":{"term":{"distribution":"Moose"}}}',
         ),
         'POST /rating with MetaCPAN::Client test UA'


### PR DESCRIPTION
The fake rating search end points need the Deserialize ActionClass to parse their body.

Also, MetaCPAN::Client has a bug that prevents it from properly using its testing user agent, so just give the results for normal MC::C UAs.