### PR TITLE
Improved configuration mechanism for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /local/
 /log4perl_local.conf
 /metacpan_server_local.*
+/metacpan_server_testing_local.*
 /perltidy.LOG
 /pm_to_blib
 /var

--- a/lib/MetaCPAN/Server.pm
+++ b/lib/MetaCPAN/Server.pm
@@ -4,10 +4,11 @@ use Moose;
 
 ## no critic (Modules::RequireEndWithOne)
 use Catalyst qw( +MetaCPAN::Role::Fastly::Catalyst ), '-Log=warn,error,fatal';
-use Digest::SHA             ();
-use Log::Log4perl::Catalyst ();
-use Plack::Builder          qw( builder enable );
-use Ref::Util               qw( is_arrayref is_hashref );
+use Digest::SHA              ();
+use Log::Log4perl::Catalyst  ();
+use Plack::Builder           qw( builder enable );
+use Ref::Util                qw( is_arrayref is_hashref );
+use MetaCPAN::Server::Config ();
 
 extends 'Catalyst';
 
@@ -72,9 +73,9 @@ __PACKAGE__->config(
 
 __PACKAGE__->log( Log::Log4perl::Catalyst->new( undef, autoflush => 1 ) );
 
+__PACKAGE__->config( MetaCPAN::Server::Config::config() );
 __PACKAGE__->setup( qw(
     Static::Simple
-    ConfigLoader
     Session
     Session::Store::ElasticSearch
     Session::State::Cookie

--- a/lib/MetaCPAN/Server/Config.pm
+++ b/lib/MetaCPAN/Server/Config.pm
@@ -21,9 +21,9 @@ sub _zomg {
     my $path = shift;
 
     my $config = Config::ZOMG->new(
-        local_suffix => $ENV{HARNESS_ACTIVE} ? 'testing' : 'local',
-        name         => 'metacpan_server',
-        path         => $path,
+        name => 'metacpan_server'
+            . ( $ENV{HARNESS_ACTIVE} ? '_testing' : '' ),
+        path => $path,
     );
 
     my $c = $config->open;

--- a/metacpan_server_testing.yaml
+++ b/metacpan_server_testing.yaml
@@ -1,3 +1,4 @@
+git: /usr/bin/git
 cpan: var/t/tmp/fakecpan
 die_on_error: 1
 level: warn
@@ -8,12 +9,11 @@ elasticsearch_servers:
   client: '2_0::Direct'
   nodes: http://elasticsearch_test:9200
 
+minion_dsn: "postgresql://metacpan:t00lchain@pghost:5432/minion_queue"
+
 logger:
   class: Log::Log4perl::Appender::Screen
   name: testing
-
-github_key: foo
-github_secret: bar
 
 secret: weak
 
@@ -22,3 +22,16 @@ smtp:
   port: 465
   username: foo@metacpan.org
   password: seekrit
+
+oauth:
+  github:
+    key: seekrit
+    secret: seekrit
+  google:
+    key: seekrit
+    secret: seekrit
+  twitter:
+    key: seekrit
+    secret: seekrit
+
+front_end_url: http://0.0.0.0:5001


### PR DESCRIPTION
This ensures that the configuration used by Catalyst is the same as what is used by the scripts and everything else. And it allows a `metacpan_server_testing_local` config file to be used.