### PR TITLE
use primary branch in metacpan-docker when testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,6 @@ jobs:
           command: |
             git clone https://github.com/metacpan/metacpan-docker.git
             cd metacpan-docker
-            git switch oalders/cloud-config
           name: metacpan-docker checkout
       - checkout:
           path: metacpan-docker/src/metacpan-api


### PR DESCRIPTION
The oalders/cloud-config branch has been merged and deleted.