### PR TITLE
normalize package names to use ::

### DIFF
--- a/lib/MetaCPAN/Model/Release.pm
+++ b/lib/MetaCPAN/Model/Release.pm
@@ -545,9 +545,15 @@ sub _modules_from_files {
 
           # Ignore packages that people cannot claim.
           # https://github.com/andk/pause/blob/master/lib/PAUSE/pmfile.pm#L236
-                for my $pkg ( grep { $_ ne 'main' && $_ ne 'DB' }
-                    $info->packages_inside )
-                {
+          #
+          # Parse::PMFile and PAUSE translate apostrophes to double colons,
+          # but Module::Metadata does not.
+                my @packages
+                    = map s{'}{::}gr,
+                    grep { $_ ne 'main' && $_ ne 'DB' }
+                    $info->packages_inside;
+
+                for my $pkg (@packages) {
                     my $version = $info->version($pkg);
                     $file->add_module( {
                         name => $pkg,


### PR DESCRIPTION
package names extracted by PAUSE or Parse::PMFile are normalized to use double colons rather than apostrophe. Module::Metadata does not. Add the normalization to the output of Module::Metadata when we index files so that the module names will match what exists in 02packages.