### PR TITLE
allow strings for backup script index option

### DIFF
--- a/lib/MetaCPAN/Types/TypeTiny.pm
+++ b/lib/MetaCPAN/Types/TypeTiny.pm
@@ -132,5 +132,8 @@ declare CommaSepOption, as ArrayRef [ StrMatch [qr{^[^, ]+$}] ];
 coerce CommaSepOption, from ArrayRef [Str], via {
     return [ map split(/\s*,\s*/), @$_ ];
 };
+coerce CommaSepOption, from Str, via {
+    return [ map split(/\s*,\s*/), $_ ];
+};
 
 1;


### PR DESCRIPTION
Using command line options, the index option will always be assigned as an arrayref. But the default was still a plain string, which would error if no index option was given. The default could be changed to an array ref, but it also makes sense to coerce a normal string.