### PR TITLE
remove index option from scripts and reimplement it for backup

### DIFF
--- a/bin/cron/author.sh
+++ b/bin/cron/author.sh
@@ -3,7 +3,4 @@
 # export ES_SCRIPT_INDEX=author_01
 # /home/metacpan/bin/metacpan-api-carton-exec bin/metacpan author --index author_01
 
-export ES_SCRIPT_INDEX=cpan_v1_01
-/home/metacpan/bin/metacpan-api-carton-exec bin/metacpan author --index cpan_v1_01
-
-unset ES_SCRIPT_INDEX
+/home/metacpan/bin/metacpan-api-carton-exec bin/metacpan author

--- a/bin/cron/backups.sh
+++ b/bin/cron/backups.sh
@@ -1,16 +1,6 @@
 #!/bin/sh
 
-#export ES_SCRIPT_INDEX=favorite_01
-#/home/metacpan/bin/metacpan-api-carton-exec bin/metacpan backup --index favorite_01 --type favorite
-
-#export ES_SCRIPT_INDEX=author_01
-#/home/metacpan/bin/metacpan-api-carton-exec bin/metacpan backup --index author_01 --type author
-
-export ES_SCRIPT_INDEX=cpan_v1_01
 /home/metacpan/bin/metacpan-api-carton-exec bin/metacpan backup --index cpan_v1_01 --type favorite
 /home/metacpan/bin/metacpan-api-carton-exec bin/metacpan backup --index cpan_v1_01 --type author
 
-export ES_SCRIPT_INDEX=user
 /home/metacpan/bin/metacpan-api-carton-exec bin/metacpan backup --index user
-
-unset ES_SCRIPT_INDEX

--- a/lib/MetaCPAN/Model.pm
+++ b/lib/MetaCPAN/Model.pm
@@ -44,7 +44,7 @@ analyzer edge => (
 
 index cpan => (
     namespace => 'MetaCPAN::Document',
-    alias_for => ( $ENV{'ES_SCRIPT_INDEX'} || 'cpan_v1_01' ),
+    alias_for => 'cpan_v1_01',
     shards    => 3
 );
 

--- a/lib/MetaCPAN/Role/Script.pm
+++ b/lib/MetaCPAN/Role/Script.pm
@@ -86,16 +86,6 @@ has model => (
     traits   => ['NoGetopt'],
 );
 
-has index => (
-    reader        => '_index',
-    is            => 'ro',
-    isa           => Str,
-    lazy          => 1,
-    default       => 'cpan',
-    documentation =>
-        'Index to use, defaults to "cpan" (when used: also export ES_SCRIPT_INDEX)',
-);
-
 has cluster_info => (
     isa     => HashRef,
     traits  => ['Hash'],
@@ -158,20 +148,6 @@ has queue => (
     documentation => 'add indexing jobs to the minion queue',
 );
 
-sub BUILDARGS {
-    my ( $self, @args ) = @_;
-    my %args = @args == 1 ? %{ $args[0] } : @args;
-
-    if ( exists $args{index} ) {
-        die
-            "when setting --index, please export ES_SCRIPT_INDEX to the same value\n"
-            unless $ENV{ES_SCRIPT_INDEX}
-            and $args{index} eq $ENV{ES_SCRIPT_INDEX};
-    }
-
-    return \%args;
-}
-
 sub handle_error {
     my ( $self, $error, $die_always ) = @_;
 
@@ -194,7 +170,7 @@ sub print_error {
 
 sub index {
     my $self = shift;
-    return $self->model->index( $self->_index );
+    return $self->model->index('cpan');
 }
 
 sub _build_model {

--- a/lib/MetaCPAN/Types/TypeTiny.pm
+++ b/lib/MetaCPAN/Types/TypeTiny.pm
@@ -18,6 +18,8 @@ use Type::Library -base, -declare => ( qw(
 
     Logger
     HashRefCPANMeta
+
+    CommaSepOption
 ) );
 use Type::Utils qw( as coerce declare extends from via );
 
@@ -125,5 +127,10 @@ if ( eval { require MooseX::Getopt; 1 } ) {
         MooseX::Getopt::OptionTypeMap->add_option_type_to_map( $type, '=s' );
     }
 }
+
+declare CommaSepOption, as ArrayRef [ StrMatch [qr{^[^, ]+$}] ];
+coerce CommaSepOption, from ArrayRef [Str], via {
+    return [ map split(/\s*,\s*/), @$_ ];
+};
 
 1;


### PR DESCRIPTION
The index option is meant to control the index that has all of our ES data. But in the future, each document type will need to be in a separate index. So the idea of having a global configurable index doesn't make sense.

The backup script needs to be able to operate on all indexes, and works generically with any type. Reimplement an index option for it, allowing multiple indexes to be specified.