### PR TITLE
A large CircleCI VM can able to handle 4 test jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,8 @@
 # Use the latest 2.1 version of CircleCI pipeline process engine. See:
 # https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
+orbs:
+  codecov: codecov/codecov@4.1.0
 # Orchestrate or schedule a set of jobs
 workflows:
   docker-compose:
@@ -38,42 +40,40 @@ jobs:
             ./bin/metacpan-docker init
             docker-compose --verbose up -d api_test
           name: compose up
+      - run:
+          command: |
+            pushd metacpan-docker
+            docker-compose exec -T api_test cpm install -g Devel::Cover
+          name: install Devel::Cover
       # Since we're running docker-compose -d, we don't actually know if
       # Elasticsearch is available at the time this build step begins. We
       # probably need to wait for it here, so we'll add our own check.
       - run:
           command: |
             pushd metacpan-docker
-            ./src/metacpan-api/wait-for-es.sh http://localhost:9200 elasticsearch_test --
+            ./src/metacpan-api/wait-for-es.sh http://localhost:9200 elasticsearch_test
           name: wait for ES
-      # We are running coverage inside the container, but creating the report
-      # from outside of the container, so Devel::Cover is installed twice. We
-      # are relying on environment variables from the host to be available when
-      # we publish the report, so we publish from the host rather than trying
-      # to propagate env variables to the container. There is a CircleCI orb
-      # that can publish the report for us, but it is hard to debug. I had to
-      # set up the following config in order to debug the orb, so we may as
-      # well keep it around for now.
       - run:
           command: |
             pushd metacpan-docker
-            docker-compose exec -T api_test cpm install -g Devel::Cover
-          name: install Devel::Cover
-      - run:
-          command: |
-            pushd metacpan-docker
-            docker-compose exec -T api_test env HARNESS_PERL_SWITCHES="-MDevel::Cover=+ignore,^t/|^test-data/|^etc/" prove -lr --jobs 2 t
+            docker-compose exec -T api_test env HARNESS_PERL_SWITCHES="-MDevel::Cover=+ignore,^t/|^test-data/|^etc/" prove -lr --jobs 4 t
           name: run tests with coverage
-      # The report ends up being owned by root. We need to chown it so that
-      # the cover command can make changes to it.
+      # We are relying on environment variables from the host to be available when
+      # we publish the report, so we publish from the host rather than trying
+      # to propagate env variables to the container.
+      - run:
+          command: |
+            pushd metacpan-docker
+            docker-compose exec -T api_test cover -report json
+          name: create coverage report
+      # The report ends up being owned by root, but we may not need to chown it.
       - run:
           command: |
             pushd metacpan-docker/src/metacpan-api
-            sudo apt install cpanminus
-            sudo cpanm --notest Devel::Cover Devel::Cover::Report::Codecov Devel::Cover::Report::Codecovbash
             sudo chown -R circleci.circleci cover_db
-            cover -report codecov
-          name: upload coverage report
+          name: chown coverage report
+      - codecov/upload:
+          file: metacpan-docker/src/metacpan-api/cover_db/cover.json
       - run:
           command: |
             pushd metacpan-docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,12 +66,6 @@ jobs:
             pushd metacpan-docker
             docker-compose exec -T api_test cover -report json
           name: create coverage report
-      # The report ends up being owned by root, but we may not need to chown it.
-      - run:
-          command: |
-            pushd metacpan-docker/src/metacpan-api
-            sudo chown -R circleci.circleci cover_db
-          name: chown coverage report
       - codecov/upload:
           file: metacpan-docker/src/metacpan-api/cover_db/cover.json
       - run:


### PR DESCRIPTION
This PR:
* reduces the CircleCI build time by ~10%
* simplifies the CircleCI config by using an official Orb rather than deprecated code