### PR TITLE
Increase version of Module::Metadata

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -87,7 +87,7 @@ requires 'MIME::Base64', '3.15';
 requires 'Minion', '9.03';
 requires 'Minion::Backend::SQLite';
 requires 'Module::Load';
-requires 'Module::Metadata', '1.000022';
+requires 'Module::Metadata', '1.000038';
 requires 'Module::Pluggable';
 requires 'Module::Runtime';
 requires 'Mojolicious::Plugin::MountPSGI', '0.14';


### PR DESCRIPTION
So MetaCPAN understands packages that are `class`es