### PR TITLE
Remove unused Term::Choose prereq

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -125,7 +125,6 @@ requires 'Scalar::Util', '1.62'; # Moose
 requires 'Search::Elasticsearch' => '8.12';
 requires 'Search::Elasticsearch::Client::2_0' => '6.81';
 requires 'Search::Elasticsearch::Client::5_0' => '6.81';
-requires 'Term::Choose', '1.754'; # Git::Helpers
 requires 'Throwable::Error';
 requires 'Term::Size::Any'; # for Catalyst
 requires 'Text::CSV_XS';


### PR DESCRIPTION
Git::Helpers has been removed from the prereqs, so we don't need Term::Choose