### PR TITLE
Use delete_by_query to remove all duplicate favorite documents

### DIFF
--- a/lib/MetaCPAN/Server/Controller/User/Favorite.pm
+++ b/lib/MetaCPAN/Server/Controller/User/Favorite.pm
@@ -3,8 +3,10 @@ package MetaCPAN::Server::Controller::User::Favorite;
 use strict;
 use warnings;
 
+use List::Util         qw( uniq );
+use MetaCPAN::ESConfig qw( es_doc_path );
+use MetaCPAN::Util     qw( true false hit_total );
 use Moose;
-use MetaCPAN::Util qw( true false );
 
 BEGIN { extends 'Catalyst::Controller::REST' }
 
@@ -36,17 +38,41 @@ sub index_POST {
 
 sub index_DELETE {
     my ( $self, $c, $distribution ) = @_;
-    my $favorite
-        = $c->model('ESModel')
-        ->doc('favorite')
-        ->get( { user => $c->user->id, distribution => $distribution } );
-    if ($favorite) {
-        $favorite->delete( { refresh => true } );
-        $c->purge_author_key( $favorite->author )
-            if $favorite->author;
+    my $user_id = $c->user->id;
+
+    my $query = {
+        bool => {
+            must => [
+                { term => { user         => $user_id } },
+                { term => { distribution => $distribution } },
+            ],
+        },
+    };
+
+    my $res = $c->model('ES')->search(
+        es_doc_path('favorite'),
+        body => {
+            query => $query,
+            size  => 100,
+        },
+    );
+
+    if ( hit_total($res) ) {
+        my @authors = uniq grep {defined}
+            map { $_->{_source}{author} } @{ $res->{hits}{hits} };
+
+        $c->model('ES')->delete_by_query(
+            es_doc_path('favorite'),
+            body    => { query => $query },
+            refresh => true,
+        );
+
+        for my $author (@authors) {
+            $c->purge_author_key($author);
+        }
         $c->purge_dist_key($distribution);
-        $self->status_ok( $c,
-            entity => $favorite->meta->get_data($favorite) );
+
+        $self->status_ok( $c, entity => $res->{hits}{hits}[0]{_source}, );
     }
     else {
         $self->status_not_found( $c, message => 'Entity could not be found' );

--- a/t/lib/MetaCPAN/TestServer.pm
+++ b/t/lib/MetaCPAN/TestServer.pm
@@ -2,7 +2,7 @@ package MetaCPAN::TestServer;
 
 use MetaCPAN::Moose;
 
-use MetaCPAN::ESConfig               qw( es_config );
+use MetaCPAN::ESConfig               qw( es_config es_doc_path );
 use MetaCPAN::Script::Author         ();
 use MetaCPAN::Script::BusFactor      ();
 use MetaCPAN::Script::Cover          ();
@@ -291,6 +291,32 @@ sub prepare_user_test_data {
     );
 
     $self->_create_test_favorites( $user->id );
+
+    # Favorite fixture with a duplicate (different ES doc ID) for delete tests.
+    my $user_id = $user->id;
+
+    MetaCPAN::Server->model('ESModel')->doc('favorite')->put(
+        {
+            user         => $user_id,
+            distribution => 'WWW-Mechanize',
+            release      => 'WWW-Mechanize-1.00',
+            author       => 'JESSE',
+        },
+        { refresh => true }
+    );
+
+    $self->es_client->index(
+        es_doc_path('favorite'),
+        id   => 'duplicate_favorite_doc',
+        body => {
+            user         => $user_id,
+            distribution => 'WWW-Mechanize',
+            release      => 'WWW-Mechanize-2.00',
+            author       => 'SIMBABQUE',
+            date         => '2024-01-01T00:00:00',
+        },
+        refresh => 'true',
+    );
 }
 
 sub _create_test_favorites {

--- a/t/lib/MetaCPAN/TestServer.pm
+++ b/t/lib/MetaCPAN/TestServer.pm
@@ -2,7 +2,7 @@ package MetaCPAN::TestServer;
 
 use MetaCPAN::Moose;
 
-use MetaCPAN::ESConfig               qw( es_config );
+use MetaCPAN::ESConfig               qw( es_config es_doc_path );
 use MetaCPAN::Script::Author         ();
 use MetaCPAN::Script::BusFactor      ();
 use MetaCPAN::Script::Cover          ();
@@ -305,6 +305,32 @@ sub prepare_user_test_data {
     );
 
     $self->_create_test_favorites( $user->id );
+
+   # Favorite fixture with a duplicate (different ES doc ID) for delete tests.
+    my $user_id = $user->id;
+
+    MetaCPAN::Server->model('ESModel')->doc('favorite')->put(
+        {
+            user         => $user_id,
+            distribution => 'WWW-Mechanize',
+            release      => 'WWW-Mechanize-1.00',
+            author       => 'JESSE',
+        },
+        { refresh => true }
+    );
+
+    $self->es_client->index(
+        es_doc_path('favorite'),
+        id   => 'duplicate_favorite_doc',
+        body => {
+            user         => $user_id,
+            distribution => 'WWW-Mechanize',
+            release      => 'WWW-Mechanize-2.00',
+            author       => 'SIMBABQUE',
+            date         => '2024-01-01T00:00:00',
+        },
+        refresh => 'true',
+    );
 }
 
 sub _create_test_favorites {

--- a/t/query/favorite.t
+++ b/t/query/favorite.t
@@ -51,6 +51,23 @@ test_psgi app, sub {
         date         => re(qr/^2024-09-01/),
     };
 
+    # Duplicate WWW-Mechanize favorites seeded by
+    # TestServer::prepare_user_test_data for the delete tests. They are not
+    # backed by a release, so by_user (which filters to non-backpan dists)
+    # never returns them, but recent() does a global match_all and includes
+    # them. The duplicate doc has an explicit date; the other defaults to
+    # DateTime->now, so it sorts as the most recent favorite.
+    my $fav_www_dup = {
+        author       => 'SIMBABQUE',
+        distribution => 'WWW-Mechanize',
+        date         => re(qr/^2024-01-01/),
+    };
+    my $fav_www = {
+        author       => 'JESSE',
+        distribution => 'WWW-Mechanize',
+        date         => ignore(),
+    };
+
     subtest 'by_user returns seeded favorites in case-insensitive order' =>
         sub {
         my $result = $favorite->by_user( $user_id, 1, 250 );
@@ -142,10 +159,11 @@ test_psgi app, sub {
             $favorite->recent( 1, 100, 'date:asc' ),
             {
                 took      => ignore(),
-                total     => 5,
+                total     => 7,
                 favorites => [
-                    $fav_dist,     $fav_distc, $fav_distb,
-                    $fav_multiple, $fav_weblint,
+                    $fav_dist,  $fav_www_dup,  $fav_distc,
+                    $fav_distb, $fav_multiple, $fav_weblint,
+                    $fav_www,
                 ],
             },
             'date:asc'
@@ -154,10 +172,11 @@ test_psgi app, sub {
             $favorite->recent( 1, 100, 'date:desc' ),
             {
                 took      => ignore(),
-                total     => 5,
+                total     => 7,
                 favorites => [
-                    $fav_weblint, $fav_multiple, $fav_distb,
-                    $fav_distc,   $fav_dist,
+                    $fav_www,   $fav_weblint, $fav_multiple,
+                    $fav_distb, $fav_distc,   $fav_dist,
+                    $fav_www_dup,
                 ],
             },
             'date:desc'
@@ -166,10 +185,11 @@ test_psgi app, sub {
             $favorite->recent( 1, 100, 'distribution:asc' ),
             {
                 took      => ignore(),
-                total     => 5,
+                total     => 7,
                 favorites => [
-                    $fav_dist,     $fav_distb, $fav_distc,
-                    $fav_multiple, $fav_weblint,
+                    $fav_dist,     $fav_distb,   $fav_distc,
+                    $fav_multiple, $fav_weblint, $fav_www_dup,
+                    $fav_www,
                 ],
             },
             'distribution:asc'
@@ -178,10 +198,11 @@ test_psgi app, sub {
             $favorite->recent( 1, 100, 'distribution:desc' ),
             {
                 took      => ignore(),
-                total     => 5,
+                total     => 7,
                 favorites => [
-                    $fav_weblint, $fav_multiple, $fav_distc,
-                    $fav_distb,   $fav_dist,
+                    $fav_www_dup,  $fav_www,   $fav_weblint,
+                    $fav_multiple, $fav_distc, $fav_distb,
+                    $fav_dist,
                 ],
             },
             'distribution:desc'
@@ -190,10 +211,11 @@ test_psgi app, sub {
             $favorite->recent( 1, 100, 'bogus' ),
             {
                 took      => ignore(),
-                total     => 5,
+                total     => 7,
                 favorites => [
-                    $fav_weblint, $fav_multiple, $fav_distb,
-                    $fav_distc,   $fav_dist,
+                    $fav_www,   $fav_weblint, $fav_multiple,
+                    $fav_distb, $fav_distc,   $fav_dist,
+                    $fav_www_dup,
                 ],
             },
             'invalid sort falls back to date:desc'

--- a/t/server/controller/user/favorite.t
+++ b/t/server/controller/user/favorite.t
@@ -3,8 +3,10 @@ use warnings;
 use lib 't/lib';
 
 use Cpanel::JSON::XS       qw( encode_json );
-use MetaCPAN::Server::Test qw( app DELETE GET POST test_psgi );
+use MetaCPAN::ESConfig     qw( es_doc_path );
+use MetaCPAN::Server::Test qw( app DELETE es GET POST test_psgi );
 use MetaCPAN::TestHelpers  qw( decode_json_ok );
+use MetaCPAN::Util         qw( hit_total );
 use Test::More;
 
 test_psgi app, sub {
@@ -62,6 +64,129 @@ test_psgi app, sub {
 
     ok( $user = $cb->( GET '/user?access_token=bot' ), 'get bot' );
     is( $user->code, 200, 'code 200' );
+};
+
+subtest 'API enforces uniqueness on (user, distribution)' => sub {
+    test_psgi app, sub {
+        my $cb = shift;
+
+        ok( my $user_res = $cb->( GET '/user?access_token=testing' ),
+            'get user' );
+        my $user_id = decode_json_ok($user_res)->{id};
+
+        my $res = $cb->(
+            POST '/user/favorite?access_token=testing',
+            Content_Type => 'application/json',
+            Content      => encode_json( {
+                distribution => 'WWW-Mechanize',
+                release      => 'WWW-Mechanize-2.00',
+                author       => 'SIMBABQUE',
+            } )
+        );
+        is( $res->code, 201, 'second POST returns 201' );
+
+        my $search = es()->search(
+            es_doc_path('favorite'),
+            body => {
+                query => {
+                    bool => {
+                        must => [
+                            { term => { user         => $user_id } },
+                            { term => { distribution => 'WWW-Mechanize' } },
+                        ],
+                    },
+                },
+            },
+        );
+        is( hit_total($search), 2, 'upsert did not create a third doc' );
+    };
+};
+
+subtest 'DELETE removes all duplicates but preserves other users' => sub {
+    test_psgi app, sub {
+        my $cb = shift;
+
+        ok( my $user_res = $cb->( GET '/user?access_token=testing' ),
+            'get user' );
+        my $user_id = decode_json_ok($user_res)->{id};
+
+        my $bot_res = $cb->( GET '/user?access_token=bot' );
+        my $bot_id  = decode_json_ok($bot_res)->{id};
+
+        my $res = $cb->(
+            POST '/user/favorite?access_token=bot',
+            Content_Type => 'application/json',
+            Content      => encode_json( {
+                distribution => 'WWW-Mechanize',
+                release      => 'WWW-Mechanize-1.00',
+                author       => 'JESSE',
+            } )
+        );
+        is( $res->code, 201, 'bot user also favorited WWW-Mechanize' );
+
+        my $search = es()->search(
+            es_doc_path('favorite'),
+            body => {
+                query => {
+                    bool => {
+                        must => [
+                            { term => { user         => $user_id } },
+                            { term => { distribution => 'WWW-Mechanize' } },
+                        ],
+                    },
+                },
+            },
+        );
+        ok( hit_total($search) >= 2,
+            'testing user has duplicate favorites before delete' );
+
+        ok(
+            $res = $cb->(
+                DELETE '/user/favorite/WWW-Mechanize?access_token=testing'
+            ),
+            'DELETE duplicate favorites'
+        );
+        is( $res->code, 200, 'delete returned 200' );
+
+        $search = es()->search(
+            es_doc_path('favorite'),
+            body => {
+                query => {
+                    bool => {
+                        must => [
+                            { term => { user         => $user_id } },
+                            { term => { distribution => 'WWW-Mechanize' } },
+                        ],
+                    },
+                },
+            },
+        );
+        is( hit_total($search), 0, 'all favorites for dist deleted' );
+
+        $search = es()->search(
+            es_doc_path('favorite'),
+            body => {
+                query => {
+                    bool => {
+                        must => [
+                            { term => { user         => $bot_id } },
+                            { term => { distribution => 'WWW-Mechanize' } },
+                        ],
+                    },
+                },
+            },
+        );
+        is( hit_total($search), 1,
+            'favorite for same dist by other user are preserved' );
+    };
+};
+
+test_psgi app, sub {
+    my $cb = shift;
+
+    my $res
+        = $cb->( DELETE '/user/favorite/No-Such-Dist?access_token=testing' );
+    is( $res->code, 404, 'delete nonexistent favorite returns 404' );
 };
 
 done_testing;


### PR DESCRIPTION
Prod has cases where duplicate favorite documents exist for the same
(user, distribution) pair with different authors -- I don't know exactly
why this is. The previous delete handler used get(), which computes a
single composite ID, deletes one document and leaves orphans behind.
This is possibly why users sometimes reported removing a ++ but not
actually being able to delete it. Switch to search + delete_by_query to
remove all matching documents and purge cache keys for every affected
author.
