### PR TITLE
sort favorites case insensitively 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,7 @@ services:
       - discovery.type=single-node
       - xpack.security.enabled=false
       - xpack.security.http.ssl.enabled=false
+      - ES_JAVA_OPTS=-Xms2g -Xmx2g
     healthcheck:
       timeout: 5s
       start_period: 60s

--- a/es/favorite/mapping.json
+++ b/es/favorite/mapping.json
@@ -9,7 +9,13 @@
             "type": "date"
         },
         "distribution": {
-            "type": "keyword"
+            "type": "keyword",
+            "fields": {
+                "lowercase": {
+                    "type": "keyword",
+                    "normalizer": "lowercase"
+                }
+            }
         },
         "id": {
             "type": "keyword"

--- a/es/favorite/settings.json
+++ b/es/favorite/settings.json
@@ -1,4 +1,12 @@
 {
+    "analysis": {
+        "normalizer": {
+            "lowercase": {
+                "type": "custom",
+                "filter": ["lowercase"]
+            }
+        }
+    },
     "number_of_replicas": 1,
     "number_of_shards": 1,
     "refresh_interval": "1s"

--- a/lib/MetaCPAN/Query/Favorite.pm
+++ b/lib/MetaCPAN/Query/Favorite.pm
@@ -66,7 +66,7 @@ sub agg_by_distributions {
 my %VALID_FAVORITE_SORT_FIELDS = map { $_ => 1 } qw( distribution date );
 
 my %SORT_TIEBREAKER = (
-    date         => 'distribution',
+    date         => 'distribution.lowercase',
     distribution => { date => 'asc' },
 );
 
@@ -76,6 +76,12 @@ sub _favorite_sort {
         // $default;
 
     my ($primary) = keys %$fixed;
+
+    # Use the lowercase normalizer for case-insensitive distribution sort.
+    if ( $primary eq 'distribution' ) {
+        $fixed = { 'distribution.lowercase' => $fixed->{distribution} };
+    }
+
     return [ $fixed, $SORT_TIEBREAKER{$primary} ];
 }
 

--- a/t/lib/MetaCPAN/TestServer.pm
+++ b/t/lib/MetaCPAN/TestServer.pm
@@ -273,6 +273,18 @@ sub _create_test_favorites {
             author       => 'LOCAL',
             date         => '2024-03-15T00:00:00',
         },
+        {
+            distribution => 'weblint',
+            release      => 'weblint++-1.15',
+            author       => 'LOCAL',
+            date         => '2024-09-01T00:00:00',
+        },
+        {
+            distribution => 'Multiple-Modules',
+            release      => 'Multiple-Modules-1.01',
+            author       => 'LOCAL',
+            date         => '2024-07-15T00:00:00',
+        },
         )
     {
         ok(

--- a/t/query/favorite.t
+++ b/t/query/favorite.t
@@ -19,9 +19,11 @@ test_psgi app, sub {
     my $user_id = decode_json_ok($user_res)->{id};
 
     # Seeded favorites (dates set in TestServer::_create_test_favorites):
-    #   Fav-Dist   2024-01-01
-    #   Fav-DistC  2024-03-15
-    #   Fav-DistB  2024-06-01
+    #   Fav-Dist          2024-01-01
+    #   Fav-DistC         2024-03-15
+    #   Fav-DistB         2024-06-01
+    #   Multiple-Modules  2024-07-15
+    #   weblint           2024-09-01
 
     my $fav_dist = {
         author       => 'LOCAL',
@@ -38,17 +40,31 @@ test_psgi app, sub {
         distribution => 'Fav-DistC',
         date         => re(qr/^2024-03-15/),
     };
+    my $fav_multiple = {
+        author       => 'LOCAL',
+        distribution => 'Multiple-Modules',
+        date         => re(qr/^2024-07-15/),
+    };
+    my $fav_weblint = {
+        author       => 'LOCAL',
+        distribution => 'weblint',
+        date         => re(qr/^2024-09-01/),
+    };
 
-    subtest 'by_user returns seeded favorites' => sub {
+    subtest 'by_user returns seeded favorites in case-insensitive order' =>
+        sub {
         my $result = $favorite->by_user( $user_id, 1, 250 );
         cmp_deeply(
             $result,
             {
                 took      => ignore(),
-                total     => 3,
-                favorites => [ $fav_dist, $fav_distb, $fav_distc ],
+                total     => 5,
+                favorites => [
+                    $fav_dist,     $fav_distb, $fav_distc,
+                    $fav_multiple, $fav_weblint,
+                ],
             },
-            'returns all favorites sorted by distribution asc'
+            'returns all favorites sorted case-insensitively by distribution asc'
         );
 
         cmp_deeply(
@@ -56,15 +72,18 @@ test_psgi app, sub {
             { favorites => [], took => 0, total => 0 },
             'unknown user returns empty result'
         );
-    };
+        };
 
     subtest 'by_user sort param' => sub {
         cmp_deeply(
             $favorite->by_user( $user_id, 1, 250, 'distribution:desc' ),
             {
                 took      => ignore(),
-                total     => 3,
-                favorites => [ $fav_distc, $fav_distb, $fav_dist ],
+                total     => 5,
+                favorites => [
+                    $fav_weblint, $fav_multiple, $fav_distc,
+                    $fav_distb,   $fav_dist,
+                ],
             },
             'distribution:desc reverses default order'
         );
@@ -72,8 +91,11 @@ test_psgi app, sub {
             $favorite->by_user( $user_id, 1, 250, 'date:asc' ),
             {
                 took      => ignore(),
-                total     => 3,
-                favorites => [ $fav_dist, $fav_distc, $fav_distb ],
+                total     => 5,
+                favorites => [
+                    $fav_dist,     $fav_distc, $fav_distb,
+                    $fav_multiple, $fav_weblint,
+                ],
             },
             'date:asc sorts oldest first'
         );
@@ -81,8 +103,11 @@ test_psgi app, sub {
             $favorite->by_user( $user_id, 1, 250, 'date:desc' ),
             {
                 took      => ignore(),
-                total     => 3,
-                favorites => [ $fav_distb, $fav_distc, $fav_dist ],
+                total     => 5,
+                favorites => [
+                    $fav_weblint, $fav_multiple, $fav_distb,
+                    $fav_distc,   $fav_dist,
+                ],
             },
             'date:desc sorts newest first'
         );
@@ -90,8 +115,11 @@ test_psgi app, sub {
             $favorite->by_user( $user_id, 1, 250, 'bogus' ),
             {
                 took      => ignore(),
-                total     => 3,
-                favorites => [ $fav_dist, $fav_distb, $fav_distc ],
+                total     => 5,
+                favorites => [
+                    $fav_dist,     $fav_distb, $fav_distc,
+                    $fav_multiple, $fav_weblint,
+                ],
             },
             'invalid sort falls back to default'
         );
@@ -99,8 +127,11 @@ test_psgi app, sub {
             $favorite->by_user( $user_id, 1, 250, 'author:asc' ),
             {
                 took      => ignore(),
-                total     => 3,
-                favorites => [ $fav_dist, $fav_distb, $fav_distc ],
+                total     => 5,
+                favorites => [
+                    $fav_dist,     $fav_distb, $fav_distc,
+                    $fav_multiple, $fav_weblint,
+                ],
             },
             'disallowed field falls back to default'
         );
@@ -111,8 +142,11 @@ test_psgi app, sub {
             $favorite->recent( 1, 100, 'date:asc' ),
             {
                 took      => ignore(),
-                total     => 3,
-                favorites => [ $fav_dist, $fav_distc, $fav_distb ],
+                total     => 5,
+                favorites => [
+                    $fav_dist,     $fav_distc, $fav_distb,
+                    $fav_multiple, $fav_weblint,
+                ],
             },
             'date:asc'
         );
@@ -120,8 +154,11 @@ test_psgi app, sub {
             $favorite->recent( 1, 100, 'date:desc' ),
             {
                 took      => ignore(),
-                total     => 3,
-                favorites => [ $fav_distb, $fav_distc, $fav_dist ],
+                total     => 5,
+                favorites => [
+                    $fav_weblint, $fav_multiple, $fav_distb,
+                    $fav_distc,   $fav_dist,
+                ],
             },
             'date:desc'
         );
@@ -129,8 +166,11 @@ test_psgi app, sub {
             $favorite->recent( 1, 100, 'distribution:asc' ),
             {
                 took      => ignore(),
-                total     => 3,
-                favorites => [ $fav_dist, $fav_distb, $fav_distc ],
+                total     => 5,
+                favorites => [
+                    $fav_dist,     $fav_distb, $fav_distc,
+                    $fav_multiple, $fav_weblint,
+                ],
             },
             'distribution:asc'
         );
@@ -138,8 +178,11 @@ test_psgi app, sub {
             $favorite->recent( 1, 100, 'distribution:desc' ),
             {
                 took      => ignore(),
-                total     => 3,
-                favorites => [ $fav_distc, $fav_distb, $fav_dist ],
+                total     => 5,
+                favorites => [
+                    $fav_weblint, $fav_multiple, $fav_distc,
+                    $fav_distb,   $fav_dist,
+                ],
             },
             'distribution:desc'
         );
@@ -147,8 +190,11 @@ test_psgi app, sub {
             $favorite->recent( 1, 100, 'bogus' ),
             {
                 took      => ignore(),
-                total     => 3,
-                favorites => [ $fav_distb, $fav_distc, $fav_dist ],
+                total     => 5,
+                favorites => [
+                    $fav_weblint, $fav_multiple, $fav_distb,
+                    $fav_distc,   $fav_dist,
+                ],
             },
             'invalid sort falls back to date:desc'
         );
@@ -190,8 +236,8 @@ test_psgi app, sub {
             = map { $_->{distribution} => 1 } @{ $result->{favorites} };
         ok( !$dists{'Fav-Dist'}, 'Fav-Dist excluded after full backpan' );
 
-        # Fav-DistB and Fav-DistC are unaffected by the backpan update
-        is( $result->{total}, 2, 'remaining favorites still returned' );
+        # Other favorites are unaffected by the backpan update
+        is( $result->{total}, 4, 'remaining favorites still returned' );
     };
 };
 


### PR DESCRIPTION
- **Allow for case-insensitive sort on favorites**
- **default to using less RAM for elasticsearch-test container**

We will need to re-index faves:

```bash
curl -X POST 'https://[production-url]/cpan_v1_01_favorite/_update_by_query?refresh'
