### PR TITLE
various fixes for Elasticsearch 5 compatibility

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -124,6 +124,7 @@ requires 'Safe', '2.35'; # bug fixes (used by Parse::PMFile)
 requires 'Scalar::Util', '1.62'; # Moose
 requires 'Search::Elasticsearch' => '8.12';
 requires 'Search::Elasticsearch::Client::2_0' => '6.81';
+requires 'Search::Elasticsearch::Client::5_0' => '6.81';
 requires 'Term::Choose', '1.754'; # Git::Helpers
 requires 'Throwable::Error';
 requires 'Term::Size::Any'; # for Catalyst

--- a/cpanfile
+++ b/cpanfile
@@ -99,7 +99,7 @@ requires 'MooseX::Getopt::Dashes';
 requires 'MooseX::Getopt::OptionTypeMap';
 requires 'MooseX::StrictConstructor';
 requires 'MooseX::Types';
-requires 'MooseX::Types::ElasticSearch', '== 0.0.4';
+requires 'MooseX::Types::ElasticSearch', '0.0.4';
 requires 'MooseX::Types::Moose';
 requires 'Mozilla::CA', '20211001';
 requires 'namespace::autoclean';
@@ -122,7 +122,8 @@ requires 'Pod::Text', '4.14';
 requires 'Ref::Util';
 requires 'Safe', '2.35'; # bug fixes (used by Parse::PMFile)
 requires 'Scalar::Util', '1.62'; # Moose
-requires 'Search::Elasticsearch', '== 2.03';
+requires 'Search::Elasticsearch' => '8.12';
+requires 'Search::Elasticsearch::Client::2_0' => '6.81';
 requires 'Term::Choose', '1.754'; # Git::Helpers
 requires 'Throwable::Error';
 requires 'Term::Size::Any'; # for Catalyst

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -6480,6 +6480,38 @@ DISTRIBUTIONS
       namespace::clean 0
       strict 0
       warnings 0
+  Search-Elasticsearch-Client-5_0-6.81
+    pathname: E/EZ/EZIMUEL/Search-Elasticsearch-Client-5_0-6.81.tar.gz
+    provides:
+      Search::Elasticsearch::Client::5_0 6.81
+      Search::Elasticsearch::Client::5_0::Bulk 6.81
+      Search::Elasticsearch::Client::5_0::Direct 6.81
+      Search::Elasticsearch::Client::5_0::Direct::Cat 6.81
+      Search::Elasticsearch::Client::5_0::Direct::Cluster 6.81
+      Search::Elasticsearch::Client::5_0::Direct::Indices 6.81
+      Search::Elasticsearch::Client::5_0::Direct::Ingest 6.81
+      Search::Elasticsearch::Client::5_0::Direct::Nodes 6.81
+      Search::Elasticsearch::Client::5_0::Direct::Snapshot 6.81
+      Search::Elasticsearch::Client::5_0::Direct::Tasks 6.81
+      Search::Elasticsearch::Client::5_0::Role::API 6.81
+      Search::Elasticsearch::Client::5_0::Role::Bulk 6.81
+      Search::Elasticsearch::Client::5_0::Role::Scroll 6.81
+      Search::Elasticsearch::Client::5_0::Scroll 6.81
+      Search::Elasticsearch::Client::5_0::TestServer 6.81
+    requirements:
+      Devel::GlobalDestruction 0
+      ExtUtils::MakeMaker 0
+      Moo 0
+      Moo::Role 0
+      Search::Elasticsearch 6.00
+      Search::Elasticsearch::Role::API 0
+      Search::Elasticsearch::Role::Client::Direct 0
+      Search::Elasticsearch::Role::Is_Sync 0
+      Search::Elasticsearch::Util 0
+      Try::Tiny 0
+      namespace::clean 0
+      strict 0
+      warnings 0
   Sereal-Decoder-5.004
     pathname: Y/YV/YVES/Sereal-Decoder-5.004.tar.gz
     provides:

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -5041,6 +5041,12 @@ DISTRIBUTIONS
       perl 5.006002
       strict 0
       warnings 0
+  Net-IP-1.26
+    pathname: M/MA/MANU/Net-IP-1.26.tar.gz
+    provides:
+      Net::IP 1.26
+    requirements:
+      ExtUtils::MakeMaker 0
   Net-OAuth-0.28
     pathname: K/KG/KGRENNAN/Net-OAuth-0.28.tar.gz
     provides:
@@ -6324,65 +6330,87 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       Test::More 0
       perl 5.006001
-  Search-Elasticsearch-2.03
-    pathname: D/DR/DRTECH/Search-Elasticsearch-2.03.tar.gz
+  Search-Elasticsearch-8.12
+    pathname: E/EZ/EZIMUEL/Search-Elasticsearch-8.12.tar.gz
     provides:
-      Search::Elasticsearch 2.03
-      Search::Elasticsearch::Bulk 2.03
-      Search::Elasticsearch::Client::0_90::Direct 2.03
-      Search::Elasticsearch::Client::0_90::Direct::Cluster 2.03
-      Search::Elasticsearch::Client::0_90::Direct::Indices 2.03
-      Search::Elasticsearch::Client::1_0::Direct 2.03
-      Search::Elasticsearch::Client::1_0::Direct::Cat 2.03
-      Search::Elasticsearch::Client::1_0::Direct::Cluster 2.03
-      Search::Elasticsearch::Client::1_0::Direct::Indices 2.03
-      Search::Elasticsearch::Client::1_0::Direct::Nodes 2.03
-      Search::Elasticsearch::Client::1_0::Direct::Snapshot 2.03
-      Search::Elasticsearch::Client::2_0::Direct 2.03
-      Search::Elasticsearch::Client::2_0::Direct::Cat 2.03
-      Search::Elasticsearch::Client::2_0::Direct::Cluster 2.03
-      Search::Elasticsearch::Client::2_0::Direct::Indices 2.03
-      Search::Elasticsearch::Client::2_0::Direct::Nodes 2.03
-      Search::Elasticsearch::Client::2_0::Direct::Snapshot 2.03
-      Search::Elasticsearch::Client::2_0::Direct::Tasks 2.03
-      Search::Elasticsearch::Cxn::Factory 2.03
-      Search::Elasticsearch::Cxn::HTTPTiny 2.03
-      Search::Elasticsearch::Cxn::Hijk 2.03
-      Search::Elasticsearch::Cxn::LWP 2.03
-      Search::Elasticsearch::CxnPool::Sniff 2.03
-      Search::Elasticsearch::CxnPool::Static 2.03
-      Search::Elasticsearch::CxnPool::Static::NoPing 2.03
-      Search::Elasticsearch::Error 2.03
-      Search::Elasticsearch::Logger::LogAny 2.03
-      Search::Elasticsearch::Role::API::0_90 2.03
-      Search::Elasticsearch::Role::API::1_0 2.03
-      Search::Elasticsearch::Role::API::2_0 2.03
-      Search::Elasticsearch::Role::Bulk 2.03
-      Search::Elasticsearch::Role::Client 2.03
-      Search::Elasticsearch::Role::Client::Direct 2.03
-      Search::Elasticsearch::Role::Client::Direct::Main 2.03
-      Search::Elasticsearch::Role::Cxn 2.03
-      Search::Elasticsearch::Role::Cxn::HTTP 2.03
-      Search::Elasticsearch::Role::CxnPool 2.03
-      Search::Elasticsearch::Role::CxnPool::Sniff 2.03
-      Search::Elasticsearch::Role::CxnPool::Static 2.03
-      Search::Elasticsearch::Role::CxnPool::Static::NoPing 2.03
-      Search::Elasticsearch::Role::Is_Sync 2.03
-      Search::Elasticsearch::Role::Logger 2.03
-      Search::Elasticsearch::Role::Scroll 2.03
-      Search::Elasticsearch::Role::Serializer 2.03
-      Search::Elasticsearch::Role::Serializer::JSON 2.03
-      Search::Elasticsearch::Role::Transport 2.03
-      Search::Elasticsearch::Scroll 2.03
-      Search::Elasticsearch::Serializer::JSON 2.03
-      Search::Elasticsearch::Serializer::JSON::Cpanel 2.03
-      Search::Elasticsearch::Serializer::JSON::PP 2.03
-      Search::Elasticsearch::Serializer::JSON::XS 2.03
-      Search::Elasticsearch::TestServer 2.03
-      Search::Elasticsearch::Transport 2.03
-      Search::Elasticsearch::Util 2.03
-      Search::Elasticsearch::Util::API::Path 2.03
-      Search::Elasticsearch::Util::API::QS 2.03
+      Search::Elasticsearch 8.12
+      Search::Elasticsearch::Client::8_0 8.12
+      Search::Elasticsearch::Client::8_0::Bulk 8.12
+      Search::Elasticsearch::Client::8_0::Direct 8.12
+      Search::Elasticsearch::Client::8_0::Direct::Autoscaling 8.12
+      Search::Elasticsearch::Client::8_0::Direct::CCR 8.12
+      Search::Elasticsearch::Client::8_0::Direct::Cat 8.12
+      Search::Elasticsearch::Client::8_0::Direct::Cluster 8.12
+      Search::Elasticsearch::Client::8_0::Direct::Connector 8.12
+      Search::Elasticsearch::Client::8_0::Direct::ConnectorSyncJob 8.12
+      Search::Elasticsearch::Client::8_0::Direct::DanglingIndices 8.12
+      Search::Elasticsearch::Client::8_0::Direct::Enrich 8.12
+      Search::Elasticsearch::Client::8_0::Direct::Eql 8.12
+      Search::Elasticsearch::Client::8_0::Direct::Esql 8.12
+      Search::Elasticsearch::Client::8_0::Direct::Features 8.12
+      Search::Elasticsearch::Client::8_0::Direct::Fleet 8.12
+      Search::Elasticsearch::Client::8_0::Direct::Graph 8.12
+      Search::Elasticsearch::Client::8_0::Direct::ILM 8.12
+      Search::Elasticsearch::Client::8_0::Direct::Indices 8.12
+      Search::Elasticsearch::Client::8_0::Direct::Inference 8.12
+      Search::Elasticsearch::Client::8_0::Direct::Ingest 8.12
+      Search::Elasticsearch::Client::8_0::Direct::License 8.12
+      Search::Elasticsearch::Client::8_0::Direct::Logstash 8.12
+      Search::Elasticsearch::Client::8_0::Direct::ML 8.12
+      Search::Elasticsearch::Client::8_0::Direct::Migration 8.12
+      Search::Elasticsearch::Client::8_0::Direct::Monitoring 8.12
+      Search::Elasticsearch::Client::8_0::Direct::Nodes 8.12
+      Search::Elasticsearch::Client::8_0::Direct::Profiling 8.12
+      Search::Elasticsearch::Client::8_0::Direct::QueryRuleset 8.12
+      Search::Elasticsearch::Client::8_0::Direct::Rollup 8.12
+      Search::Elasticsearch::Client::8_0::Direct::SQL 8.12
+      Search::Elasticsearch::Client::8_0::Direct::SSL 8.12
+      Search::Elasticsearch::Client::8_0::Direct::SearchApplication 8.12
+      Search::Elasticsearch::Client::8_0::Direct::SearchableSnapshots 8.12
+      Search::Elasticsearch::Client::8_0::Direct::Security 8.12
+      Search::Elasticsearch::Client::8_0::Direct::Shutdown 8.12
+      Search::Elasticsearch::Client::8_0::Direct::Simulate 8.12
+      Search::Elasticsearch::Client::8_0::Direct::Slm 8.12
+      Search::Elasticsearch::Client::8_0::Direct::Snapshot 8.12
+      Search::Elasticsearch::Client::8_0::Direct::Synonyms 8.12
+      Search::Elasticsearch::Client::8_0::Direct::Tasks 8.12
+      Search::Elasticsearch::Client::8_0::Direct::TextStructure 8.12
+      Search::Elasticsearch::Client::8_0::Direct::Transform 8.12
+      Search::Elasticsearch::Client::8_0::Direct::Watcher 8.12
+      Search::Elasticsearch::Client::8_0::Direct::XPack 8.12
+      Search::Elasticsearch::Client::8_0::Role::API 8.12
+      Search::Elasticsearch::Client::8_0::Role::Bulk 8.12
+      Search::Elasticsearch::Client::8_0::Role::Scroll 8.12
+      Search::Elasticsearch::Client::8_0::Scroll 8.12
+      Search::Elasticsearch::Client::8_0::TestServer 8.12
+      Search::Elasticsearch::Cxn::Factory 8.12
+      Search::Elasticsearch::Cxn::HTTPTiny 8.12
+      Search::Elasticsearch::Cxn::LWP 8.12
+      Search::Elasticsearch::CxnPool::Sniff 8.12
+      Search::Elasticsearch::CxnPool::Static 8.12
+      Search::Elasticsearch::CxnPool::Static::NoPing 8.12
+      Search::Elasticsearch::Error 8.12
+      Search::Elasticsearch::Logger::LogAny 8.12
+      Search::Elasticsearch::Role::API 8.12
+      Search::Elasticsearch::Role::Client 8.12
+      Search::Elasticsearch::Role::Client::Direct 8.12
+      Search::Elasticsearch::Role::Cxn 8.12
+      Search::Elasticsearch::Role::CxnPool 8.12
+      Search::Elasticsearch::Role::CxnPool::Sniff 8.12
+      Search::Elasticsearch::Role::CxnPool::Static 8.12
+      Search::Elasticsearch::Role::CxnPool::Static::NoPing 8.12
+      Search::Elasticsearch::Role::Is_Sync 8.12
+      Search::Elasticsearch::Role::Logger 8.12
+      Search::Elasticsearch::Role::Serializer 8.12
+      Search::Elasticsearch::Role::Serializer::JSON 8.12
+      Search::Elasticsearch::Role::Transport 8.12
+      Search::Elasticsearch::Serializer::JSON 8.12
+      Search::Elasticsearch::Serializer::JSON::Cpanel 8.12
+      Search::Elasticsearch::Serializer::JSON::PP 8.12
+      Search::Elasticsearch::Serializer::JSON::XS 8.12
+      Search::Elasticsearch::TestServer 8.12
+      Search::Elasticsearch::Transport 8.12
+      Search::Elasticsearch::Util 8.12
     requirements:
       Any::URI::Escape 0
       Data::Dumper 0
