### PR TITLE
update CVE data urls

### DIFF
--- a/lib/MetaCPAN/Script/CVE.pm
+++ b/lib/MetaCPAN/Script/CVE.pm
@@ -16,14 +16,14 @@ has cve_url => (
     is      => 'ro',
     isa     => Uri,
     coerce  => 1,
-    default => 'https://hackeriet.github.io/cpansa-feed/cpansa.json',
+    default => 'https://cpan-security.github.io/cpansa-feed/cpansa.json',
 );
 
 has cve_dev_url => (
     is      => 'ro',
     isa     => Uri,
     coerce  => 1,
-    default => 'https://hackeriet.github.io/cpansa-feed/cpansa_dev.json',
+    default => 'https://cpan-security.github.io/cpansa-feed/cpansa_dev.json',
 );
 
 has test => (


### PR DESCRIPTION
The old URLs have stopped working.

I'm not certain that the new URLs are the correct ones, but they seem to be getting updated regularly.

@stigtsp