### PR TITLE
various cleanups

### DIFF
--- a/app.psgi
+++ b/app.psgi
@@ -61,6 +61,9 @@ my $static
 
 my $urlmap = Plack::App::URLMap->new;
 $urlmap->map( '/static' => $static );
-$urlmap->map( '/'       => MetaCPAN::Server->app );
+if ( $ENV{PLACK_ENV} && $ENV{PLACK_ENV} eq 'development' ) {
+    $urlmap->map( '/v1' => MetaCPAN::Server->app );
+}
+$urlmap->map( '/' => MetaCPAN::Server->app );
 
 return $urlmap->to_app;

--- a/cpanfile
+++ b/cpanfile
@@ -113,7 +113,6 @@ requires 'PAUSE::Permissions', '0.17';
 requires 'PerlIO::gzip';
 requires 'Plack', '1.0048';
 requires 'Plack::App::Directory';
-requires 'Plack::Middleware::Header';
 requires 'Plack::Middleware::ReverseProxy';
 requires 'Plack::Middleware::Session';
 requires 'Plack::Session::Store';

--- a/cpanfile
+++ b/cpanfile
@@ -58,7 +58,6 @@ requires 'File::stat';
 requires 'File::Temp';
 requires 'FindBin';
 requires 'Getopt::Long::Descriptive', '0.103';
-requires 'Git::Helpers', '1.000001';
 requires 'Gravatar::URL';
 requires 'Hash::Merge::Simple';
 requires 'HTML::Entities';

--- a/cpanfile
+++ b/cpanfile
@@ -115,7 +115,6 @@ requires 'Plack', '1.0048';
 requires 'Plack::App::Directory';
 requires 'Plack::Middleware::Header';
 requires 'Plack::Middleware::ReverseProxy';
-requires 'Plack::Middleware::Rewrite';
 requires 'Plack::Middleware::Session';
 requires 'Plack::Session::Store';
 requires 'Pod::Markdown', '3.300';
@@ -167,5 +166,4 @@ requires 'Test::Routine', '0.012';
 requires 'Test::Vars', '0.015';
 
 # author requirements
-requires 'Plack::Middleware::Rewrite';
 requires 'App::perlimports';

--- a/cpanfile
+++ b/cpanfile
@@ -45,7 +45,6 @@ requires 'Encoding::FixLatin';
 requires 'Encoding::FixLatin::XS';
 requires 'EV';
 requires 'Exporter', '5.74';
-requires 'ExtUtils::HasCompiler';
 requires 'File::Basename';
 requires 'File::Copy';
 requires 'File::Find';

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -2312,23 +2312,6 @@ DISTRIBUTIONS
       File::Spec 0
       IO::File 0
       perl 5.006
-  ExtUtils-HasCompiler-0.025
-    pathname: L/LE/LEONT/ExtUtils-HasCompiler-0.025.tar.gz
-    provides:
-      ExtUtils::HasCompiler 0.025
-    requirements:
-      Carp 0
-      DynaLoader 0
-      Exporter 0
-      ExtUtils::MakeMaker 0
-      ExtUtils::Mksymlists 0
-      File::Basename 0
-      File::Spec::Functions 0
-      File::Temp 0
-      base 0
-      perl 5.006
-      strict 0
-      warnings 0
   ExtUtils-Helpers-0.028
     pathname: L/LE/LEONT/ExtUtils-Helpers-0.028.tar.gz
     provides:

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -6062,17 +6062,6 @@ DISTRIBUTIONS
       parent 0
       strict 0
       warnings 0
-  Plack-Middleware-Header-0.04
-    pathname: C/CH/CHIBA/Plack-Middleware-Header-0.04.tar.gz
-    provides:
-      Plack::Middleware::Header 0.04
-    requirements:
-      ExtUtils::MakeMaker 6.42
-      Filter::Util::Call 0
-      Plack::Middleware 0
-      Test::More 0
-      parent 0
-      perl 5.008001
   Plack-Middleware-MethodOverride-0.20
     pathname: M/MI/MIYAGAWA/Plack-Middleware-MethodOverride-0.20.tar.gz
     provides:

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -229,14 +229,6 @@ DISTRIBUTIONS
     requirements:
       B 0
       ExtUtils::MakeMaker 0
