### PR TITLE
fix the pod end point when given a module name

### DIFF
--- a/lib/MetaCPAN/Query/File.pm
+++ b/lib/MetaCPAN/Query/File.pm
@@ -679,7 +679,7 @@ sub find_pod {
                 query => $query,
             },
         );
-        return $pod_file->{hits}{hits}[0];
+        return $pod_file->{hits}{hits}[0]->{_source};
     }
     else {
         return $file;

--- a/lib/MetaCPAN/Server/Controller/Pod.pm
+++ b/lib/MetaCPAN/Server/Controller/Pod.pm
@@ -38,8 +38,7 @@ sub get : Path('') : Args(1) {
     my ( $self, $c, $module ) = @_;
     $module = $c->model('ESQuery')->file->find_pod($module)
         or $c->detach( '/not_found', [] );
-    $c->forward( 'find',
-        [ map { $module->{_source}{$_} } qw(author release path) ] );
+    $c->forward( 'find', [ map { $module->{$_} } qw(author release path) ] );
 }
 
 sub find_dist_links {

--- a/lib/MetaCPAN/Server/Model/Source.pm
+++ b/lib/MetaCPAN/Server/Model/Source.pm
@@ -87,8 +87,11 @@ sub path {
     my $source      = $source_base->child( $distvname, @file );
     return $source
         if -e $source;
+
+    # if the directory exists, we already extracted the archive, so if the
+    # file didn't exist, we can stop here
     return undef
-        if -e $source_base->child($distvname);    # previously extracted, but file does not exist
+        if -e $source_base->child($distvname);
 
     my $release_data
         = $self->es_query->release->by_author_and_name( $pauseid, $distvname )


### PR DESCRIPTION
The find_pod method would sometimes return the source and sometimes a full record from Elasticsearch. Fix the return to always return the source, and adjust the caller to work with this form.