### PR TITLE
Don't throw exception on ::: in search

### DIFF
--- a/lib/MetaCPAN/Query/Search.pm
+++ b/lib/MetaCPAN/Query/Search.pm
@@ -207,7 +207,7 @@ sub _search_collapsed {
 sub build_query {
     my ( $self, $search_term, $params ) = @_;
     $params //= {};
-    ( my $clean = $search_term ) =~ s/::/ /g;
+    ( my $clean = $search_term ) =~ s/:{2,}/ /g;
 
     my $query = {
         bool => {

--- a/t/model/search.t
+++ b/t/model/search.t
@@ -67,6 +67,11 @@ ok( $search, 'search' );
 }
 
 {
+    eval { $search->search_web('DBIx::Class:::ResultSet') };
+    is( $@, '', 'search term with ::: no exception' );
+}
+
+{
     my $long_form  = $search->search_web('distribution:Pod-Pm');
     my $short_form = $search->search_web('dist:Pod-Pm');
 


### PR DESCRIPTION
[2026/03/03 06:09:07] [ERROR] [/search/web?from=0&size=20&q=DBIx%3AClass%3A%3A%3AResultSet] [Request] ** [https://metacpan.es.eu-central-1.aws.cloud.es.io:443]-[400] [parse_exception] parse_exception: Encountered " ":" ": "" at line 1, column 11.
Was expecting one of:
    <EOF>
    <AND> ...
    <OR> ...
    <NOT> ...
    "+" ...
    "-" ...
    <BAREOPER> ...
    "(" ...
    "*" ...
    "^" ...
    <QUOTED> ...
    <TERM> ...
    <FUZZY_SLOP> ...
    <PREFIXTERM> ...
    <WILDTERM> ...
    <REGEXPTERM> ...
    "[" ...
    "{" ...
    <NUMBER> ...
    , called from sub Search::Elasticsearch::Role::Client::Direct::__ANON__ at /home/metacpan/metacpan-api/lib/MetaCPAN/Query/Search.pm line 370. With vars: {'body' => {'status' => 400,'error' => {'phase' => 'query','type' => 'search_phase_execution_exception','grouped' => bless( do{\(my $o = 1)}, 'JSON::PP::Boolean' ),'reason' => 'all shards failed','root_cause' => [{'type' => 'parse_exception','reason' => 'parse_exception: Encountered " ":" ": "" at line 1, column 11.