-  Browser-Open-0.04
-    pathname: C/CF/CFRANKS/Browser-Open-0.04.tar.gz
-    provides:
-      Browser::Open 0.04
-    requirements:
-      ExtUtils::MakeMaker 0
-      Test::More 0.92
-      parent 0
   CGI-Simple-1.281
     pathname: M/MA/MANWAR/CGI-Simple-1.281.tar.gz
     provides:
@@ -2626,47 +2618,6 @@ DISTRIBUTIONS
       overload 0
       perl 5.012
       strict 0
-      warnings 0
-  Git-Helpers-1.000001
-    pathname: O/OA/OALDERS/Git-Helpers-1.000001.tar.gz
-    provides:
-      Git::Helpers 1.000001
-      Git::Helpers::CPAN 1.000001
-    requirements:
-      Browser::Open 0
-      Capture::Tiny 0
-      Carp 0
-      ExtUtils::MakeMaker 0
-      File::pushd 0
-      Getopt::Long 0
-      Git::Sub 0
-      MetaCPAN::Client 2.029000
-      Moo 0
-      MooX::Options 0
-      Pod::Usage 0
-      String::Trim 0
-      Sub::Exporter 0
-      Term::Choose 1.743
-      Try::Tiny 0
-      Types::Standard 0
-      URI 0
-      URI::Heuristic 0
-      URI::git 0
-      perl v5.12.0
-      strict 0
-      warnings 0
-  Git-Sub-0.163320
-    pathname: D/DO/DOLMEN/Git-Sub-0.163320.tar.gz
-    provides:
-      Git::Sub 0.163320
-    requirements:
-      Carp 0
-      ExtUtils::MakeMaker 0
-      File::Which 0
-      System::Sub 0.162800
-      perl 5.006
-      strict 0
-      subs 0
       warnings 0
   Gravatar-URL-1.07
     pathname: M/MS/MSCHWERN/Gravatar-URL-1.07.tar.gz
@@ -6676,18 +6627,6 @@ DISTRIBUTIONS
       perl 5.012
       strict 0
       warnings 0
-  String-Trim-0.005
-    pathname: D/DO/DOHERTY/String-Trim-0.005.tar.gz
-    provides:
-      String::Trim 0.005
-    requirements:
-      Data::Dumper 0
-      Exporter 5.57
-      ExtUtils::MakeMaker 6.31
-      File::Find 0
-      File::Temp 0
-      Test::Builder 0.94
-      Test::More 0.94
   Sub-Exporter-0.991
     pathname: R/RJ/RJBS/Sub-Exporter-0.991.tar.gz
     provides:
@@ -6811,23 +6750,6 @@ DISTRIBUTIONS
     requirements:
       Call::Context 0
       ExtUtils::MakeMaker 0
-  System-Sub-0.162800
-    pathname: D/DO/DOLMEN/System-Sub-0.162800.tar.gz
-    provides:
-      System::Sub 0.162800
-      System::Sub::AutoLoad 0.162800
-    requirements:
-      Carp 0
-      ExtUtils::MakeMaker 0
-      File::Which 0
-      IPC::Run 0
-      Scalar::Util 1.11
-      Sub::Name 0
-      Symbol 0
-      constant 0
-      perl 5.006
-      strict 0
-      warnings 0
   TOML-Tiny-0.18
     pathname: O/OA/OALDERS/TOML-Tiny-0.18.tar.gz
     provides:
@@ -6856,34 +6778,6 @@ DISTRIBUTIONS
       Scalar::Util 1.14
       perl 5.006
       strict 0
-  Term-Choose-1.765
-    pathname: K/KU/KUERBIS/Term-Choose-1.765.tar.gz
-    provides:
-      Term::Choose 1.765
-      Term::Choose::Constants 1.765
-      Term::Choose::LineFold 1.765
-      Term::Choose::LineFold::CharWidthAmbiguousWide 1.765
-      Term::Choose::LineFold::CharWidthDefault 1.765
-      Term::Choose::Linux 1.765
-      Term::Choose::Opt::Mouse 1.765
-      Term::Choose::Opt::Search 1.765
-      Term::Choose::Opt::SkipItems 1.765
-      Term::Choose::Screen 1.765
-      Term::Choose::ValidateOptions 1.765
-      Term::Choose::Win32 1.765
-    requirements:
-      Carp 0
-      Exporter 0
-      ExtUtils::MakeMaker 0
-      File::Spec::Functions 0
-      FindBin 0
-      Test::Fatal 0
-      Test::More 0
-      constant 0
-      lib 0
-      perl 5.010000
-      strict 0
-      warnings 0
   Term-Size-Any-0.002
     pathname: F/FE/FERREIRA/Term-Size-Any-0.002.tar.gz
     provides:
