### PR TITLE
Always use type coercion to construct Search::Elasticsearch object

### DIFF
--- a/lib/MetaCPAN/Script/Snapshot.pm
+++ b/lib/MetaCPAN/Script/Snapshot.pm
@@ -82,8 +82,10 @@ has snap_name => (
 has host => (
     is      => 'ro',
     isa     => Str,
-    default =>
-        sub { MetaCPAN::Server::Config::config()->{elasticsearch_servers} },
+    default => sub {
+        my $self = shift;
+        return $self->es->transport->cxn_pool->cxns->[0]->uri;
+    },
     documentation => 'ES host, defaults to: http://localhost:9200',
 );
 

--- a/metacpan_server.yaml
+++ b/metacpan_server.yaml
@@ -4,7 +4,9 @@ git: /usr/bin/git
 cpan: /CPAN
 secret: "the stone roses"
 level: info
-elasticsearch_servers: http://elasticsearch:9200
+elasticsearch_servers:
+  client: '2_0::Direct'
+  nodes: http://elasticsearch:9200
 minion_dsn: "postgresql://metacpan:t00lchain@pghost:5432/minion_queue"
 port: 5000
 

--- a/metacpan_server_testing.yaml
+++ b/metacpan_server_testing.yaml
@@ -4,7 +4,9 @@ level: warn
 port: 5000
 source_base: var/t/tmp/source
 
-elasticsearch_servers: http://elasticsearch_test:9200
+elasticsearch_servers:
+  client: '2_0::Direct'
+  nodes: http://elasticsearch_test:9200
 
 logger:
   class: Log::Log4perl::Appender::Screen

--- a/t/lib/MetaCPAN/Server/Test.pm
+++ b/t/lib/MetaCPAN/Server/Test.pm
@@ -40,8 +40,7 @@ sub app {
 
 sub model {
     my $c = MetaCPAN::Server::Config::config();
-    MetaCPAN::Model->new(
-        es => { nodes => [ $c->{elasticsearch_servers} ] } );
+    MetaCPAN::Model->new( es => $c->{elasticsearch_servers} );
 }
 
 1;

--- a/t/lib/MetaCPAN/TestServer.pm
+++ b/t/lib/MetaCPAN/TestServer.pm
@@ -18,12 +18,14 @@ use MetaCPAN::Server                 ();
 use MetaCPAN::Server::Config         ();
 use MetaCPAN::TestHelpers            qw( fakecpan_dir );
 use MetaCPAN::Types::TypeTiny        qw( HashRef Path );
+use MooseX::Types::ElasticSearch     qw( ES );
 use Search::Elasticsearch            ();
 use Test::More;
 
 has es_client => (
     is      => 'ro',
-    does    => 'Search::Elasticsearch::Role::Client',
+    isa     => ES,
+    coerce  => 1,
     lazy    => 1,
     builder => '_build_es_client',
 );
@@ -64,14 +66,13 @@ sub _build_config {
 sub _build_es_client {
     my $self = shift;
 
-    my $es = Search::Elasticsearch->new(
-        nodes => MetaCPAN::Server::Config::config()->{elasticsearch_servers},
-        ( $ENV{ES_TRACE} ? ( trace_to => [ 'File', 'es.log' ] ) : () )
-    );
+    my $es = ES->coerce(
+        MetaCPAN::Server::Config::config()->{elasticsearch_servers}, );
 
-    ok( $es, 'got ElasticSearch object' );
+    ok( $es, 'got Search::Elasticsearch object' );
 
     note( Test::More::explain( { 'Elasticsearch info' => $es->info } ) );
+
     return $es;
 }
 


### PR DESCRIPTION
Make all uses of elasticsearch_servers consistent, passing the value directly to the MooseX::Types::ElasticSearch::ES type coercion. This ensures we can use any value that the type will accept. This allows adding additional parameters that will be passed to the constructor.

With that allowed, explicitly set the client version we want to use. Since we are currently pinned to Search::Elasticsearch 2.03, this won't have any direct impact. But it will assist in upgrading the Search::Elasticsearch version.

A _local config with just a string specified will override the entire config, which for now will continue to work fine. Eventually, those should be updated to use a hash so they can override only the nodes.