### PR TITLE
Add "security" category for special files

### DIFF
--- a/lib/MetaCPAN/Query/File.pm
+++ b/lib/MetaCPAN/Query/File.pm
@@ -96,6 +96,15 @@ my %special_files = (
         dist.ini
         minil.toml
     ) ],
+    security => [
+        _doc_files( qw(
+            Security
+            security
+        ) ),
+        qw(
+            security.txt
+        ),
+    ],
     other => [
         _doc_files( qw(
             Authors


### PR DESCRIPTION
For https://github.com/metacpan/metacpan-web/issues/3246 - _doc_files will handle all-caps, md and pod variants of the files, `security.txt` included separately. Not sure if this is enough to include them in "other files" on the release page.