### PR TITLE
use a simple numeric total for hits on a scroll

### DIFF
--- a/lib/MetaCPAN/Server/Controller.pm
+++ b/lib/MetaCPAN/Server/Controller.pm
@@ -4,7 +4,7 @@ use Moose;
 use namespace::autoclean;
 
 use MetaCPAN::ESConfig qw( es_doc_path );
-use MetaCPAN::Util     qw( single_valued_arrayref_to_scalar );
+use MetaCPAN::Util     qw( single_valued_arrayref_to_scalar simplify_total );
 
 BEGIN { extends 'Catalyst::Controller'; }
 
@@ -107,6 +107,7 @@ sub search : Path('_search') : ActionClass('~Deserialize') {
         } );
         single_valued_arrayref_to_scalar( $_->{fields} )
             for @{ $res->{hits}{hits} };
+        simplify_total($res);
         $c->stash($res);
         1;
     } or do { $self->internal_error( $c, $@ ) };

--- a/lib/MetaCPAN/Server/Controller/Scroll.pm
+++ b/lib/MetaCPAN/Server/Controller/Scroll.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use namespace::autoclean;
 
-use MetaCPAN::Util qw(true false);
+use MetaCPAN::Util qw(true false simplify_total);
 use Moose;
 use Try::Tiny qw( catch try );
 
@@ -60,6 +60,8 @@ sub index : Path('/_search/scroll') : Args {
             scroll    => $c->req->params->{scroll},
         } );
     } or do { $self->internal_error( $c, $@ ); };
+
+    simplify_total($res);
 
     $c->stash($res);
 }

--- a/lib/MetaCPAN/Util.pm
+++ b/lib/MetaCPAN/Util.pm
@@ -30,6 +30,7 @@ use Sub::Exporter -setup => {
         fix_version
         generate_sid
         hit_total
+        simplify_total
         numify_version
         pod_lines
         strip_pod
@@ -110,6 +111,20 @@ sub hit_total {
         return $total->{value};
     }
     return $total;
+}
+
+# Backward compatibility with older clients, especially MetaCPAN::Client.
+# The simple numeric total can be valid in modern ES, so it seems acceptable
+# to use it as a default.
+sub simplify_total {
+    my $res = shift;
+    if ( ref $res && ref $res->{hits} ) {
+        my $total = ref $res->{hits}{total};
+        if ( ref $total ) {
+            $res->{hits}{total} = $total->{value};
+        }
+    }
+    return;
 }
 
 # TODO: E<escape>


### PR DESCRIPTION
Newer Elasticsearch versions can return a more complex value for hits total on a scroll. MetaCPAN::Client is not expecting this. According to the ES docs, a simple number for total is still valid, so we can simplify the return to just use a number for now. This should fix the MetaCPAN::Client tests.

Fixes metacpan/MetaCPAN-Client#130