@@ -7962,15 +7856,6 @@ DISTRIBUTIONS
       URI 1.40
       URI::Nested 0.10
       perl 5.008001
-  URI-git-0.02
-    pathname: M/MI/MIYAGAWA/URI-git-0.02.tar.gz
-    provides:
-      URI::git 0.02
-    requirements:
-      ExtUtils::MakeMaker 6.42
-      Filter::Util::Call 0
-      Test::More 0
-      URI 0
   URI-ws-0.03
     pathname: P/PL/PLICEASE/URI-ws-0.03.tar.gz
     provides:

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -6109,18 +6109,6 @@ DISTRIBUTIONS
       Test::More 0
       parent 0
       perl 5.008001
-  Plack-Middleware-Rewrite-2.102
-    pathname: A/AR/ARISTOTLE/Plack-Middleware-Rewrite-2.102.tar.gz
-    provides:
-      Plack::Middleware::Rewrite 2.102
-    requirements:
-      Plack 0.9942
-      Plack::Middleware 0
-      Plack::Request 0
-      Plack::Util 0
-      Plack::Util::Accessor 0
-      overload 0
-      perl 5.006
   Plack-Middleware-Session-0.34
     pathname: M/MI/MIYAGAWA/Plack-Middleware-Session-0.34.tar.gz
     provides:

--- a/lib/MetaCPAN/API/Plugin/Model.pm
+++ b/lib/MetaCPAN/API/Plugin/Model.pm
@@ -5,7 +5,7 @@ use Mojo::Base 'Mojolicious::Plugin';
 use Carp ();
 
 # Models from the catalyst app
-use MetaCPAN::Model::Search ();
+use MetaCPAN::Query::Search ();
 
 # New models
 use MetaCPAN::API::Model::Cover    ();