@@ -6392,9 +6420,12 @@ DISTRIBUTIONS
       File::Temp 0
       HTTP::Headers 0
       HTTP::Request 0
-      HTTP::Tiny 0.043
+      HTTP::Tiny 0.076
+      IO::Compress::Deflate 0
+      IO::Compress::Gzip 0
       IO::Select 0
       IO::Socket 0
+      IO::Uncompress::Gunzip 0
       IO::Uncompress::Inflate 0
       JSON::MaybeXS 1.002002
       JSON::PP 0
@@ -6404,8 +6435,9 @@ DISTRIBUTIONS
       Log::Any::Adapter 0
       MIME::Base64 0
       Module::Runtime 0
-      Moo 1.003
+      Moo 2.001000
       Moo::Role 0
+      Net::IP 0
       POSIX 0
       Package::Stash 0.34
       Scalar::Util 0
@@ -6415,6 +6447,37 @@ DISTRIBUTIONS
       URI 0
       namespace::clean 0
       overload 0
+      strict 0
+      warnings 0
+  Search-Elasticsearch-Client-2_0-6.81
+    pathname: E/EZ/EZIMUEL/Search-Elasticsearch-Client-2_0-6.81.tar.gz
+    provides:
+      Search::Elasticsearch::Client::2_0 6.81
+      Search::Elasticsearch::Client::2_0::Bulk 6.81
+      Search::Elasticsearch::Client::2_0::Direct 6.81
+      Search::Elasticsearch::Client::2_0::Direct::Cat 6.81
+      Search::Elasticsearch::Client::2_0::Direct::Cluster 6.81
+      Search::Elasticsearch::Client::2_0::Direct::Indices 6.81
+      Search::Elasticsearch::Client::2_0::Direct::Nodes 6.81
+      Search::Elasticsearch::Client::2_0::Direct::Snapshot 6.81
+      Search::Elasticsearch::Client::2_0::Direct::Tasks 6.81
+      Search::Elasticsearch::Client::2_0::Role::API 6.81
+      Search::Elasticsearch::Client::2_0::Role::Bulk 6.81
+      Search::Elasticsearch::Client::2_0::Role::Scroll 6.81
+      Search::Elasticsearch::Client::2_0::Scroll 6.81
+      Search::Elasticsearch::Client::2_0::TestServer 6.81
+    requirements:
+      Devel::GlobalDestruction 0
+      ExtUtils::MakeMaker 0
+      Moo 0
+      Moo::Role 0
+      Search::Elasticsearch 6.00
+      Search::Elasticsearch::Role::API 0
+      Search::Elasticsearch::Role::Client::Direct 0
+      Search::Elasticsearch::Role::Is_Sync 0
+      Search::Elasticsearch::Util 0
+      Try::Tiny 0
+      namespace::clean 0
       strict 0
       warnings 0
   Sereal-Decoder-5.004

--- a/lib/Catalyst/Plugin/Session/Store/ElasticSearch.pm
+++ b/lib/Catalyst/Plugin/Session/Store/ElasticSearch.pm
@@ -7,6 +7,7 @@ extends 'Catalyst::Plugin::Session::Store';
 use MooseX::Types::ElasticSearch qw( ES );
 
 use MetaCPAN::Server::Config ();
+use MetaCPAN::Util           qw( true false );
 
 has _session_es => (
     is      => 'ro',
@@ -55,7 +56,7 @@ sub store_session_data {
             type    => $self->_session_es_type,
             id      => $sid,
             body    => $session,
-            refresh => 1,
+            refresh => true,
         );
     }
 }
@@ -68,7 +69,7 @@ sub delete_session_data {
                 index   => $self->_session_es_index,
                 type    => $self->_session_es_type,
                 id      => $sid,
-                refresh => 1,
+                refresh => true,
             );
         };
     }

--- a/lib/ElasticSearchX/Model/Document/Set.pm
+++ b/lib/ElasticSearchX/Model/Document/Set.pm
@@ -29,4 +29,19 @@ my $delete = \&delete;
     return $delete->(@_);
 };
 
+my $get = \&get;
+*get = sub {
+    my ( $self, $args, $qs ) = @_;
+    if ( $self->es->api_version eq '2_0' ) {
+        goto &$get;
+    }
+    my %qs = %{ $qs || {} };
+    if ( my $fields = $self->fields ) {
+        $qs{_source} = $fields;
+        local $self->{fields};
+        return $get->( $self, $args, \%qs );
+    }
+    goto &$get;
+};
+
 1;

--- a/lib/ElasticSearchX/Model/Document/Set.pm
+++ b/lib/ElasticSearchX/Model/Document/Set.pm
@@ -1,0 +1,32 @@
+package ElasticSearchX::Model::Document::Set;
+use strict;
+use warnings;
+
+use MetaCPAN::Model::Hacks;
+
+no warnings 'redefine';
+
+our %query_override;
+my $_build_query = \&_build_query;
+*_build_query = sub {
+    my $query = $_build_query->(@_);
+    %$query = ( %$query, %query_override, );
+    return $query;
+};
+
+our %qs_override;
+my $_build_qs = \&_build_qs;
+*_build_qs = sub {
+    my $qs = $_build_qs->(@_);
+    %$qs = ( %$qs, %qs_override, );
+    return $qs;
+};
+
+my $delete = \&delete;
+*delete = sub {
+    local %qs_override    = ( search_type => 'query_then_fetch' );
+    local %query_override = ( sort        => '_doc' );
+    return $delete->(@_);
+};
+
+1;

--- a/lib/MetaCPAN/API/Model/Cover.pm
+++ b/lib/MetaCPAN/API/Model/Cover.pm
@@ -2,6 +2,8 @@ package MetaCPAN::API::Model::Cover;
 
 use MetaCPAN::Moose;
 
+use MetaCPAN::Util qw(hit_total);
+
 with 'MetaCPAN::API::Model::Role::ES';
 
 sub find_release_coverage {
@@ -17,7 +19,7 @@ sub find_release_coverage {
             size  => 999,
         }
     );
