### PR TITLE
return more versions for all dists

### DIFF
--- a/lib/MetaCPAN/Query/Release.pm
+++ b/lib/MetaCPAN/Query/Release.pm
@@ -538,7 +538,7 @@ sub all_by_author {
 sub versions {
     my ( $self, $dist, $versions ) = @_;
 
-    my $size = $dist eq 'perl' ? 1000 : 250;
+    my $size = 1000;
 
     my $query;
 


### PR DESCRIPTION
The perl dist isn't the only one with more than 250 releases.