### PR TITLE
fix digest calculation from misuse or tr

### DIFF
--- a/lib/MetaCPAN/Server/Controller/CVE.pm
+++ b/lib/MetaCPAN/Server/Controller/CVE.pm
@@ -4,7 +4,6 @@ use strict;
 use warnings;
 
 use Moose;
-use MetaCPAN::Util qw( digest );
 
 BEGIN { extends 'MetaCPAN::Server::Controller' }
 

--- a/lib/MetaCPAN/Server/Controller/Contributor.pm
+++ b/lib/MetaCPAN/Server/Controller/Contributor.pm
@@ -4,7 +4,6 @@ use strict;
 use warnings;
 
 use Moose;
-use MetaCPAN::Util qw( digest );
 
 BEGIN { extends 'MetaCPAN::Server::Controller' }
 

--- a/lib/MetaCPAN/Server/Controller/Cover.pm
+++ b/lib/MetaCPAN/Server/Controller/Cover.pm
@@ -4,7 +4,6 @@ use strict;
 use warnings;
 
 use Moose;
-use MetaCPAN::Util qw( digest );
 
 BEGIN { extends 'MetaCPAN::Server::Controller' }
 

--- a/lib/MetaCPAN/Util.pm
+++ b/lib/MetaCPAN/Util.pm
@@ -48,7 +48,7 @@ sub checkout_root {
 
 sub digest {
     my $digest = sha1_base64( join( "\0", grep {defined} @_ ) );
-    $digest =~ tr/[+\/]/-_/;
+    $digest =~ tr{+/}{-_};
     return $digest;
 }
 


### PR DESCRIPTION
tr/// always transforms character classes. Trying to put a regex character class wrapped in brackets will result in the brackets getting transformed, and other characters getting converted incorrectly.

Fix the tr/// used to generate a digest for an ID. This is only used for the contributors data, which is generally only updated when new releases are indexed. When querying the data, the author and release names are used, not the ID. The old records will continue to be found. If the data is reindexed, an additional record may be created for a release, but it should have the same data.

After making this change, eventually all of the contributor data should be recalculated to make sure the IDs are correct, and the old records purged. But they shouldn't interfere with anything until that is done.