### PR TITLE
set a 1% theshold for coverage changes

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,3 +6,11 @@ comment:
   require_base: false  # [true :: must have a base report to post]
   require_head: true  # [true :: must have a head report to post]
   hide_project_coverage: false  # [true :: only show coverage on the git diff]
+coverage:
+  status:
+    patch:
+      default:
+        threshold: 1%
+    project:
+      default:
+        threshold: 1%


### PR DESCRIPTION
Our tests are somewhat inconsistent in their coverage, so coverage can go down slightly even with unrelated changes. We also have untested code, and small tweaks will often be shown as a reduction in coverage.

Setting a 1% threshold will reduce friction on both of these cases. Any larger changes will still require an increase in coverage, so we should still trend upward over time.