### PR TITLE
fix autocomplete not including exact matches

### DIFF
--- a/lib/MetaCPAN/Query/File.pm
+++ b/lib/MetaCPAN/Query/File.pm
@@ -452,7 +452,7 @@ sub _autocomplete {
 
     return {
         took        => $sugg_res->{took} + $res->{took} + $fav_res->{took},
-        suggestions => \@sorted,
+        suggestions => [ ( $exact ? $exact : () ), @sorted ],
     };
 }
 


### PR DESCRIPTION
This was broken by a29eff9fbe01a93a711e92f5554228e4c0186a23.

Fixes metacpan/metacpan-web#3309