### PR TITLE
fix use of identity as object

### DIFF
--- a/lib/MetaCPAN/Model/User/Account.pm
+++ b/lib/MetaCPAN/Model/User/Account.pm
@@ -97,7 +97,7 @@ after add_identity => sub {
 
 sub has_identity {
     my ( $self, $identity ) = @_;
-    return scalar grep { $_->name eq $identity } @{ $self->identity };
+    return scalar grep { $_->{name} eq $identity } @{ $self->identity };
 }
 
 =head2 get_identities
@@ -106,7 +106,7 @@ sub has_identity {
 
 sub get_identities {
     my ( $self, $identity ) = @_;
-    return grep { $_->name eq $identity } @{ $self->identity };
+    return grep { $_->{name} eq $identity } @{ $self->identity };
 }
 
 sub remove_identity {

--- a/lib/MetaCPAN/Server/Controller/User.pm
+++ b/lib/MetaCPAN/Server/Controller/User.pm
@@ -76,7 +76,7 @@ sub profile : Local : ActionClass('REST') {
         $c->detach;
     }
     my $profile
-        = $c->model('ESModel')->doc('author')->raw->get( $pause->key );
+        = $c->model('ESModel')->doc('author')->raw->get( $pause->{key} );
     $c->stash->{profile} = $profile->{_source};
 }
 


### PR DESCRIPTION
Account identities are no longer objects, but just hashrefs. Convert some remaining uses of accessors into hash access.

Fixes #1437