### PR TITLE
use Archive::Tar to make reproducible archives in mk-cpan

### DIFF
--- a/precious.toml
+++ b/precious.toml
@@ -3,7 +3,7 @@ exclude = [
     "/blib/**",
     "/root/assets/**",
     "/local/**",
-    "/test-data/**",
+    "/test-data/fakecpan/**",
 ]
 
 [commands.perlimports]

--- a/t/model/archive.t
+++ b/t/model/archive.t
@@ -24,10 +24,13 @@ subtest 'file does not exist' => sub {
 
 subtest 'archive extraction' => sub {
     my %want = (
+        'Some-1.00-TRIAL'             => undef,
+        'Some-1.00-TRIAL/lib'         => undef,
         'Some-1.00-TRIAL/lib/Some.pm' =>
             '2f806b4c7413496966f52ef353984dde10b6477b',
         'Some-1.00-TRIAL/Makefile.PL' =>
             'bc7f47a8e0e9930f41c06e150c7d229cfd3feae7',
+        'Some-1.00-TRIAL/t'          => undef,
         'Some-1.00-TRIAL/t/00-nop.t' =>
             '2eba5fd5f9e08a9dcc1c5e2166b7d7d958caf377',
         'Some-1.00-TRIAL/META.json' => qr/"meta-spec"/,
@@ -44,18 +47,25 @@ subtest 'archive extraction' => sub {
     ok !$archive->is_impolite;
     ok !$archive->is_naughty;
 
-    my @files = grep !m{/$}, @{ $archive->files };
+    my @files = @{ $archive->files };
     cmp_bag [@files], [ keys %want ];
 
     my $dir = $archive->extract;
-    for my $file ( keys %want ) {
-        my $content = $dir->child($file)->slurp;
-        if ( ref $want{$file} ) {
-            like $content, $want{$file}, "content of $file";
+    for my $file ( sort keys %want ) {
+        my $full = $dir->child($file);
+        my $want = $want{$file};
+        if ( $full->is_dir ) {
+            ok !defined $want, "directory of $file";
         }
         else {
-            my $digest = sha1_hex($content);
-            is $digest, $want{$file}, "content of $file";
+            my $content = $full->slurp;
+            if ( ref $want ) {
+                like $content, $want, "content of $file";
+            }
+            else {
+                my $digest = sha1_hex($content);
+                is $digest, $want, "content of $file";
+            }
         }
     }
 };

--- a/test-data/mk-cpan.pl
+++ b/test-data/mk-cpan.pl
@@ -2,15 +2,15 @@
 use strict;
 use warnings;
 
-use File::Basename qw(dirname basename);
-use File::Spec::Functions qw(catdir catfile abs2rel rel2abs splitdir);
-use File::Path qw(mkpath);
-use File::Find ();
-use File::Copy qw(copy);
-use Cwd qw(cwd);
-use CPAN::Checksums ();
-use Getopt::Long qw(:config gnu_getopt);
-use JSON::PP qw(decode_json);
+use File::Basename        qw( basename dirname );
+use File::Spec::Functions qw( abs2rel catdir rel2abs splitdir );
+use File::Path            qw( mkpath );
+use File::Find            ();
+use File::Copy            qw( copy );
+use Cwd                   qw( cwd );
+use CPAN::Checksums       ();
+use Getopt::Long          qw( GetOptions );
+use JSON::PP              qw( decode_json );
 
 sub is_empty_dir {
     my $dir = shift;
@@ -19,7 +19,7 @@ sub is_empty_dir {
     opendir my $dh, $dir
         or die "can't read $dir: $!";
     my $empty = !!1;
-    while (my $entry = readdir $dh) {
+    while ( my $entry = readdir $dh ) {
         next
             if $entry eq '.' || $entry eq '..';
         $empty = !!0;
@@ -33,16 +33,17 @@ GetOptions(
     'h|help'    => \my $help,
 ) or die "Invalid options!\n";
 
-pod2usage(-verbose => 2, -exitval => 0)
+pod2usage( -verbose => 2, -exitval => 0 )
     if $help;
 
 my $out = shift
     or die "output directory must be specified!\n";
 
-!-e $out or is_empty_dir($out)
+!-e $out
+    or is_empty_dir($out)
     or die "output directory must not exist or be empty!\n";
 
-my $source_dir = catdir(dirname(__FILE__), 'fakecpan');
+my $source_dir = catdir( dirname(__FILE__), 'fakecpan' );
 
 mkpath($out);
 
@@ -50,99 +51,102 @@ die "couldn't create $out: $!\n"
     if !-d $out;
 
 my %gz = (
-    'authors/01mailrc.txt'              => 0,
-    'authors/08pumpkings.txt'           => 0,
-    'modules/02packages.details.txt'    => 0,
-    'modules/03modlist.data'            => 0,
-    'modules/06perms.txt'               => 1,
+    'authors/01mailrc.txt'           => 0,
+    'authors/08pumpkings.txt'        => 0,
+    'modules/02packages.details.txt' => 0,
+    'modules/03modlist.data'         => 0,
+    'modules/06perms.txt'            => 1,
 );
 
-File::Find::find({
-    no_chdir => 1,
-    wanted => sub {
-        my $file = $_;
-        return
-            if $file eq '.';
-        my $rel = abs2rel($file, $source_dir);
-        my $dest = rel2abs($rel, $out);
-        if (-d $file) {
-            my @parts = splitdir($rel);
-            if ($parts[0] eq 'authors' && @parts == 6) {
-                my $dirname = dirname($file);
-                my $basename = basename($file);
-                my $options = {};
-                my $extra = "$file/x_metacpan.json";
-                if (open my $fh, '<', $extra) {
-                    my $json = do { local $/; <$fh> };
-                    close $fh;
-                    $options = decode_json($json);
+File::Find::find(
+    {
+        no_chdir => 1,
+        wanted   => sub {
+            my $file = $_;
+            return
+                if $file eq '.';
+            my $rel  = abs2rel( $file, $source_dir );
+            my $dest = rel2abs( $rel, $out );
+            if ( -d $file ) {
+                my @parts = splitdir($rel);
+                if ( $parts[0] eq 'authors' && @parts == 6 ) {
+                    my $dirname  = dirname($file);
+                    my $basename = basename($file);
+                    my $options  = {};
+                    my $extra    = "$file/x_metacpan.json";
+                    if ( open my $fh, '<', $extra ) {
+                        my $json = do { local $/; <$fh> };
+                        close $fh;
+                        $options = decode_json($json);
+                    }
+
+                    if ( $options->{no_top_level} ) {
+                        $dirname  = $file;
+                        $basename = '.';
+                    }
+
+                    my $tarball = "$dest.tar.gz";
+                    print "creating $rel.tar.gz\n" if $v;
+                    system qw(tar -c -z),
+                        '--format'  => 'ustar',
+                        '--exclude' => 'x_metacpan.json',
+                        '-C'        => $dirname,
+                        '-f'        => $tarball,
+                        $basename;
+
+                    if ( my $mtime = $options->{mtime} ) {
+                        utime $mtime, $mtime, $tarball;
+                    }
+
+                    $File::Find::prune = 1;
                 }
-
-                if ($options->{no_top_level}) {
-                    $dirname = $file;
-                    $basename = '.';
+                elsif ( !-e $dest ) {
+                    print "creating $rel/\n" if $v;
+                    mkdir $dest;
                 }
-
-                my $tarball = "$dest.tar.gz";
-                print "creating $rel.tar.gz\n" if $v;
-                system qw(tar -c -z),
-                    '--format'  => 'ustar',
-                    '--exclude' => 'x_metacpan.json',
-                    '-C'        => $dirname,
-                    '-f'        => $tarball,
-                    $basename;
-
-                if (my $mtime = $options->{mtime}) {
-                    utime $mtime, $mtime, $tarball;
+            }
+            else {
+                print "copying $rel\n" if $v;
+                copy $file, $dest;
+                if ( exists $gz{$rel} ) {
+                    my $keep    = $gz{$rel};
+                    my @command = qw(gzip -9 -n);
+                    push @command, '-k'
+                        if $keep;
+                    print "gzipping $rel\n" if $v;
+                    system @command, $dest;
                 }
-
-                $File::Find::prune = 1;
             }
-            elsif (!-e $dest) {
-                print "creating $rel/\n" if $v;
-                mkdir $dest;
+        },
+        postprocess => sub {
+            my $dir  = $File::Find::dir;
+            my $rel  = abs2rel( $dir, $source_dir );
+            my $dest = rel2abs( $rel, $out );
+            if ( $rel =~ m{\Aauthors/id(?:\z|/)} ) {
+                print "generating $rel/CHECKSUMS\n" if $v;
+                CPAN::Checksums::updatedir( $dest, "$out/authors/id" );
             }
-        }
-        else {
-            print "copying $rel\n" if $v;
-            copy $file, $dest;
-            if (exists $gz{$rel}) {
-                my $keep = $gz{$rel};
-                my @command = qw(gzip -9 -n);
-                push @command, '-k'
-                    if $keep;
-                print "gzipping $rel\n" if $v;
-                system @command, $dest;
+            elsif ( $rel eq 'authors' ) {
+                my $cwd = cwd;
+                chdir $out;
+                mkdir 'indices';
+                my $out_file = 'indices/find-ls';
+                print "generating $out_file\n" if $v;
+                open my $in, '-|:raw', 'find', 'authors', '-ls'
+                    or die "can't run find: $!";
+                open my $out, '>:raw', $out_file
+                    or die "can't write $out_file: $!\n";
+                copy $in, $out;
+                close $in;
+                close $out;
+                print "gzipping $out_file\n" if $v;
+                system qw(gzip -9 -n), $out_file;
+                chdir $cwd;
             }
-        }
+        },
     },
-    postprocess => sub {
-        my $dir = $File::Find::dir;
-        my $rel = abs2rel($dir, $source_dir);
-        my $dest = rel2abs($rel, $out);
-        if ($rel =~ m{\Aauthors/id(?:\z|/)}) {
-            print "generating $rel/CHECKSUMS\n" if $v;
-            CPAN::Checksums::updatedir($dest, "$out/authors/id");
-        }
-        elsif ($rel eq 'authors') {
-            my $cwd = cwd;
-            chdir $out;
-            mkdir 'indices';
-            my $out_file = 'indices/find-ls';
-            print "generating $out_file\n" if $v;
-            open my $in, '-|:raw', 'find', 'authors', '-ls'
-                or die "can't run find: $!";
-            open my $out, '>:raw', $out_file
-                or die "can't write $out_file: $!\n";
-            copy $in, $out;
-            close $in;
-            close $out;
-            print "gzipping $out_file\n" if $v;
-            system qw(gzip -9 -n), $out_file;
-            chdir $cwd;
-        }
-    },
-}, $source_dir);
+    $source_dir
+);
 
 __END__
 

--- a/test-data/mk-cpan.pl
+++ b/test-data/mk-cpan.pl
@@ -2,6 +2,7 @@
 use strict;
 use warnings;
 
+use Archive::Tar          qw( COMPRESS_GZIP );
 use File::Basename        qw( basename dirname );
 use File::Spec::Functions qw( abs2rel catdir rel2abs splitdir );
 use File::Path            qw( mkpath );
@@ -70,10 +71,12 @@ File::Find::find(
             if ( -d $file ) {
                 my @parts = splitdir($rel);
                 if ( $parts[0] eq 'authors' && @parts == 6 ) {
-                    my $dirname  = dirname($file);
-                    my $basename = basename($file);
-                    my $options  = {};
-                    my $extra    = "$file/x_metacpan.json";
+                    $File::Find::prune = 1;
+                    my $archive_root_dir = $file;
+                    my $dirname          = dirname($archive_root_dir);
+                    my $tar_root         = basename($archive_root_dir);
+                    my $options          = {};
+                    my $extra = "$archive_root_dir/x_metacpan.json";
                     if ( open my $fh, '<', $extra ) {
                         my $json = do { local $/; <$fh> };
                         close $fh;
@@ -81,24 +84,49 @@ File::Find::find(
                     }
 
                     if ( $options->{no_top_level} ) {
-                        $dirname  = $file;
-                        $basename = '.';
+                        $tar_root = '';
                     }
 
                     my $tarball = "$dest.tar.gz";
+
+                    # jan 1 2026
+                    my $mtime = $options->{mtime} // 1767225600;
+
                     print "creating $rel.tar.gz\n" if $v;
-                    system qw(tar -c -z),
-                        '--format'  => 'ustar',
-                        '--exclude' => 'x_metacpan.json',
-                        '-C'        => $dirname,
-                        '-f'        => $tarball,
-                        $basename;
 
-                    if ( my $mtime = $options->{mtime} ) {
-                        utime $mtime, $mtime, $tarball;
-                    }
+                    my $tar = Archive::Tar->new;
+                    File::Find::find(
+                        {
+                            no_chdir   => 1,
+                            preprocess => sub { sort @_ },
+                            wanted     => sub {
+                                my $name = $_;
+                                my $rel  = abs2rel( $_, $archive_root_dir )
+                                    =~ s{\A\.(?:/|\z)}{}r;
+                                return
+                                    if $rel eq 'x_metacpan.json';
 
-                    $File::Find::prune = 1;
+                                my $tar_path = join '/', grep length,
+                                    $tar_root, $rel;
+                                return
+                                    if !length $tar_path;
+
+                                my ($afile) = $tar->add_files($name);
+                                $afile->rename($tar_path);
+                                $afile->uid(0);
+                                $afile->gid(0);
+                                $afile->uname('root');
+                                $afile->gname('root');
+                                $afile->mode( oct( -x ? '0755' : '0644' ) );
+                                $afile->mtime($mtime);
+                            },
+                        },
+                        $archive_root_dir,
+                    );
+
+                    $tar->write( $tarball, COMPRESS_GZIP );
+
+                    utime $mtime, $mtime, $tarball;
                 }
                 elsif ( !-e $dest ) {
                     print "creating $rel/\n" if $v;


### PR DESCRIPTION
Indexing stores SHA sums of the tarballs it indexes, as well as the modification time of files inside the tarball. If the values aren't consistent between runs, the generated documents won't be the same.

Update mk-cpan.pl to produce fully reproducible tarballs so they always produce the same documents.