### PR TITLE
fetch cpantesters data from the primary api domain

### DIFF
--- a/lib/MetaCPAN/Script/CPANTestersAPI.pm
+++ b/lib/MetaCPAN/Script/CPANTestersAPI.pm
@@ -18,7 +18,7 @@ has url => (
     isa     => Uri,
     coerce  => 1,
     lazy    => 1,
-    default => 'http://api-3.cpantesters.org/v3/release',
+    default => 'http://api.cpantesters.org/v3/release',
 );
 
 has _bulk => (


### PR DESCRIPTION
The server at api-3.cpantesters.org died, and the alias was once a way to get around Fastly for looking at this data. It seems like using Fastly works fine now, so we can switch to the primary API domain.