### PR TITLE
remove use of search_type scan

### DIFF
--- a/lib/MetaCPAN/Script/Author.pm
+++ b/lib/MetaCPAN/Script/Author.pm
@@ -135,11 +135,10 @@ sub index_authors {
     );
 
     my $scroll = $self->es->scroll_helper(
-        index       => $self->index->name,
-        type        => 'author',
-        search_type => 'scan',
-        size        => 500,
-        body        => {
+        index => $self->index->name,
+        type  => 'author',
+        size  => 500,
+        body  => {
             query => {
                 $self->pauseid
                 ? (
@@ -150,6 +149,7 @@ sub index_authors {
                 : ( match_all => {} ),
             },
             _source => [@compare_fields],
+            sort    => '_doc',
         },
     );
 

--- a/lib/MetaCPAN/Script/Backup.pm
+++ b/lib/MetaCPAN/Script/Backup.pm
@@ -75,10 +75,12 @@ sub run {
     my $scroll = $es->scroll_helper(
         index => $self->index->name,
         $self->type ? ( type => $self->type ) : (),
-        size        => $self->size,
-        search_type => 'scan',
-        fields      => [qw(_parent _source)],
-        scroll      => '1m',
+        size   => $self->size,
+        fields => [qw(_parent _source)],
+        scroll => '1m',
+        body   => {
+            sort => '_doc',
+        },
     );
 
     log_info { 'Backing up ', $scroll->total, ' documents' };

--- a/lib/MetaCPAN/Script/CPANTesters.pm
+++ b/lib/MetaCPAN/Script/CPANTesters.pm
@@ -85,10 +85,12 @@ sub index_reports {
     bunzip2 "$db.bz2" => "$db", AutoClose => 1 if -e "$db.bz2";
 
     my $scroll = $es->scroll_helper(
-        index       => $self->index->name,
-        search_type => 'scan',
-        size        => '500',
-        type        => 'release',
+        index => $self->index->name,
+        size  => '500',
+        type  => 'release',
+        body  => {
+            sort => '_doc',
+        },
     );
 
     my %releases;

--- a/lib/MetaCPAN/Script/CPANTestersAPI.pm
+++ b/lib/MetaCPAN/Script/CPANTestersAPI.pm
@@ -62,10 +62,12 @@ sub index_reports {
     my $data = decode_json $json;
 
     my $scroll = $es->scroll_helper(
-        index       => $self->index->name,
-        search_type => 'scan',
-        size        => '500',
-        type        => 'release',
+        index => $self->index->name,
+        size  => '500',
+        type  => 'release',
+        body  => {
+            sort => '_doc',
+        },
     );
 
     # Create a cache of all releases (dist + version combos)

--- a/lib/MetaCPAN/Script/Mapping.pm
+++ b/lib/MetaCPAN/Script/Mapping.pm
@@ -411,17 +411,17 @@ sub _copy_slice {
     my ( $self, $query, $index, $type ) = @_;
 
     my $scroll = $self->es->scroll_helper(
-        search_type => 'scan',
-        size        => 250,
-        scroll      => '10m',
-        index       => $self->index->name,
-        type        => $type,
-        body        => {
+        size   => 250,
+        scroll => '10m',
+        index  => $self->index->name,
+        type   => $type,
+        body   => {
             query => {
                 filtered => {
                     query => $query
                 }
-            }
+            },
+            sort => '_doc',
         },
     );
 
@@ -453,12 +453,14 @@ sub empty_type {
     );
 
     my $scroll = $self->es->scroll_helper(
-        search_type => 'scan',
-        size        => 250,
-        scroll      => '10m',
-        index       => $self->index->name,
-        type        => $type,
-        body        => { query => { match_all => {} } },
+        size   => 250,
+        scroll => '10m',
+        index  => $self->index->name,
+        type   => $type,
+        body   => {
+            query => { match_all => {} },
+            sort  => '_doc',
+        },
     );
 
     my @ids;

--- a/lib/MetaCPAN/Script/Suggest.pm
+++ b/lib/MetaCPAN/Script/Suggest.pm
@@ -63,20 +63,20 @@ sub _update_slice {
     my ( $self, $range ) = @_;
 
     my $files = $self->es->scroll_helper(
-        index       => $self->index->name,
-        type        => 'file',
-        search_type => 'scan',
-        scroll      => '5m',
-        fields      => [qw< id documentation >],
-        size        => 500,
-        body        => {
+        index  => $self->index->name,
+        type   => 'file',
+        scroll => '5m',
+        fields => [qw< id documentation >],
+        size   => 500,
+        body   => {
             query => {
                 bool => {
                     must => [
                         { exists => { field => "documentation" } }, $range
                     ],
-                }
-            }
+                },
+            },
+            sort => '_doc',
         },
     );
 

--- a/lib/MetaCPAN/Script/Watcher.pm
+++ b/lib/MetaCPAN/Script/Watcher.pm
@@ -109,8 +109,9 @@ sub backpan_changes {
                             filter => { term => { status => 'backpan' } }
                         }
                     },
-                }
-            }
+                },
+            },
+            sort => '_doc',
         }
     } );
     my @changes;
@@ -183,13 +184,12 @@ sub reindex_release {
 
     my $es     = $self->es;
     my $scroll = $es->scroll_helper( {
-        index       => $self->index->name,
-        type        => 'file',
-        scroll      => '1m',
-        size        => 1000,
-        search_type => 'scan',
-        fields      => [ '_parent', '_source' ],
-        body        => {
+        index  => $self->index->name,
+        type   => 'file',
+        scroll => '1m',
+        size   => 1000,
+        fields => [ '_parent', '_source' ],
+        body   => {
             query => {
                 filtered => {
                     query  => { match_all => {} },
@@ -208,8 +208,9 @@ sub reindex_release {
                         ]
                     }
                 }
-            }
-        }
+            },
+            sort => '_doc',
+        },
     } );
     return if ( $self->dry_run );
 


### PR DESCRIPTION
search_type: scan has been removed from newer Elasticsearch versions,
replaced with sort: _doc.