### PR TITLE
fix code generation in oauth2 controller

### DIFF
--- a/lib/MetaCPAN/Server/Controller/OAuth2.pm
+++ b/lib/MetaCPAN/Server/Controller/OAuth2.pm
@@ -109,7 +109,7 @@ sub bad_request {
 
 sub _build_code {
     my $digest = Digest::SHA::sha1_base64( rand() . $$ . {} . time );
-    $digest =~ tr/[+\/]/-_/;
+    $digest =~ tr{+/}{-_};
     return $digest;
 }
 


### PR DESCRIPTION
tr takes a character class. Trying to give it a class wrapped in brackets will try to convert the bracket characters. We're just generating a random ID, so it's ok for the format being generated to change.