### PR TITLE
Don't force asciiname on author profile update

### DIFF
--- a/lib/MetaCPAN/Document/Author.pm
+++ b/lib/MetaCPAN/Document/Author.pm
@@ -137,7 +137,16 @@ sub validate {
     my ( $class, $data ) = @_;
     my @result;
     foreach my $attr ( $class->meta->get_all_attributes ) {
-        if ( $attr->is_required && !exists $data->{ $attr->name } ) {
+
+      # A required attribute with a default (or builder) is still satisfiable
+      # without input -- the default fills it in at construction time -- so an
+      # absent value must not be reported as missing. asciiname is the case
+      # this guards: required => 1 but default => q{}.
+        if (   $attr->is_required
+            && !exists $data->{ $attr->name }
+            && !$attr->has_default
+            && !$attr->has_builder )
+        {
             push(
                 @result,
                 {

--- a/t/document/author.t
+++ b/t/document/author.t
@@ -10,4 +10,11 @@ my @errors = MetaCPAN::Document::Author->validate(
 
 ok( !( grep { $_->{field} eq 'perlmongers' } @errors ), 'perlmongers ok' );
 
+# asciiname is required => 1 but has a default => q{}, so an absent asciiname
+# must not be reported as missing (the default satisfies the requirement).
+ok(
+    !( grep { $_->{field} eq 'asciiname' } @errors ),
+    'absent asciiname not reported as required'
+);
+
 done_testing;

--- a/t/server/controller/user/profile.t
+++ b/t/server/controller/user/profile.t
@@ -1,0 +1,47 @@
+use strict;
+use warnings;
+use lib 't/lib';
+
+use Cpanel::JSON::XS       qw( encode_json );
+use MetaCPAN::Server::Test qw( app GET test_psgi );
+use MetaCPAN::TestHelpers  qw( decode_json_ok );
+use Test::More;
+
+use HTTP::Request::Common ();
+
+test_psgi app, sub {
+    my $cb = shift;
+
+    ok( my $res = $cb->( GET '/user/profile?access_token=testing' ),
+        'GET /user/profile' );
+    is( $res->code, 200, 'code 200' );
+    my $profile = decode_json_ok($res);
+
+   # An author whose name is already ASCII has an empty/null asciiname. Saving
+   # the profile form sends "asciiname": null. This must not be rejected with
+   # "asciiname is required": asciiname is required => 1 but has a default, so
+   # an absent value is filled in at construction time.
+    my $put = HTTP::Request::Common::PUT(
+        '/user/profile?access_token=testing',
+        Content_Type => 'application/json',
+        Content      => encode_json( {
+            name      => 'Moritz Onken',
+            asciiname => undef,
+            website   => ['http://metacpan.org/'],
+            email     => ['onken@netcubed.de'],
+            city      => 'Karlsruhe',
+            region    => 'BW',
+            country   => 'DE',
+        } ),
+    );
+
+    ok( $res = $cb->($put), 'PUT /user/profile with null asciiname' );
+    is( $res->code, 201, 'profile saved (status created)' )
+        or diag( $res->content );
+
+    my $saved = decode_json_ok($res);
+    is( $saved->{asciiname} // q{},
+        q{}, 'asciiname is empty (default applied), not rejected' );
+};
+
+done_testing;


### PR DESCRIPTION
this should make the profile updates from the front end less mysterious
to debug.
