### PR TITLE
ignore cpanfile.snapshot in search tools like ripgrep

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,1 @@
+/cpanfile.snapshot


### PR DESCRIPTION
Tools like ripgrep will ignore various files such as those in .gitignore. The cpanfile.snapshot is very rarely relevant to search, but we do want it to be included in the repository so it is not in .gitignore. ripgrep will also ignore files based on an .ignore file, so add cpanfile.snapshot there.