@@ -21,9 +21,9 @@ has download => sub {
 
 has search => sub {
     my $self = shift;
-    return MetaCPAN::Model::Search->new(
-        es    => $self->app->es,
-        index => 'cpan',
+    return MetaCPAN::Query::Search->new(
+        es         => $self->app->es,
+        index_name => 'cpan',
     );
 };
 

--- a/lib/MetaCPAN/Query/Search.pm
+++ b/lib/MetaCPAN/Query/Search.pm
@@ -1,4 +1,4 @@
-package MetaCPAN::Model::Search;
+package MetaCPAN::Query::Search;
 
 use MetaCPAN::Moose;
 
@@ -10,18 +10,7 @@ use MetaCPAN::Types::TypeTiny qw( Object Str );
 use MetaCPAN::Util qw( single_valued_arrayref_to_scalar true false );
 use MooseX::StrictConstructor;
 
-has es => (
-    is       => 'ro',
-    isa      => Object,
-    handles  => { _run_query => 'search', },
-    required => 1,
-);
-
-has index => (
-    is       => 'ro',
-    isa      => Str,
-    required => 1,
-);
+with 'MetaCPAN::Query::Role::Common';
 
 const my $RESULTS_PER_RUN => 200;
 const my @ROGUE_DISTRIBUTIONS => qw(
@@ -368,8 +357,8 @@ sub build_query {
 
 sub run_query {
     my ( $self, $type, $es_query ) = @_;
-    return $self->_run_query(
-        index       => $self->index,
+    return $self->es->search(
+        index       => $self->index_name,
         type        => $type,
         body        => $es_query,
         search_type => 'dfs_query_then_fetch',

--- a/lib/MetaCPAN/Role/HasConfig.pm
+++ b/lib/MetaCPAN/Role/HasConfig.pm
@@ -4,7 +4,6 @@ use Moose::Role;
 
 use MetaCPAN::Server::Config  ();
 use MetaCPAN::Types::TypeTiny qw( HashRef );
-use MetaCPAN::Util            qw( checkout_root );
 
 # Done like this so can be required by a role
 sub config {

--- a/lib/MetaCPAN/Role/Script.pm
+++ b/lib/MetaCPAN/Role/Script.pm
@@ -9,7 +9,7 @@ use IO::Prompt::Tiny                       qw( prompt );
 use Log::Contextual                        qw( :log :dlog );
 use MetaCPAN::Model                        ();
 use MetaCPAN::Types::TypeTiny              qw( Bool HashRef Int Path Str );
-use MetaCPAN::Util                         qw( checkout_root );
+use MetaCPAN::Util                         qw( root_dir );
 use Mojo::Server                           ();
 use Term::ANSIColor                        qw( colored );
 
@@ -123,7 +123,7 @@ has home => (
     isa     => Path,
     lazy    => 1,
     coerce  => 1,
-    default => sub { checkout_root() },
+    default => sub { root_dir() },
 );
 
 has quarantine => (

--- a/lib/MetaCPAN/Server.pm
+++ b/lib/MetaCPAN/Server.pm
@@ -107,10 +107,6 @@ sub app {
             };
         };
 
-        if ( $ENV{PLACK_ENV} && $ENV{PLACK_ENV} eq 'development' ) {
-            enable 'Rewrite', rules => sub {s{^/?v\d+/}{}};
-        }
-
         $class->apply_default_middlewares( $class->psgi_app );
     };
 }

--- a/lib/MetaCPAN/Server/Config.pm
+++ b/lib/MetaCPAN/Server/Config.pm
@@ -3,20 +3,15 @@ package MetaCPAN::Server::Config;
 use warnings;
 use strict;
 
-use Config::ZOMG    ();
-use FindBin         ();
-use Module::Runtime qw( require_module );
+use Config::ZOMG   ();
+use MetaCPAN::Util qw(root_dir);
 
 sub config {
-    my $config = _zomg("$FindBin::RealBin/..");
-    return $config if $config;
-
-    require_module('Git::Helpers');
-    $config = _zomg( Git::Helpers::checkout_root() );
+    my $root   = root_dir();
+    my $config = _zomg($root);
 
     if ( !$config ) {
-        die "Couldn't find config file in $FindBin::RealBin/.. or "
-            . Git::Helpers::checkout_root();
+        die "Couldn't find config file in $root";
     }
 
     return $config;

--- a/lib/MetaCPAN/Server/Model/Search.pm
+++ b/lib/MetaCPAN/Server/Model/Search.pm
@@ -4,20 +4,20 @@ use strict;
 use warnings;
 
 use Moose;
-use MetaCPAN::Model::Search ();
+use MetaCPAN::Query::Search ();
 
 extends 'MetaCPAN::Server::Model::CPAN';
 
 has search => (
     is      => 'ro',
-    isa     => 'MetaCPAN::Model::Search',
+    isa     => 'MetaCPAN::Query::Search',
     lazy    => 1,
     handles => [qw( search_for_first_result search_web )],
     default => sub {
         my $self = shift;
-        return MetaCPAN::Model::Search->new(
-            es    => $self->es,
-            index => $self->index,
+        return MetaCPAN::Query::Search->new(
+            es         => $self->es,
+            index_name => $self->index,
         );
     },
 );

--- a/lib/MetaCPAN/Util.pm
+++ b/lib/MetaCPAN/Util.pm
@@ -6,10 +6,12 @@ use strict;
 use warnings;
 use version;
 
-use Digest::SHA qw( sha1_base64 sha1_hex );
-use Encode      qw( decode_utf8 );
-use IPC::Run3   ();
-use Ref::Util   qw(
+use Cwd            ();
+use Digest::SHA    qw( sha1_base64 sha1_hex );
+use Encode         qw( decode_utf8 );
+use File::Basename ();
+use File::Spec     ();
+use Ref::Util      qw(
     is_arrayref
     is_hashref
     is_plain_arrayref
@@ -19,7 +21,7 @@ use Ref::Util   qw(
 use Cpanel::JSON::XS ();
 use Sub::Exporter -setup => {
     exports => [ qw(
-        checkout_root
+        root_dir
         author_dir
         diff_struct
         digest
@@ -41,17 +43,11 @@ use Sub::Exporter -setup => {
 *false   = \&Cpanel::JSON::XS::false;
 *is_bool = \&Cpanel::JSON::XS::is_bool;
 
-sub checkout_root {
-    IPC::Run3::run3( [qw(git rev-parse --show-toplevel)],
-        \undef, \my $stdout, \my $stderr );
-    if ($?) {
-        die $stderr;
-    }
-    chomp $stdout;
-    if ( !-d $stdout ) {
-        die "Failed to find git dir: '$stdout'";
-    }
-    return $stdout;
+sub root_dir {
+    Cwd::abs_path( File::Spec->catdir(
+        File::Basename::dirname(__FILE__),
+        ( File::Spec->updir ) x 2
+    ) );
 }
 
 sub digest {

--- a/t/lib/MetaCPAN/TestHelpers.pm
+++ b/t/lib/MetaCPAN/TestHelpers.pm
@@ -10,7 +10,7 @@ use Cpanel::JSON::XS         qw( decode_json encode_json );
 use File::Copy               qw( copy );
 use File::pushd              qw( pushd );
 use MetaCPAN::Server::Config ();
-use MetaCPAN::Util           qw( checkout_root );
+use MetaCPAN::Util           qw( root_dir );
 use Path::Tiny               qw( path );
 use Test::More;
 use Test::Routine::Util qw( run_tests );
@@ -103,7 +103,7 @@ sub get_config {
 }
 
 sub tmp_dir {
-    my $dir = path( checkout_root(), 'var', 't', 'tmp' );
+    my $dir = path( root_dir(), 'var', 't', 'tmp' );
     $dir->mkpath;
     return $dir;
 }
@@ -116,7 +116,7 @@ sub fakecpan_dir {
 }
 
 sub fakecpan_configs_dir {
-    my $source = path( checkout_root(), 'test-data', 'fakecpan' );
+    my $source = path( root_dir(), 'test-data', 'fakecpan' );
     $source->mkpath;
     return $source;
 }

--- a/t/model/search.t
+++ b/t/model/search.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use lib 't/lib';
 
-use MetaCPAN::Model::Search ();
+use MetaCPAN::Query::Search ();
 use MetaCPAN::TestServer    ();
 use MetaCPAN::Util          qw(true false);
 use Test::Deep              qw( cmp_deeply ignore );
@@ -10,9 +10,9 @@ use Test::More;
 
 # Just use this to get an es object.
 my $server = MetaCPAN::TestServer->new;
-my $search = MetaCPAN::Model::Search->new(
-    es    => $server->es_client,
-    index => 'cpan',
+my $search = MetaCPAN::Query::Search->new(
+    es         => $server->es_client,
+    index_name => 'cpan',
 );
 
 ok( $search, 'search' );

--- a/t/script/cover.t
+++ b/t/script/cover.t
@@ -5,11 +5,11 @@ use lib 't/lib';
 
 use MetaCPAN::Script::Cover  ();
 use MetaCPAN::Server::Config ();
-use MetaCPAN::Util           qw( checkout_root );
+use MetaCPAN::Util           qw( root_dir );
 use Test::More;
 use URI ();
 
-my $root = checkout_root();
+my $root = root_dir();
 my $file = URI->new('t/var/cover.json')->abs("file://$root/");
 
 my $config = MetaCPAN::Server::Config::config();

--- a/t/script/river.t
+++ b/t/script/river.t
@@ -5,7 +5,7 @@ use lib 't/lib';
 use MetaCPAN::Script::River ();
 use MetaCPAN::Server::Test  qw( app GET );
 use MetaCPAN::TestHelpers   qw( decode_json_ok );
-use MetaCPAN::Util          qw( checkout_root );
+use MetaCPAN::Util          qw( root_dir );
 use Plack::Test             ();
 use Test::More;
 use URI ();
@@ -13,7 +13,7 @@ use URI ();
 my $config = MetaCPAN::Server::Config::config();
 
 # local json file with structure from https://github.com/metacpan/metacpan-api/issues/460
-my $root = checkout_root();
+my $root = root_dir();
 my $file = URI->new('t/var/river.json')->abs("file://$root/");
 $config->{'river_url'} = "$file";
 

--- a/xt/search_web.t
+++ b/xt/search_web.t
@@ -5,15 +5,15 @@ use lib 't/lib';
 # USE `bin/prove_live` to run this
 # READ the README.txt in this dir
 
-use MetaCPAN::Model::Search ();
+use MetaCPAN::Query::Search ();
 use MetaCPAN::TestServer    ();
 use Test::More;
 
 # Just use this to get an es object.
 my $server = MetaCPAN::TestServer->new;
-my $search = MetaCPAN::Model::Search->new(
-    es    => $server->es_client,
-    index => 'cpan',
+my $search = MetaCPAN::Query::Search->new(
+    es          => $server->es_client,
+    index_name => 'cpan',
 );
 
 my %tests = (


### PR DESCRIPTION
Remove some unused prereqs.

Simplify the /v1/ URL handling in dev mode by using a mount, rather than a rewrite.

Move the search module to a query module, since it essentially matches the pattern of those modules.

Calculate the root directory based on the files, not based on git.