-    $res->{hits}{total} or return {};
+    hit_total($res) or return {};
 
     return +{
         %{ $res->{hits}{hits}[0]{_source} },

--- a/lib/MetaCPAN/Document/File.pm
+++ b/lib/MetaCPAN/Document/File.pm
@@ -414,9 +414,8 @@ sub _build_suggest {
     $weight = 0 if $weight < 0;
 
     return +{
-        input   => [$doc],
-        payload => { doc_name => $doc },
-        weight  => $weight,
+        input  => [$doc],
+        weight => $weight,
     };
 }
 

--- a/lib/MetaCPAN/Document/Mirror.pm
+++ b/lib/MetaCPAN/Document/Mirror.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 use Moose;
-use ElasticSearchX::Model::Document::Types qw( Location );
+use MooseX::Types::ElasticSearch qw( Location );
 use ElasticSearchX::Model::Document;
 
 use MetaCPAN::Types::TypeTiny qw( Dict Str );

--- a/lib/MetaCPAN/Document/Release/Set.pm
+++ b/lib/MetaCPAN/Document/Release/Set.pm
@@ -2,8 +2,6 @@ package MetaCPAN::Document::Release::Set;
 
 use Moose;
 
-use MetaCPAN::Util qw( single_valued_arrayref_to_scalar );
-
 use MetaCPAN::Query::Release ();
 
 extends 'ElasticSearchX::Model::Document::Set';

--- a/lib/MetaCPAN/Model/Hacks.pm
+++ b/lib/MetaCPAN/Model/Hacks.pm
@@ -1,0 +1,23 @@
+package MetaCPAN::Model::Hacks;
+use strict;
+use warnings;
+
+sub import {
+    my ( $caller, $caller_file ) = caller;
+
+    my $file = $caller      =~ s{::}{/}gr . '.pm';
+    my $dir  = $caller_file =~ s{/\Q$file\E\z}{}r;
+    local @INC = grep $_ ne $dir, @INC;
+    my $inc;
+    {
+        local $INC{$file};
+        delete $INC{$file};
+        require $file;
+        $inc = $INC{$file};
+    }
+    delete $INC{$file};
+    $INC{$file} = $inc;
+    return;
+}
+
+1;

--- a/lib/MetaCPAN/Model/Release.pm
+++ b/lib/MetaCPAN/Model/Release.pm
@@ -222,7 +222,8 @@ sub _build_document {
         || $document->{abstract} eq 'null' );
 
     $document
-        = $self->index->type('release')->put( $document, { refresh => 1 } );
+        = $self->index->type('release')
+        ->put( $document, { refresh => true } );
 
     # create distribution if doesn't exist
     my $dist_count = $self->es->count(

--- a/lib/MetaCPAN/Query/Author.pm
+++ b/lib/MetaCPAN/Query/Author.pm
@@ -2,8 +2,7 @@ package MetaCPAN::Query::Author;
 
 use MetaCPAN::Moose;
 
-use MetaCPAN::Util qw( single_valued_arrayref_to_scalar );
-use Ref::Util      qw( is_arrayref );
+use Ref::Util qw( is_arrayref );
 
 with 'MetaCPAN::Query::Role::Common';
 
@@ -23,10 +22,7 @@ sub by_ids {
         body  => $body,
     );
 
-    my @authors = map {
-        single_valued_arrayref_to_scalar( $_->{_source} );
-        $_->{_source}
-    } @{ $authors->{hits}{hits} };
+    my @authors = map $_->{_source}, @{ $authors->{hits}{hits} };
 
     return {
         authors => \@authors,
@@ -48,10 +44,7 @@ sub by_user {
         }
     );
 
-    my @authors = map {
-        single_valued_arrayref_to_scalar( $_->{_source} );
-        $_->{_source}
-    } @{ $authors->{hits}{hits} };
+    my @authors = map $_->{_source}, @{ $authors->{hits}{hits} };
 
     return {
         authors => \@authors,
@@ -94,10 +87,8 @@ sub search {
         body  => $body,
     );
 
-    my @authors = map {
-        single_valued_arrayref_to_scalar( $_->{_source} );
-        +{ %{ $_->{_source} }, id => $_->{_id} }
-    } @{ $ret->{hits}{hits} };
+    my @authors = map { +{ %{ $_->{_source} }, id => $_->{_id} } }
+        @{ $ret->{hits}{hits} };
 
     return +{
         authors => \@authors,
@@ -127,10 +118,8 @@ sub prefix_search {
         body  => $body,
     );
 
-    my @authors = map {
-        single_valued_arrayref_to_scalar( $_->{_source} );
-        +{ %{ $_->{_source} }, id => $_->{_id} }
-    } @{ $ret->{hits}{hits} };
+    my @authors = map { +{ %{ $_->{_source} }, id => $_->{_id} } }
+        @{ $ret->{hits}{hits} };
 
     return +{
         authors => \@authors,

--- a/lib/MetaCPAN/Query/Author.pm
+++ b/lib/MetaCPAN/Query/Author.pm
@@ -2,7 +2,8 @@ package MetaCPAN::Query::Author;
 
 use MetaCPAN::Moose;
 
-use Ref::Util qw( is_arrayref );
+use MetaCPAN::Util qw(hit_total);
+use Ref::Util      qw( is_arrayref );
 
 with 'MetaCPAN::Query::Role::Common';
 
@@ -27,7 +28,7 @@ sub by_ids {
     return {
         authors => \@authors,
         took    => $authors->{took},
-        total   => $authors->{hits}{total},
+        total   => hit_total($authors),
     };
 }
 
@@ -49,7 +50,7 @@ sub by_user {
     return {
         authors => \@authors,
         took    => $authors->{took},
-        total   => $authors->{hits}{total},
+        total   => hit_total($authors),
     };
 }
 
@@ -93,7 +94,7 @@ sub search {
     return +{
         authors => \@authors,
         took    => $ret->{took},
-        total   => $ret->{hits}{total},
+        total   => hit_total($ret),
     };
 }
 
@@ -124,7 +125,7 @@ sub prefix_search {
     return +{
         authors => \@authors,
         took    => $ret->{took},
-        total   => $ret->{hits}{total},
+        total   => hit_total($ret),
     };
 }
 

--- a/lib/MetaCPAN/Query/Contributor.pm
+++ b/lib/MetaCPAN/Query/Contributor.pm
@@ -2,6 +2,8 @@ package MetaCPAN::Query::Contributor;
 
 use MetaCPAN::Moose;
 
+use MetaCPAN::Util qw(hit_total);
+
 with 'MetaCPAN::Query::Role::Common';
 
 sub find_release_contributors {
@@ -24,7 +26,7 @@ sub find_release_contributors {
             size  => 999,
         }
     );
-    $res->{hits}{total} or return {};
+    hit_total($res) or return {};
 
     return +{
         contributors => [ map { $_->{_source} } @{ $res->{hits}{hits} } ] };

--- a/lib/MetaCPAN/Query/Cover.pm
+++ b/lib/MetaCPAN/Query/Cover.pm
@@ -2,6 +2,8 @@ package MetaCPAN::Query::Cover;
 
 use MetaCPAN::Moose;
 
+use MetaCPAN::Util qw(hit_total);
+
 with 'MetaCPAN::Query::Role::Common';
 
 sub find_release_coverage {
@@ -17,7 +19,7 @@ sub find_release_coverage {
             size  => 999,
         }
     );
-    $res->{hits}{total} or return {};
+    hit_total($res) or return {};
 
     return +{
         %{ $res->{hits}{hits}[0]{_source} },

--- a/lib/MetaCPAN/Query/Distribution.pm
+++ b/lib/MetaCPAN/Query/Distribution.pm
@@ -2,6 +2,8 @@ package MetaCPAN::Query::Distribution;
 
 use MetaCPAN::Moose;
 
+use MetaCPAN::Util qw(hit_total);
+
 with 'MetaCPAN::Query::Role::Common';
 
 sub get_river_data_by_dist {
@@ -21,7 +23,7 @@ sub get_river_data_by_dist {
             size  => 999,
         }
     );
-    $res->{hits}{total} or return {};
+    hit_total($res) or return {};
 
     return +{ river => +{ $dist => $res->{hits}{hits}[0]{_source}{river} } };
 }
@@ -43,7 +45,7 @@ sub get_river_data_by_dists {
             size  => 999,
         }
     );
-    $res->{hits}{total} or return {};
+    hit_total($res) or return {};
 
     return +{
         river => +{

--- a/lib/MetaCPAN/Query/Favorite.pm
+++ b/lib/MetaCPAN/Query/Favorite.pm
@@ -2,6 +2,8 @@ package MetaCPAN::Query::Favorite;
 
 use MetaCPAN::Moose;
 
+use MetaCPAN::Util qw(hit_total);
+
 with 'MetaCPAN::Query::Role::Common';
 
 sub agg_by_distributions {
@@ -76,7 +78,7 @@ sub by_user {
             size    => $size,
         }
     );
-    return {} unless $favs->{hits}{total};
+    return {} unless hit_total($favs);
     my $took = $favs->{took};
 
     my @favs = map { $_->{_source} } @{ $favs->{hits}{hits} };
@@ -106,7 +108,7 @@ sub by_user {
     );
     $took += $no_backpan->{took};
 
-    if ( $no_backpan->{hits}{total} ) {
+    if ( hit_total($no_backpan) ) {
         my %has_no_backpan = map { $_->{_source}{distribution} => 1 }
             @{ $no_backpan->{hits}{hits} };
 
@@ -171,7 +173,7 @@ sub recent {
     return +{
         favorites => \@favs,
         took      => $favs->{took},
-        total     => $favs->{hits}{total}
+        total     => hit_total($favs),
     };
 }
 
@@ -187,7 +189,7 @@ sub users_by_distribution {
             size    => 1000,
         }
     );
-    return {} unless $favs->{hits}{total};
+    return {} unless hit_total($favs);
 
     my @plusser_users = map { $_->{_source}{user} } @{ $favs->{hits}{hits} };
 

--- a/lib/MetaCPAN/Query/File.pm
+++ b/lib/MetaCPAN/Query/File.pm
@@ -2,7 +2,7 @@ package MetaCPAN::Query::File;
 
 use MetaCPAN::Moose;
 
-use MetaCPAN::Util qw( true false );
+use MetaCPAN::Util qw( hit_total true false );
 
 with 'MetaCPAN::Query::Role::Common';
 
@@ -301,7 +301,7 @@ sub interesting_files {
     } );
 
     $return->{took}  = $data->{took};
-    $return->{total} = $data->{hits}{total};
+    $return->{total} = hit_total($data);
 
     return $return
         unless $return->{total};

--- a/lib/MetaCPAN/Query/Mirror.pm
+++ b/lib/MetaCPAN/Query/Mirror.pm
@@ -1,6 +1,7 @@
 package MetaCPAN::Query::Mirror;
 
 use MetaCPAN::Moose;
+use MetaCPAN::Util qw( hit_total );
 
 with 'MetaCPAN::Query::Role::Common';
 
@@ -57,7 +58,7 @@ sub search {
 
     return {
         mirrors => $data,
-        total   => $ret->{hits}{total},
+        total   => hit_total($ret),
         took    => $ret->{took}
     };
 }

--- a/lib/MetaCPAN/Query/Package.pm
+++ b/lib/MetaCPAN/Query/Package.pm
@@ -8,13 +8,11 @@ sub get_modules {
     my ( $self, $dist, $ver ) = @_;
 
     my $query = +{
-        query => {
-            bool => {
-                must => [
-                    { term => { distribution => $dist } },
-                    { term => { dist_version => $ver } },
-                ],
-            }
+        bool => {
+            must => [
+                { term => { distribution => $dist } },
+                { term => { dist_version => $ver } },
+            ],
         }
     };
 

--- a/lib/MetaCPAN/Query/Release.pm
+++ b/lib/MetaCPAN/Query/Release.pm
@@ -63,14 +63,12 @@ sub get_contributors {
     my ( $self, $author_name, $release_name ) = @_;
 
     my $query = +{
-        query => {
-            bool => {
-                must => [
-                    { term => { name   => $release_name } },
-                    { term => { author => $author_name } },
-                ],
-            },
-        }
+        bool => {
+            must => [
+                { term => { name   => $release_name } },
+                { term => { author => $author_name } },
+            ],
+        },
     };
 
     my $res = $self->es->search(
@@ -195,11 +193,9 @@ sub get_contributors {
     }
 
     my $contrib_query = +{
-        query => {
-            terms => {
-                pauseid =>
-                    [ map { $_->{pauseid} ? $_->{pauseid} : () } @contribs ]
-            }
+        terms => {
+            pauseid =>
+                [ map { $_->{pauseid} ? $_->{pauseid} : () } @contribs ]
         }
     };
 
@@ -256,7 +252,7 @@ sub get_files {
 sub get_checksums {
     my ( $self, $release ) = @_;
 
-    my $query = +{ query => { term => { name => $release } } };
+    my $query = { term => { name => $release } };
 
     my $ret = $self->es->search(
         index => $self->index_name,
@@ -386,17 +382,15 @@ sub by_author_and_names {
                 should => [
                     map {
                         +{
-                            query => {
-                                bool => {
-                                    must => [
-                                        {
-                                            term => {
-                                                author => uc( $_->{author} )
-                                            }
-                                        },
-                                        { term => { 'name' => $_->{name} } },
-                                    ]
-                                }
+                            bool => {
+                                must => [
+                                    {
+                                        term => {
+                                            author => uc( $_->{author} )
+                                        }
+                                    },
+                                    { term => { 'name' => $_->{name} } },
+                                ]
                             }
                         }
                     } @$releases

--- a/lib/MetaCPAN/Query/Release.pm
+++ b/lib/MetaCPAN/Query/Release.pm
@@ -1120,13 +1120,13 @@ sub find_download_url {
     my $query;
 
     if ($dev) {
-        $query = { filtered => { filter => $filter } };
+        $query = $filter;
     }
     else {
         # if not dev, then prefer latest > cpan > backpan
         $query = {
             function_score => {
-                filter     => $filter,
+                query      => $filter,
                 score_mode => 'first',
                 boost_mode => 'replace',
                 functions  => [

--- a/lib/MetaCPAN/Query/Release.pm
+++ b/lib/MetaCPAN/Query/Release.pm
@@ -2,7 +2,8 @@ package MetaCPAN::Query::Release;
 
 use MetaCPAN::Moose;
 
-use MetaCPAN::Util qw( single_valued_arrayref_to_scalar true false );
+use MetaCPAN::Util
+    qw( hit_total single_valued_arrayref_to_scalar true false );
 
 with 'MetaCPAN::Query::Role::Common';
 
@@ -184,7 +185,7 @@ sub get_contributors {
                     }
                 );
 
-                if ( $check_author->{hits}{total} ) {
+                if ( hit_total($check_author) ) {
                     $contrib->{pauseid}
                         = uc $check_author->{hits}{hits}[0]{_source}{pauseid};
                 }
@@ -365,7 +366,7 @@ sub by_author_and_name {
     return {
         took    => $ret->{took},
         release => $data,
-        total   => $ret->{hits}{total}
+        total   => hit_total($ret),
     };
 }
 
@@ -412,7 +413,7 @@ sub by_author_and_names {
 
     return {
         took     => $ret->{took},
-        total    => $ret->{hits}{total},
+        total    => hit_total($ret),
         releases => \@releases,
     };
 }
@@ -450,7 +451,7 @@ sub by_author {
 
     return {
         releases => $data,
-        total    => $ret->{hits}{total},
+        total    => hit_total($ret),
         took     => $ret->{took}
     };
 }
@@ -486,7 +487,7 @@ sub latest_by_distribution {
     return {
         release => $data,
         took    => $ret->{took},
-        total   => $ret->{hits}{total}
+        total   => hit_total($ret),
     };
 }
 
@@ -546,7 +547,7 @@ sub all_by_author {
     return {
         took     => $ret->{took},
         releases => $data,
-        total    => $ret->{hits}{total}
+        total    => hit_total($ret),
     };
 }
 
@@ -617,7 +618,7 @@ sub versions {
 
     return {
         releases => $data,
-        total    => $ret->{hits}{total},
+        total    => hit_total($ret),
         took     => $ret->{took}
     };
 }
@@ -812,7 +813,7 @@ sub _get_depended_releases {
 
     return +{
         data  => [ map { $_->{_source} } @{ $depended->{hits}{hits} } ],
-        total => $depended->{hits}{total},
+        total => hit_total($depended),
         took  => $depended->{took},
     };
 }
@@ -880,7 +881,7 @@ sub recent {
 
     return {
         releases => $data,
-        total    => $ret->{hits}{total},
+        total    => hit_total($ret),
         took     => $ret->{took}
     };
 }
@@ -969,7 +970,7 @@ sub modules {
 
     return {
         files => \@files,
-        total => $ret->{hits}{total},
+        total => hit_total($ret),
         took  => $ret->{took}
     };
 }
@@ -1153,7 +1154,7 @@ sub find_download_url {
         search_type => 'dfs_query_then_fetch',
     );
 
-    return unless $res->{hits}{total};
+    return unless hit_total($res);
 
     my @checksums;
 

--- a/lib/MetaCPAN/Query/Release.pm
+++ b/lib/MetaCPAN/Query/Release.pm
@@ -1090,7 +1090,7 @@ sub find_download_url {
             nested => {
                 path       => 'module',
                 inner_hits => { _source => 'version' },
-                filter     => $entity_filter,
+                query      => $entity_filter,
             }
             };
     }

--- a/lib/MetaCPAN/Query/Release.pm
+++ b/lib/MetaCPAN/Query/Release.pm
@@ -1044,7 +1044,9 @@ sub find_download_url {
     my $module_filter = $type eq 'module';
 
     if ( !$explicit_version ) {
-        push @filters, { not => { term => { status => 'backpan' } } };
+        push @filters,
+            { bool => { must_not => [ { term => { status => 'backpan' } } ] }
+            };
         if ( !$dev ) {
             push @filters, { term => { maturity => 'released' } };
         }

--- a/lib/MetaCPAN/Query/Release.pm
+++ b/lib/MetaCPAN/Query/Release.pm
@@ -1082,9 +1082,8 @@ sub find_download_url {
         push @filters,
             {
             nested => {
-                path       => 'module',
-                inner_hits => { _source => 'version' },
-                query      => $entity_filter,
+                path  => 'module',
+                query => $entity_filter,
             }
             };
     }

--- a/lib/MetaCPAN/Query/Search.pm
+++ b/lib/MetaCPAN/Query/Search.pm
@@ -157,8 +157,10 @@ sub _search_collapsed {
                 },
                 max_score => {
                     max => {
-                        lang   => "expression",
-                        script => "_score",
+                        script => {
+                            lang   => "expression",
+                            inline => "_score",
+                        },
                     },
                 },
             },

--- a/lib/MetaCPAN/Query/Search.pm
+++ b/lib/MetaCPAN/Query/Search.pm
@@ -7,7 +7,7 @@ use Hash::Merge               qw( merge );
 use List::Util                qw( min uniq );
 use Log::Contextual           qw( :log :dlog );
 use MetaCPAN::Types::TypeTiny qw( Object Str );
-use MetaCPAN::Util qw( single_valued_arrayref_to_scalar true false );
+use MetaCPAN::Util            qw( true false );
 use MooseX::StrictConstructor;
 
 with 'MetaCPAN::Query::Role::Common';
@@ -31,8 +31,7 @@ sub search_for_first_result {
     my $es_results = $self->run_query( file => $es_query );
 
     my $data = $es_results->{hits}{hits}[0];
-    single_valued_arrayref_to_scalar( $data->{fields} );
-    return $data->{fields};
+    return $data->{_source};
 }
 
 =head2 search_web
@@ -129,13 +128,12 @@ sub _search_collapsed {
     my $total_size = $from + $page_size;
 
     my $es_query_opts = {
-        size   => 0,
-        fields => [ qw(
+        size    => 0,
+        _source => [ qw(
         ) ],
     };
 
     my $es_query = $self->build_query( $search_term, $es_query_opts );
-    my $fields   = delete $es_query->{fields};
     my $source   = delete $es_query->{_source};
 
     $es_query->{aggregations} = {
@@ -150,7 +148,6 @@ sub _search_collapsed {
             aggregations => {
                 top_files => {
                     top_hits => {
-                        fields  => $fields,
                         _source => $source,
                         size    => $max_collapsed_hits,
                     },
@@ -330,9 +327,9 @@ sub build_query {
         $params,
         {
             query   => $query,
-            _source => [ "module", ],
-            fields  => [ qw(
-                abstract.analyzed
+            _source => [ qw(
+                module
+                abstract
                 author
                 authorized
                 date
@@ -352,7 +349,7 @@ sub build_query {
 
     # Ensure our requested fields are unique so that Elasticsearch doesn't
     # return us the same value multiple times in an unexpected arrayref.
-    $search->{fields} = [ uniq @{ $search->{fields} || [] } ];
+    $search->{_source} = [ uniq @{ $search->{_source} || [] } ];
 
     return $search;
 }
@@ -373,11 +370,8 @@ sub _extract_results {
     return [
         map {
             my $res = $_;
-            single_valued_arrayref_to_scalar( $res->{fields} );
             +{
-                abstract  => delete $res->{fields}->{'abstract.analyzed'},
-                favorites => delete $res->{fields}->{dist_fav_count},
-                %{ $res->{fields} },
+                favorites => delete $res->{_source}->{dist_fav_count},
                 %{ $res->{_source} },
                 score => $res->{_score},
             }

--- a/lib/MetaCPAN/Query/Search.pm
+++ b/lib/MetaCPAN/Query/Search.pm
@@ -7,7 +7,7 @@ use Hash::Merge               qw( merge );
 use List::Util                qw( min uniq );
 use Log::Contextual           qw( :log :dlog );
 use MetaCPAN::Types::TypeTiny qw( Object Str );
-use MetaCPAN::Util            qw( true false );
+use MetaCPAN::Util            qw( hit_total true false );
 use MooseX::StrictConstructor;
 
 with 'MetaCPAN::Query::Role::Common';
@@ -113,7 +113,7 @@ sub _search_expanded {
 
     my $return = {
         results   => $results,
-        total     => $es_results->{hits}->{total},
+        total     => hit_total($es_results),
         took      => $es_results->{took},
         collapsed => false,
     };

--- a/lib/MetaCPAN/Role/Script.pm
+++ b/lib/MetaCPAN/Role/Script.pm
@@ -2,16 +2,16 @@ package MetaCPAN::Role::Script;
 
 use Moose::Role;
 
-use Carp                                   ();
-use ElasticSearchX::Model::Document::Types qw( ES );
-use File::Path                             ();
-use IO::Prompt::Tiny                       qw( prompt );
-use Log::Contextual                        qw( :log :dlog );
-use MetaCPAN::Model                        ();
-use MetaCPAN::Types::TypeTiny              qw( Bool HashRef Int Path Str );
-use MetaCPAN::Util                         qw( root_dir );
-use Mojo::Server                           ();
-use Term::ANSIColor                        qw( colored );
+use Carp                         ();
+use MooseX::Types::ElasticSearch qw( ES );
+use File::Path                   ();
+use IO::Prompt::Tiny             qw( prompt );
+use Log::Contextual              qw( :log :dlog );
+use MetaCPAN::Model              ();
+use MetaCPAN::Types::TypeTiny    qw( Bool HashRef Int Path Str );
+use MetaCPAN::Util               qw( root_dir );
+use Mojo::Server                 ();
+use Term::ANSIColor              qw( colored );
 
 with( 'MetaCPAN::Role::HasConfig', 'MetaCPAN::Role::Fastly',
     'MetaCPAN::Role::Logger' );

--- a/lib/MetaCPAN/Script/Author.pm
+++ b/lib/MetaCPAN/Script/Author.pm
@@ -282,7 +282,7 @@ sub update_author {
     $bulk->update( {
         id            => $pauseid,
         doc           => $data,
-        doc_as_upsert => 1,
+        doc_as_upsert => true,
     } );
 
     $self->purge_author_key($pauseid);

--- a/lib/MetaCPAN/Script/Backpan.pm
+++ b/lib/MetaCPAN/Script/Backpan.pm
@@ -94,7 +94,8 @@ sub _get_release_query {
     unless ( $self->undo ) {
         return +{
             query => {
-                not => { term => { status => 'backpan' } }
+                bool =>
+                    { must_not => [ { term => { status => 'backpan' } } ] }
             }
         };
     }

--- a/lib/MetaCPAN/Script/Backpan.pm
+++ b/lib/MetaCPAN/Script/Backpan.pm
@@ -62,18 +62,20 @@ sub build_release_status_map {
     log_info {"find_releases"};
 
     my $scroll = $self->es->scroll_helper(
-        size   => 500,
         scroll => '5m',
         index  => $self->index->name,
         type   => 'release',
-        fields => [ 'author', 'archive', 'name' ],
-        body   => $self->_get_release_query,
+        body   => {
+            %{ $self->_get_release_query },
+            size    => 500,
+            _source => [ 'author', 'archive', 'name' ],
+        },
     );
 
     while ( my $release = $scroll->next ) {
-        my $author  = $release->{fields}{author}[0];
-        my $archive = $release->{fields}{archive}[0];
-        my $name    = $release->{fields}{name}[0];
+        my $author  = $release->{_source}{author};
+        my $archive = $release->{_source}{archive};
+        my $name    = $release->{_source}{name};
         next unless $name;    # bypass some broken releases
 
         $self->_release_status->{$author}{$name} = [
@@ -163,11 +165,9 @@ sub update_files_author {
     log_info { "update_files: " . $author };
 
     my $scroll = $self->es->scroll_helper(
-        size   => 500,
         scroll => '5m',
         index  => $self->index->name,
         type   => 'file',
-        fields => ['release'],
         body   => {
             query => {
                 bool => {
@@ -176,7 +176,9 @@ sub update_files_author {
                         { terms => { release => $author_releases } }
                     ]
                 }
-            }
+            },
+            size    => 500,
+            _source => ['release'],
         },
     );
 
@@ -189,7 +191,7 @@ sub update_files_author {
     my $bulk = $self->_bulk->{file};
 
     while ( my $file = $scroll->next ) {
-        my $release = $file->{fields}{release}[0];
+        my $release = $file->{_source}{release};
         $bulk->update( {
             id  => $file->{_id},
             doc => {

--- a/lib/MetaCPAN/Script/Backup.pm
+++ b/lib/MetaCPAN/Script/Backup.pm
@@ -88,11 +88,11 @@ sub run {
         my $scroll = $es->scroll_helper(
             index => $index,
             $self->type ? ( type => $self->type ) : (),
-            size   => $self->size,
-            fields => [qw(_parent _source)],
             scroll => '1m',
             body   => {
-                sort => '_doc',
+                _source => true,
+                size    => $self->size,
+                sort    => '_doc',
             },
         );
 
@@ -144,7 +144,7 @@ sub run_restore {
         # Fetch relevant bulk helper
         my $bulk = $bulk_store{$bulk_key};
 
-        my $parent = $raw->{fields}->{_parent};
+        my $parent = $raw->{_parent};
 
         if ( $raw->{_type} eq 'author' ) {
 

--- a/lib/MetaCPAN/Script/Backup.pm
+++ b/lib/MetaCPAN/Script/Backup.pm
@@ -9,6 +9,7 @@ use DateTime                  ();
 use IO::Zlib                  ();
 use Log::Contextual           qw( :log :dlog );
 use MetaCPAN::Types::TypeTiny qw( Bool Int Path Str CommaSepOption );
+use MetaCPAN::Util            qw( true false );
 use Moose;
 use Try::Tiny qw( catch try );
 
@@ -176,7 +177,7 @@ sub run_restore {
             $bulk->update( {
                 id            => $raw->{_id},
                 doc           => $raw->{_source},
-                doc_as_upsert => 1,
+                doc_as_upsert => true,
             } );
 
         }

--- a/lib/MetaCPAN/Script/CPANTesters.pm
+++ b/lib/MetaCPAN/Script/CPANTesters.pm
@@ -8,6 +8,7 @@ use File::stat                             qw( stat );
 use IO::Uncompress::Bunzip2                qw( bunzip2 );
 use Log::Contextual                        qw( :log :dlog );
 use MetaCPAN::Types::TypeTiny              qw( Bool Path Uri );
+use MetaCPAN::Util                         qw( true false );
 
 with 'MetaCPAN::Role::Script', 'MooseX::Getopt::Dashes';
 
@@ -157,7 +158,7 @@ sub index_reports {
         my %tests = map { $_ => $row_from_db->{$_} } qw(fail pass na unknown);
         $self->_bulk->update( {
             doc           => { tests => \%tests },
-            doc_as_upsert => 1,
+            doc_as_upsert => true,
             id            => $release_doc->{id},
         } );
     }

--- a/lib/MetaCPAN/Script/CPANTestersAPI.pm
+++ b/lib/MetaCPAN/Script/CPANTestersAPI.pm
@@ -7,6 +7,7 @@ use Cpanel::JSON::XS                       qw( decode_json );
 use ElasticSearchX::Model::Document::Types qw( ESBulk );
 use Log::Contextual                        qw( :log :dlog );
 use MetaCPAN::Types::TypeTiny              qw( Uri );
+use MetaCPAN::Util                         qw( true false );
 use Moose;
 
 with 'MetaCPAN::Role::Script', 'MooseX::Getopt::Dashes';
@@ -127,7 +128,7 @@ sub index_reports {
         my %tests = map { $_ => $row->{$_} } qw(fail pass na unknown);
         $self->_bulk->update( {
             doc           => { tests => \%tests },
-            doc_as_upsert => 1,
+            doc_as_upsert => true,
             id            => $release_doc->{id},
         } );
     }

--- a/lib/MetaCPAN/Script/CVE.pm
+++ b/lib/MetaCPAN/Script/CVE.pm
@@ -6,7 +6,7 @@ use namespace::autoclean;
 use Cpanel::JSON::XS          qw( decode_json );
 use Log::Contextual           qw( :log :dlog );
 use MetaCPAN::Types::TypeTiny qw( Bool Str Uri );
-use MetaCPAN::Util            qw( numify_version true false );
+use MetaCPAN::Util            qw( hit_total numify_version true false );
 use Path::Tiny                qw( path );
 use Ref::Util                 qw( is_arrayref );
 
@@ -177,7 +177,7 @@ sub index_cve_data {
                     },
                 );
 
-                if ( $releases->{hits}{total} ) {
+                if ( hit_total($releases) ) {
                     ## no critic (ControlStructures::ProhibitMutatingListFunctions)
                     @matches = map { $_->[0] }
                         sort { $a->[1] <=> $b->[1] }

--- a/lib/MetaCPAN/Script/CVE.pm
+++ b/lib/MetaCPAN/Script/CVE.pm
@@ -6,7 +6,7 @@ use namespace::autoclean;
 use Cpanel::JSON::XS          qw( decode_json );
 use Log::Contextual           qw( :log :dlog );
 use MetaCPAN::Types::TypeTiny qw( Bool Str Uri );
-use MetaCPAN::Util            qw( numify_version );
+use MetaCPAN::Util            qw( numify_version true false );
 use Path::Tiny                qw( path );
 use Ref::Util                 qw( is_arrayref );
 
@@ -215,7 +215,7 @@ sub index_cve_data {
             $bulk->update( {
                 id            => $cpansa->{cpansa_id},
                 doc           => $doc_data,
-                doc_as_upsert => 1,
+                doc_as_upsert => true,
             } );
         }
     }

--- a/lib/MetaCPAN/Script/Checksum.pm
+++ b/lib/MetaCPAN/Script/Checksum.pm
@@ -4,6 +4,7 @@ use Moose;
 
 use Log::Contextual           qw( :log );
 use MetaCPAN::Types::TypeTiny qw( Bool Int );
+use MetaCPAN::Util            qw( true false );
 
 use Digest::file qw( digest_file_hex );
 
@@ -90,7 +91,7 @@ sub run {
                         checksum_md5    => $checksum_md5,
                         checksum_sha256 => $checksum_sha256
                     },
-                    doc_as_upsert => 1,
+                    doc_as_upsert => true,
                 } );
             }
         }

--- a/lib/MetaCPAN/Script/Checksum.pm
+++ b/lib/MetaCPAN/Script/Checksum.pm
@@ -60,8 +60,8 @@ sub run {
                     ],
                 },
             },
+            _source => [qw( name download_url )],
         },
-        fields => [qw( id name download_url )],
     );
 
     log_warn { "Found " . $scroll->total . " releases" };
@@ -75,12 +75,11 @@ sub run {
             last;
         }
 
-        log_info { "Adding checksums for " . $p->{fields}{name}->[0] };
+        log_info { "Adding checksums for " . $p->{_source}{name} };
 
-        if ( my $download_url = $p->{fields}{download_url} ) {
+        if ( my $download_url = $p->{_source}{download_url} ) {
             my $file
-                = $self->cpan . "/authors" . $p->{fields}{download_url}->[0]
-                =~ s/^.*authors//r;
+                = $self->cpan . "/authors" . $download_url =~ s/^.*authors//r;
             my $checksum_md5    = digest_file_hex( $file, 'MD5' );
             my $checksum_sha256 = digest_file_hex( $file, 'SHA-256' );
 
@@ -101,7 +100,7 @@ sub run {
         }
         else {
             log_info {
-                $p->{fields}{name}->[0] . " is missing a download_url"
+                $p->{_source}{name} . " is missing a download_url"
             };
         }
     }

--- a/lib/MetaCPAN/Script/Checksum.pm
+++ b/lib/MetaCPAN/Script/Checksum.pm
@@ -50,12 +50,16 @@ sub run {
         scroll => '10m',
         body   => {
             query => {
-                not => {
-                    exists => {
-                        field => "checksum_md5"
-                    }
-                }
-            }
+                bool => {
+                    must_not => [
+                        {
+                            exists => {
+                                field => "checksum_md5"
+                            }
+                        },
+                    ],
+                },
+            },
         },
         fields => [qw( id name download_url )],
     );

--- a/lib/MetaCPAN/Script/Cover.pm
+++ b/lib/MetaCPAN/Script/Cover.pm
@@ -7,7 +7,7 @@ use Cpanel::JSON::XS          qw( decode_json );
 use Log::Contextual           qw( :log :dlog );
 use MetaCPAN::Types::TypeTiny qw( Bool Str Uri );
 use Path::Tiny                qw( path );
-use MetaCPAN::Util            qw( true false );
+use MetaCPAN::Util            qw( hit_total true false );
 
 with 'MetaCPAN::Role::Script', 'MooseX::Getopt';
 
@@ -71,7 +71,7 @@ sub index_cover_data {
                     query => { term => { name => $release } },
                 },
             );
-            if ( $rel_check->{hits}{total} ) {
+            if ( hit_total($rel_check) ) {
                 log_info { "Adding release info for '" . $release . "'" };
             }
             else {

--- a/lib/MetaCPAN/Script/Cover.pm
+++ b/lib/MetaCPAN/Script/Cover.pm
@@ -7,6 +7,7 @@ use Cpanel::JSON::XS          qw( decode_json );
 use Log::Contextual           qw( :log :dlog );
 use MetaCPAN::Types::TypeTiny qw( Bool Str Uri );
 use Path::Tiny                qw( path );
+use MetaCPAN::Util            qw( true false );
 
 with 'MetaCPAN::Role::Script', 'MooseX::Getopt';
 
@@ -92,7 +93,7 @@ sub index_cover_data {
                     release      => $release,
                     criteria     => \%doc_data,
                 },
-                doc_as_upsert => 1,
+                doc_as_upsert => true,
             } );
         }
     }

--- a/lib/MetaCPAN/Script/External.pm
+++ b/lib/MetaCPAN/Script/External.pm
@@ -8,6 +8,7 @@ use Email::Simple         ();
 use Log::Contextual       qw( :log );
 
 use MetaCPAN::Types::TypeTiny qw( Str );
+use MetaCPAN::Util            qw( true false );
 
 with(
     'MetaCPAN::Role::Script',
@@ -103,7 +104,7 @@ sub update {
                     $external_source => $dist->{$d}
                 }
             },
-            doc_as_upsert => 1,
+            doc_as_upsert => true,
         } );
     }
 

--- a/lib/MetaCPAN/Script/Latest.pm
+++ b/lib/MetaCPAN/Script/Latest.pm
@@ -123,8 +123,8 @@ sub run {
                 must => [
                     {
                         nested => {
-                            path   => 'module',
-                            filter => { bool => { must => $filter } }
+                            path  => 'module',
+                            query => { bool => { must => $filter } }
                         }
                     },
                     { term => { 'maturity' => 'released' } },

--- a/lib/MetaCPAN/Script/Mapping.pm
+++ b/lib/MetaCPAN/Script/Mapping.pm
@@ -688,7 +688,24 @@ sub _compare_mapping {
                         }
                     }
                     else {    # Scalar Value
-                        if ( $deploy_value ne $model_value ) {
+                        if (
+                               $sfield eq 'type'
+                            && $model_value eq 'string'
+                            && (   $deploy_value eq 'text'
+                                || $deploy_value eq 'keyword' )
+                            )
+                        {
+                            # ES5 automatically converts string types to text
+                            # or keyword. once we upgrade to ES5 and update
+                            # our mappings, this special case can be removed.
+                        }
+                        elsif ($sfield eq 'index'
+                            && $model_value eq 'no'
+                            && $deploy_value eq 'false' )
+                        {
+                            # another ES5 string automatic conversion
+                        }
+                        elsif ( $deploy_value ne $model_value ) {
                             log_error {
                                 'Mismatch field: '
                                     . $sname . '.'

--- a/lib/MetaCPAN/Script/Mapping.pm
+++ b/lib/MetaCPAN/Script/Mapping.pm
@@ -708,11 +708,24 @@ sub _compare_mapping {
                         $imatch = 0;
 
                     }
+
                     unless ( defined $rmodel->{$sfield} ) {
-                        log_error {
-                            'Missing definition: ' . $sname . '.' . $sfield
-                        };
-                        $imatch = 0;
+                        if (   $sfield eq 'payloads'
+                            && $rmodel->{type}
+                            && $rmodel->{type} eq 'completion'
+                            && !$rdeploy->{$sfield} )
+                        {
+                            # ES5 doesn't allow payloads option. we've removed
+                            # it from our mapping. but it gets a default
+                            # value. ignore the default.
+                        }
+                        else {
+                            log_error {
+                                'Missing definition: ' . $sname . '.'
+                                    . $sfield
+                            };
+                            $imatch = 0;
+                        }
                     }
                 }
             }

--- a/lib/MetaCPAN/Script/Mapping/CPAN/File.pm
+++ b/lib/MetaCPAN/Script/Mapping/CPAN/File.pm
@@ -210,10 +210,7 @@ sub mapping {
             "fields" : {
               "analyzed" : {
                 "type" : "string",
-                "term_vector" : "with_positions_offsets",
-                "fielddata" : {
-                  "format" : "disabled"
-                },
+                "index" : "analyzed",
                 "analyzer" : "standard"
               }
             }

--- a/lib/MetaCPAN/Script/Mapping/CPAN/File.pm
+++ b/lib/MetaCPAN/Script/Mapping/CPAN/File.pm
@@ -206,12 +206,15 @@ sub mapping {
           },
           "pod" : {
             "type" : "string",
-            "index" : "no",
+            "index" : "analyzed",
+            "analyzer" : "standard",
+            "doc_values" : false,
             "fields" : {
               "analyzed" : {
                 "type" : "string",
                 "index" : "analyzed",
-                "analyzer" : "standard"
+                "analyzer" : "standard",
+                "doc_values" : false
               }
             }
           },

--- a/lib/MetaCPAN/Script/Mapping/CPAN/File.pm
+++ b/lib/MetaCPAN/Script/Mapping/CPAN/File.pm
@@ -283,7 +283,6 @@ sub mapping {
           "suggest" : {
             "type" : "completion",
             "analyzer" : "simple",
-            "payloads" : true,
             "preserve_separators" : true,
             "preserve_position_increments" : true,
             "max_input_length" : 50

--- a/lib/MetaCPAN/Script/Package.pm
+++ b/lib/MetaCPAN/Script/Package.pm
@@ -6,6 +6,7 @@ use CPAN::DistnameInfo        ();
 use IO::Uncompress::Gunzip    ();
 use Log::Contextual           qw( :log );
 use MetaCPAN::Types::TypeTiny qw( Bool );
+use MetaCPAN::Util            qw( true false );
 
 with 'MooseX::Getopt', 'MetaCPAN::Role::Script';
 
@@ -79,7 +80,7 @@ sub index_packages {
         $bulk->update( {
             id            => $name,
             doc           => $doc,
-            doc_as_upsert => 1,
+            doc_as_upsert => true,
         } );
 
         $seen{$name} = 1;

--- a/lib/MetaCPAN/Script/Permission.pm
+++ b/lib/MetaCPAN/Script/Permission.pm
@@ -4,6 +4,7 @@ use Moose;
 
 use Log::Contextual           qw( :log );
 use MetaCPAN::Types::TypeTiny qw( Bool );
+use MetaCPAN::Util            qw( true false );
 use PAUSE::Permissions        ();
 
 with 'MooseX::Getopt', 'MetaCPAN::Role::Script';
@@ -64,7 +65,7 @@ sub index_permissions {
         $bulk->update( {
             id            => $name,
             doc           => $doc,
-            doc_as_upsert => 1,
+            doc_as_upsert => true,
         } );
 
         $seen{$name} = 1;

--- a/lib/MetaCPAN/Script/River.pm
+++ b/lib/MetaCPAN/Script/River.pm
@@ -6,6 +6,7 @@ use namespace::autoclean;
 use Cpanel::JSON::XS          qw( decode_json );
 use Log::Contextual           qw( :log :dlog );
 use MetaCPAN::Types::TypeTiny qw( Uri );
+use MetaCPAN::Util            qw( true false );
 
 with 'MetaCPAN::Role::Script', 'MooseX::Getopt';
 
@@ -42,7 +43,7 @@ sub index_river_summaries {
                 name  => $dist,
                 river => $summary,
             },
-            doc_as_upsert => 1,
+            doc_as_upsert => true,
         } );
     }
     $bulk->flush;

--- a/lib/MetaCPAN/Script/Role/Contributor.pm
+++ b/lib/MetaCPAN/Script/Role/Contributor.pm
@@ -2,7 +2,7 @@ package MetaCPAN::Script::Role::Contributor;
 
 use Moose::Role;
 
-use MetaCPAN::Util qw( digest );
+use MetaCPAN::Util qw( digest true false );
 use Ref::Util      qw( is_arrayref );
 
 sub get_cpan_author_contributors {
@@ -58,7 +58,7 @@ sub update_release_contirbutors {
                 release_author => $d->{release_author},
                 distribution   => $d->{distribution},
             },
-            doc_as_upsert => 1,
+            doc_as_upsert => true,
         } );
     }
 

--- a/lib/MetaCPAN/Script/Suggest.pm
+++ b/lib/MetaCPAN/Script/Suggest.pm
@@ -96,9 +96,8 @@ sub _update_slice {
             id  => $file->{fields}{id}[0],
             doc => {
                 suggest => {
-                    input   => [$documentation],
-                    payload => { doc_name => $documentation },
-                    weight  => $weight,
+                    input  => [$documentation],
+                    weight => $weight,
                 }
             },
         } );

--- a/lib/MetaCPAN/Script/Suggest.pm
+++ b/lib/MetaCPAN/Script/Suggest.pm
@@ -66,8 +66,6 @@ sub _update_slice {
         index  => $self->index->name,
         type   => 'file',
         scroll => '5m',
-        fields => [qw< id documentation >],
-        size   => 500,
         body   => {
             query => {
                 bool => {
@@ -76,7 +74,9 @@ sub _update_slice {
                     ],
                 },
             },
-            sort => '_doc',
+            _source => [qw< documentation >],
+            size    => 500,
+            sort    => '_doc',
         },
     );
 
@@ -88,12 +88,12 @@ sub _update_slice {
     );
 
     while ( my $file = $files->next ) {
-        my $documentation = $file->{fields}{documentation}[0];
+        my $documentation = $file->{_source}{documentation};
         my $weight        = 1000 - length($documentation);
         $weight = 0 if $weight < 0;
 
         $bulk->update( {
-            id  => $file->{fields}{id}[0],
+            id  => $file->{_id},
             doc => {
                 suggest => {
                     input  => [$documentation],

--- a/lib/MetaCPAN/Script/Tickets.pm
+++ b/lib/MetaCPAN/Script/Tickets.pm
@@ -84,7 +84,8 @@ sub check_all_distributions {
         fields => ['distribution'],
         body   => {
             query => {
-                not => { term => { status => 'backpan' } }
+                bool =>
+                    { must_not => [ { term => { status => 'backpan' } } ] }
             }
         },
     );

--- a/lib/MetaCPAN/Script/Tickets.pm
+++ b/lib/MetaCPAN/Script/Tickets.pm
@@ -77,23 +77,23 @@ sub check_all_distributions {
 
     # first: make sure all distributions have an entry
     my $scroll = $self->es->scroll_helper(
-        size   => 500,
         scroll => '5m',
         index  => $self->index->name,
         type   => 'release',
-        fields => ['distribution'],
         body   => {
             query => {
                 bool =>
                     { must_not => [ { term => { status => 'backpan' } } ] }
-            }
+            },
+            size    => 500,
+            _source => ['distribution'],
         },
     );
 
     my $dists = {};
 
     while ( my $release = $scroll->next ) {
-        my $distribution = $release->{'fields'}{'distribution'}[0];
+        my $distribution = $release->{_source}{'distribution'};
         $distribution or next;
         $dists->{$distribution} = { name => $distribution };
     }

--- a/lib/MetaCPAN/Script/Tickets.pm
+++ b/lib/MetaCPAN/Script/Tickets.pm
@@ -8,6 +8,7 @@ $ENV{PERL_LWP_SSL_VERIFY_HOSTNAME} = 0;
 
 use HTTP::Request::Common qw( GET );
 use Log::Contextual       qw( :log :dlog );
+use MetaCPAN::Util        qw( true false );
 use Net::GitHub::V4       ();
 use Ref::Util             qw( is_hashref is_ref );
 use Text::CSV_XS          ();
@@ -275,7 +276,7 @@ sub _bulk_update {
         $self->_bulk->update( {
             id            => $distribution,
             doc           => $summary->{$distribution},
-            doc_as_upsert => 1,
+            doc_as_upsert => true,
         } );
     }
 

--- a/lib/MetaCPAN/Script/Watcher.pm
+++ b/lib/MetaCPAN/Script/Watcher.pm
@@ -8,7 +8,7 @@ use CPAN::DistnameInfo        ();
 use Cpanel::JSON::XS          qw( decode_json );
 use Log::Contextual           qw( :log );
 use MetaCPAN::Types::TypeTiny qw( Bool );
-use MetaCPAN::Util;
+use MetaCPAN::Util            qw( true false );
 
 with 'MetaCPAN::Role::Script', 'MooseX::Getopt';
 

--- a/lib/MetaCPAN/Script/Watcher.pm
+++ b/lib/MetaCPAN/Script/Watcher.pm
@@ -95,23 +95,23 @@ sub changes {
 sub backpan_changes {
     my $self   = shift;
     my $scroll = $self->es->scroll_helper( {
-        size   => 1000,
         scroll => '1m',
         index  => $self->index->name,
         type   => 'release',
-        fields => [qw(author archive)],
         body   => {
             query => {
                 bool => {
                     must_not => [ { term => { status => 'backpan' } }, ],
                 },
             },
-            sort => '_doc',
+            size    => 1000,
+            _source => [qw(author archive)],
+            sort    => '_doc',
         }
     } );
     my @changes;
     while ( my $release = $scroll->next ) {
-        my $data = $release->{fields};
+        my $data = $release->{_source};
         my $path
             = $self->cpan->child( 'authors',
             MetaCPAN::Util::author_dir( $data->{author} ),
@@ -173,8 +173,6 @@ sub reindex_release {
         index  => $self->index->name,
         type   => 'file',
         scroll => '1m',
-        size   => 1000,
-        fields => [ '_parent', '_source' ],
         body   => {
             query => {
                 bool => {
@@ -192,7 +190,9 @@ sub reindex_release {
                     ],
                 },
             },
-            sort => '_doc',
+            size    => 1000,
+            _source => true,
+            sort    => '_doc',
         },
     } );
     return if ( $self->dry_run );
@@ -210,11 +210,7 @@ sub reindex_release {
         $bulk_helper{file}->index( {
             id     => $row->{_id},
             source => {
-                $row->{fields}->{_parent}
-                ? ( parent => $row->{fields}->{_parent} )
-                : (),
-                %$source,
-                status => 'backpan',
+                %$source, status => 'backpan',
             }
         } );
     }

--- a/lib/MetaCPAN/Server/Controller/Author.pm
+++ b/lib/MetaCPAN/Server/Controller/Author.pm
@@ -4,7 +4,6 @@ use strict;
 use warnings;
 
 use Moose;
-use MetaCPAN::Util qw( single_valued_arrayref_to_scalar );
 
 BEGIN { extends 'MetaCPAN::Server::Controller' }
 

--- a/lib/MetaCPAN/Server/Controller/Login.pm
+++ b/lib/MetaCPAN/Server/Controller/Login.pm
@@ -5,6 +5,7 @@ use warnings;
 
 use Cpanel::JSON::XS qw( decode_json encode_json );
 use Moose;
+use MetaCPAN::Util qw( true false );
 
 BEGIN { extends 'Catalyst::Controller' }
 
@@ -44,7 +45,7 @@ sub update_user {
         $user ||= $model->new_document;
         $user->add_identity( { name => $type, key => $id, extra => $data } );
         $user->clear_looks_human;    # rebuild
-        $user->put( { refresh => 1 } );
+        $user->put( { refresh => true } );
     }
     $c->authenticate( { user => $user } );
 

--- a/lib/MetaCPAN/Server/Controller/OAuth2.pm
+++ b/lib/MetaCPAN/Server/Controller/OAuth2.pm
@@ -5,6 +5,7 @@ BEGIN { extends 'Catalyst::Controller' }
 
 use Cpanel::JSON::XS qw( decode_json encode_json );
 use Digest::SHA      ();
+use MetaCPAN::Util   qw( true false );
 use URI              ();
 
 has login   => ( is => 'ro' );
@@ -50,7 +51,7 @@ sub authorize : Local {
     my $code = $self->_build_code;
     $uri->query_form( { code => $code, $state ? ( state => $state ) : () } );
     $c->user->_set_code($code);
-    $c->user->put( { refresh => 1 } );
+    $c->user->put( { refresh => true } );
     $c->res->redirect($uri);
 }
 
@@ -89,7 +90,7 @@ sub access_token : Local {
             { token => $access_token, client => $client_id } );
     }
     $user->clear_token;
-    $user->put( { refresh => 1 } );
+    $user->put( { refresh => true } );
 
     $c->res->content_type('application/json');
     $c->res->body( encode_json(

--- a/lib/MetaCPAN/Server/Controller/Release.pm
+++ b/lib/MetaCPAN/Server/Controller/Release.pm
@@ -4,7 +4,6 @@ use strict;
 use warnings;
 
 use Moose;
-use MetaCPAN::Util qw( single_valued_arrayref_to_scalar );
 
 BEGIN { extends 'MetaCPAN::Server::Controller' }
 

--- a/lib/MetaCPAN/Server/Controller/Search/Autocomplete.pm
+++ b/lib/MetaCPAN/Server/Controller/Search/Autocomplete.pm
@@ -4,7 +4,6 @@ use strict;
 use warnings;
 
 use Moose;
-use MetaCPAN::Util qw( single_valued_arrayref_to_scalar );
 
 BEGIN { extends 'MetaCPAN::Server::Controller' }
 

--- a/lib/MetaCPAN/Server/Controller/User.pm
+++ b/lib/MetaCPAN/Server/Controller/User.pm
@@ -3,7 +3,8 @@ package MetaCPAN::Server::Controller::User;
 use strict;
 use warnings;
 
-use DateTime ();
+use DateTime       ();
+use MetaCPAN::Util qw( true false );
 use Moose;
 use Log::Log4perl::MDC ();
 
@@ -57,7 +58,7 @@ sub identity_DELETE {
     my $user = $c->user;
     if ( $user->has_identity($identity) ) {
         my $id = $user->remove_identity($identity);
-        $user->put( { refresh => 1 } );
+        $user->put( { refresh => true } );
         $self->status_ok( $c, entity => $id );
     }
     else {
@@ -102,7 +103,7 @@ sub profile_PUT {
     }
     else {
         $profile
-            = $c->model('CPAN::Author')->put( $profile, { refresh => 1 } );
+            = $c->model('CPAN::Author')->put( $profile, { refresh => true } );
         $self->status_created(
             $c,
             location => $c->uri_for( '/author/' . $profile->{pauseid} ),

--- a/lib/MetaCPAN/Server/Controller/User/Favorite.pm
+++ b/lib/MetaCPAN/Server/Controller/User/Favorite.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Moose;
+use MetaCPAN::Util qw( true false );
 
 BEGIN { extends 'Catalyst::Controller::REST' }
 
@@ -33,7 +34,7 @@ sub index_POST {
             release      => $data->{release},
             distribution => $data->{distribution},
         },
-        { refresh => 1 }
+        { refresh => true }
     );
     $c->purge_author_key( $data->{author} )     if $data->{author};
     $c->purge_dist_key( $data->{distribution} ) if $data->{distribution};
@@ -50,7 +51,7 @@ sub index_DELETE {
     my $favorite = $c->model('CPAN::Favorite')
         ->get( { user => $c->user->id, distribution => $distribution } );
     if ($favorite) {
-        $favorite->delete( { refresh => 1 } );
+        $favorite->delete( { refresh => true } );
         $c->purge_author_key( $favorite->author )
             if $favorite->author;
         $c->purge_dist_key($distribution);

--- a/lib/MetaCPAN/Server/Controller/User/Turing.pm
+++ b/lib/MetaCPAN/Server/Controller/User/Turing.pm
@@ -5,6 +5,7 @@ use warnings;
 
 use DateTime ();
 use Moose;
+use MetaCPAN::Util qw( true false );
 
 BEGIN { extends 'Catalyst::Controller::REST' }
 
@@ -33,7 +34,7 @@ sub index_POST {
     if ( $result->{is_valid} ) {
         $user->_set_passed_captcha( DateTime->now );
         $user->clear_looks_human;    # rebuild
-        $user->put( { refresh => 1 } );
+        $user->put( { refresh => true } );
         $self->status_ok( $c, entity => $user->meta->get_data($user) );
     }
     else {

--- a/lib/MetaCPAN/Util.pm
+++ b/lib/MetaCPAN/Util.pm
@@ -29,6 +29,7 @@ use Sub::Exporter -setup => {
         fix_pod
         fix_version
         generate_sid
+        hit_total
         numify_version
         pod_lines
         strip_pod
@@ -95,6 +96,15 @@ sub author_dir {
         substr( $pauseid, 0, 1 ),
         substr( $pauseid, 0, 2 ), $pauseid );
     return $dir;
+}
+
+sub hit_total {
+    my $res   = shift;
+    my $total = $res && $res->{hits} && $res->{hits}{total};
+    if ( ref $total ) {
+        return $total->{value};
+    }
+    return $total;
 }
 
 # TODO: E<escape>

--- a/t/lib/MetaCPAN/TestServer.pm
+++ b/t/lib/MetaCPAN/TestServer.pm
@@ -18,6 +18,7 @@ use MetaCPAN::Server                 ();
 use MetaCPAN::Server::Config         ();
 use MetaCPAN::TestHelpers            qw( fakecpan_dir );
 use MetaCPAN::Types::TypeTiny        qw( HashRef Path );
+use MetaCPAN::Util                   qw( true false );
 use MooseX::Types::ElasticSearch     qw( ES );
 use Search::Elasticsearch            ();
 use Test::More;
@@ -262,12 +263,12 @@ sub prepare_user_test_data {
     );
     ok( $user->add_identity( { name => 'pause', key => 'MO' } ),
         'add pause identity' );
-    ok( $user->put( { refresh => 1 } ), 'put user' );
+    ok( $user->put( { refresh => true } ), 'put user' );
 
     ok(
         MetaCPAN::Server->model('User::Account')->put(
             { access_token => [ { client => 'testing', token => 'bot' } ] },
-            { refresh      => 1 }
+            { refresh      => true }
         ),
         'put bot user'
     );

--- a/t/query/release.t
+++ b/t/query/release.t
@@ -7,9 +7,10 @@ use MetaCPAN::Query::Release ();
 use MetaCPAN::Server::Test   ();
 use Test::More;
 
-my $query
-    = MetaCPAN::Query::Release->new(
-    es => MetaCPAN::Server::Test::model->es() );
+my $query = MetaCPAN::Query::Release->new(
+    es         => MetaCPAN::Server::Test::model->es(),
+    index_name => 'cpan',
+);
 
 is( $query->_get_latest_release('DoesNotExist'),
     undef, '_get_latest_release returns undef when release does not exist' );

--- a/t/release/moose.t
+++ b/t/release/moose.t
@@ -3,6 +3,7 @@ use warnings;
 use lib 't/lib';
 
 use MetaCPAN::Server::Test qw( model );
+use MetaCPAN::Util         qw( true false );
 use Test::More;
 
 my $model = model();
@@ -84,7 +85,7 @@ $signature = $idx->type('file')->query( {
         must => [
             { term   => { name    => 'SIGNATURE' } },
             { exists => { field   => 'documentation' } },
-            { term   => { indexed => 1 } },
+            { term   => { indexed => true } },
         ],
     },
 } )->first;

--- a/t/release/moose.t
+++ b/t/release/moose.t
@@ -3,7 +3,7 @@ use warnings;
 use lib 't/lib';
 
 use MetaCPAN::Server::Test qw( model );
-use MetaCPAN::Util         qw( true false );
+use MetaCPAN::Util         qw( true false hit_total );
 use Test::More;
 
 my $model = model();
@@ -98,10 +98,10 @@ ok( !$signature, 'SIGNATURE is not pod' );
 
     is_deeply( $module->{hits}, $file->{hits},
         'history of Moose and lib/Moose.pm match' );
-    is( $module->{hits}->{total}, 2, 'two hits' );
+    is( hit_total($module), 2, 'two hits' );
 
     my $pod = $files->history( documentation => 'Moose::FAQ' )->raw->all;
-    is( $pod->{hits}->{total}, 1, 'one hit' );
+    is( hit_total($pod), 1, 'one hit' );
 }
 
 done_testing;

--- a/t/server/controller/distribution.t
+++ b/t/server/controller/distribution.t
@@ -4,6 +4,7 @@ use lib 't/lib';
 
 use MetaCPAN::Server::Test qw( app GET test_psgi );
 use MetaCPAN::TestHelpers  qw( decode_json_ok test_cache_headers );
+use MetaCPAN::Util         qw( hit_total );
 use Test::More;
 
 my @tests = (
@@ -53,7 +54,7 @@ test_psgi app, sub {
 
         my $json = decode_json_ok($res);
         if ( $k eq '/distribution' ) {
-            ok( $json->{hits}->{total}, 'got total count' );
+            ok( hit_total($json), 'got total count' );
         }
         elsif ( $v eq 200 ) {
 

--- a/t/server/controller/file.t
+++ b/t/server/controller/file.t
@@ -4,6 +4,7 @@ use lib 't/lib';
 
 use MetaCPAN::Server::Test qw( app GET test_psgi );
 use MetaCPAN::TestHelpers  qw( decode_json_ok test_cache_headers );
+use MetaCPAN::Util         qw( hit_total );
 use Test::More;
 
 my %tests = (
@@ -59,7 +60,7 @@ test_psgi app, sub {
 
         my $json = decode_json_ok($res);
         if ( $k eq '/file' ) {
-            ok( $json->{hits}->{total}, 'got total count' );
+            ok( hit_total($json), 'got total count' );
         }
         elsif ( $v eq 200 ) {
             ok( $json->{name} eq 'Moose.pm', 'Moose.pm' );

--- a/t/server/controller/module.t
+++ b/t/server/controller/module.t
@@ -4,6 +4,7 @@ use lib 't/lib';
 
 use MetaCPAN::Server::Test qw( app GET test_psgi );
 use MetaCPAN::TestHelpers  qw( decode_json_ok test_cache_headers );
+use MetaCPAN::Util         qw( hit_total );
 use Test::More;
 
 my %tests = (
@@ -69,7 +70,7 @@ test_psgi app, sub {
 
         my $json = decode_json_ok($res);
         if ( $k eq '/module' ) {
-            ok( $json->{hits}->{total}, 'got total count' );
+            ok( hit_total($json), 'got total count' );
         }
         elsif ( $k =~ /fields/ ) {
             is_deeply(


### PR DESCRIPTION
- Fixes a few queries that I missed before using nested.filter or not.
- Fix some ES parameters to use JSON booleans.
- Ignore string to text/keyword type conversion done by Elasticsearch 5.
  - Fixes #1269
- Monkey patch ElasticSearchX::Model to avoid search_type: scan.
- Remove some options from the mapping that are no longer supported on Elasticsearch 5, but we don't appear to be using.
- various other query fixes
- remove payload from a completion field
- don't try to limit _source in nested query
- fix max aggregation to use syntax compatible with es5 scripting
- update pod field
  - remove term_vector and fielddata settings, which seem unneeded and prevent upgrade to text or keyword
  - convert main pod field to analyzed, as we never need exact matches and indexing is problematic when large
  - disable doc_values as unneeded and problematic for long values
- convert all queries to use `_source` rather than `fields`. Requires a hack in ESXM.
  - Fixes #1263
- cope with hits.total being an object (ES7)
  - Fixes #1301