### PR TITLE
Fetch GitHub stars for any GitHub-hosted dist (and fix index_github_bugs no-op)

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -125,7 +125,7 @@ requires 'Types::Path::Tiny';
 requires 'Types::URI';
 requires 'Twitter::API', '1.0006';
 requires 'URI', '5.10';
-requires 'URI::git';
+requires 'URI::git', '0.02';
 requires 'Unicode::UTF8', '0.70';
 requires 'version', '0.9929';
 requires 'XML::XPath';

--- a/cpanfile
+++ b/cpanfile
@@ -125,6 +125,7 @@ requires 'Types::Path::Tiny';
 requires 'Types::URI';
 requires 'Twitter::API', '1.0006';
 requires 'URI', '5.10';
+requires 'URI::git';
 requires 'Unicode::UTF8', '0.70';
 requires 'version', '0.9929';
 requires 'XML::XPath';

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -7790,6 +7790,15 @@ DISTRIBUTIONS
       URI 1.40
       URI::Nested 0.10
       perl 5.008001
+  URI-git-0.02
+    pathname: M/MI/MIYAGAWA/URI-git-0.02.tar.gz
+    provides:
+      URI::git 0.02
+    requirements:
+      ExtUtils::MakeMaker 0
+      Filter::Util::Call 0
+      URI 0
+      perl 5.008001
   URL-Encode-0.03
     pathname: C/CH/CHANSEN/URL-Encode-0.03.tar.gz
     provides:

--- a/lib/MetaCPAN/Script/Tickets.pm
+++ b/lib/MetaCPAN/Script/Tickets.pm
@@ -12,6 +12,7 @@ use Net::GitHub::V4       ();
 use Ref::Util             qw( is_hashref is_ref );
 use Text::CSV_XS          ();
 use URI::Escape           qw( uri_escape );
+use URI::Split            qw( uri_split );
 
 with 'MetaCPAN::Role::Script', 'MooseX::Getopt';
 
@@ -186,7 +187,18 @@ END_QUERY
         }
 
         my $repo_data = $data->{data}{repository};
-        my $github    = $self->_github_dist_summary( $resources, $repo_data );
+
+        # A successful response can still carry a null repository (e.g. a repo
+        # that became private without an explicit NOT_FOUND error). Skip it
+        # rather than dereferencing undef.
+        unless ($repo_data) {
+            log_info {
+                "[$release->{distribution}] no repository data returned"
+            };
+            next RELEASE;
+        }
+
+        my $github = $self->_github_dist_summary( $resources, $repo_data );
 
         $dist_summary->{'repo'}{'github'} = $github->{repo}{github};
         $dist_summary->{'bugs'}{'github'} = $github->{bugs}{github}
@@ -197,39 +209,50 @@ END_QUERY
     $self->_bulk_update( \%summary );
 }
 
-# Resource fields that may contain a GitHub URL. A dist that points at GitHub
-# in any of these is eligible for star/watcher counts.
-sub _github_resource_fields {
-    return qw(
-        resources.bugtracker.web
-        resources.repository.url
-        resources.repository.web
-    );
-}
-
-sub _github_url_prefixes {
-    return qw(
-        http://github.com/
-        https://github.com/
-        git://github.com/
+# Resource fields that may contain a GitHub URL, mapped to the URL schemes
+# worth matching for each. A dist that points at GitHub in any of these is
+# eligible for star/watcher counts. Bug trackers are always served over
+# http(s); repository URLs may additionally use git://.
+sub _github_resource_field_prefixes {
+    return (
+        'resources.bugtracker.web' =>
+            [qw( http://github.com/ https://github.com/ )],
+        'resources.repository.url' =>
+            [qw( http://github.com/ https://github.com/ git://github.com/ )],
+        'resources.repository.web' =>
+            [qw( http://github.com/ https://github.com/ git://github.com/ )],
     );
 }
 
 # Build the `should` clauses matching any release with a GitHub URL in one of
 # the relevant resource fields.
 sub _github_release_query_filter {
-    my $self = shift;
+    my $self     = shift;
+    my %prefixes = $self->_github_resource_field_prefixes;
     return [
         map {
             my $field = $_;
-            map +{ prefix => { $field => $_ } }, $self->_github_url_prefixes;
-        } $self->_github_resource_fields
+            map +{ prefix => { $field => $_ } }, @{ $prefixes{$field} };
+        } sort keys %prefixes
     ];
 }
 
+# True if $url is an absolute URL whose host is github.com. Parsing out the
+# host (rather than a prefix match) avoids misclassifying look-alike hosts such
+# as github.com.evil.com. uri_split handles git:// URLs, which URI->new treats
+# as foreign (host-less).
 sub _is_github_url {
     my ( $self, $url ) = @_;
-    return !is_ref($url) && $url && $url =~ m{^(?:https?|git)://github\.com/};
+    return 0 if is_ref($url) || !defined $url || $url eq '';
+
+    my ( $scheme, $authority ) = uri_split($url);
+    return 0 unless defined $scheme && defined $authority;
+
+    # Strip any userinfo@ prefix and :port suffix to get the bare host.
+    ( my $host = $authority ) =~ s/^[^@]*@//;
+    $host =~ s/:[0-9]+\z//;
+
+    return lc($host) eq 'github.com' ? 1 : 0;
 }
 
 # Given a release's resources and the GraphQL repository data, build the

--- a/lib/MetaCPAN/Script/Tickets.pm
+++ b/lib/MetaCPAN/Script/Tickets.pm
@@ -328,7 +328,8 @@ sub github_user_repo_from_resources {
 sub _github_search_resources {
     my ( $self, $resources ) = @_;
 
-    for my $v ( values %{$resources} ) {
+    for my $k ( sort keys %{$resources} ) {
+        my $v = $resources->{$k};
         if ( is_hashref($v) ) {
             my ( $user, $repo ) = $self->_github_search_resources($v);
             return ( $user, $repo ) if $user;

--- a/lib/MetaCPAN/Script/Tickets.pm
+++ b/lib/MetaCPAN/Script/Tickets.pm
@@ -98,7 +98,10 @@ sub check_all_distributions {
     $self->_bulk_update($dists);
 }
 
-# gh issues are counted for any dist with a github url in `resources.bugtracker.web`.
+# GitHub data is fetched for any dist that points at GitHub in its bugtracker
+# or repository resources. Issue counts are only recorded when GitHub issues
+# are the bug tracker, but star/watcher counts are recorded for any dist with a
+# GitHub repository (see _github_dist_summary).
 sub index_github_bugs {
     my $self = shift;
 
@@ -114,20 +117,7 @@ sub index_github_bugs {
                         { term => { status => 'latest' } },
                         {
                             bool => {
-                                should => [
-                                    {
-                                        prefix => {
-                                            "resources.bugtracker.web" =>
-                                                'http://github.com/'
-                                        }
-                                    },
-                                    {
-                                        prefix => {
-                                            "resources.bugtracker.web" =>
-                                                'https://github.com/'
-                                        }
-                                    },
-                                ],
+                                should => $self->_github_release_query_filter,
                             },
                         },
                     ],
@@ -143,7 +133,7 @@ sub index_github_bugs {
 
 RELEASE: while ( my $release = $scroll->next ) {
         my $resources = $release->{resources};
-        my ( $user, $repo, $source )
+        my ( $user, $repo )
             = $self->github_user_repo_from_resources($resources);
         next unless $user;
         log_debug {"Retrieving issues from $user/$repo"};
@@ -196,6 +186,74 @@ END_QUERY
         }
 
         my $repo_data = $data->{data}{repository};
+        my $github    = $self->_github_dist_summary( $resources, $repo_data );
+
+        $dist_summary->{'repo'}{'github'} = $github->{repo}{github};
+        $dist_summary->{'bugs'}{'github'} = $github->{bugs}{github}
+            if $github->{bugs};
+    }
+
+    log_info {"writing github data"};
+    $self->_bulk_update( \%summary );
+}
+
+# Resource fields that may contain a GitHub URL. A dist that points at GitHub
+# in any of these is eligible for star/watcher counts.
+sub _github_resource_fields {
+    return qw(
+        resources.bugtracker.web
+        resources.repository.url
+        resources.repository.web
+    );
+}
+
+sub _github_url_prefixes {
+    return qw(
+        http://github.com/
+        https://github.com/
+        git://github.com/
+    );
+}
+
+# Build the `should` clauses matching any release with a GitHub URL in one of
+# the relevant resource fields.
+sub _github_release_query_filter {
+    my $self = shift;
+    return [
+        map {
+            my $field = $_;
+            map +{ prefix => { $field => $_ } }, $self->_github_url_prefixes;
+        } $self->_github_resource_fields
+    ];
+}
+
+sub _is_github_url {
+    my ( $self, $url ) = @_;
+    return !is_ref($url) && $url && $url =~ m{^(?:https?|git)://github\.com/};
+}
+
+# Given a release's resources and the GraphQL repository data, build the
+# distribution summary fragment. Star/watcher counts are recorded for any dist
+# with a GitHub repository; issue counts are only recorded when GitHub issues
+# are the dist's bug tracker.
+sub _github_dist_summary {
+    my ( $self, $resources, $repo_data ) = @_;
+
+    my %summary = (
+        repo => {
+            github => {
+                stars    => $repo_data->{stargazerCount},
+                watchers => $repo_data->{watchers}{totalCount},
+            },
+        },
+    );
+
+    my $bugtracker
+        = is_hashref( $resources->{bugtracker} )
+        ? $resources->{bugtracker}{web}
+        : undef;
+
+    if ( $bugtracker && $self->_is_github_url($bugtracker) ) {
         my $open
             = $repo_data->{openIssues}{totalCount}
             + $repo_data->{openPullRequests}{totalCount};
@@ -203,21 +261,15 @@ END_QUERY
             = $repo_data->{closedIssues}{totalCount}
             + $repo_data->{closedPullRequests}{totalCount};
 
-        $dist_summary->{'bugs'}{'github'} = {
+        $summary{bugs}{github} = {
             active => $open,
             open   => $open,
             closed => $closed,
-            source => $source,
-        };
-
-        $dist_summary->{'repo'}{'github'} = {
-            stars    => $repo_data->{stargazerCount},
-            watchers => $repo_data->{watchers}{totalCount},
+            source => $bugtracker,
         };
     }
 
-    log_info {"writing github data"};
-    $self->_bulk_update( \%summary );
+    return \%summary;
 }
 
 # Try (recursively) to find a github url in the resources hash.

--- a/lib/MetaCPAN/Script/Tickets.pm
+++ b/lib/MetaCPAN/Script/Tickets.pm
@@ -136,7 +136,9 @@ sub index_github_bugs {
 RELEASE: while ( my $release = $scroll->next ) {
         my $source       = $release->{_source};
         my $distribution = $source->{distribution};
-        my $resources    = $source->{resources};
+        next unless $distribution;
+
+        my $resources = $source->{resources};
         my ( $user, $repo )
             = $self->github_user_repo_from_resources($resources);
         next unless $user;
@@ -190,9 +192,9 @@ END_QUERY
 
         my $repo_data = $data->{data}{repository};
 
-        # A successful response can still carry a null repository (e.g. a repo
-        # that became private without an explicit NOT_FOUND error). Skip it
-        # rather than dereferencing undef.
+       # A successful response can still carry a null repository in some cases
+       # (rather than an explicit NOT_FOUND error). Skip it rather than
+       # dereferencing undef.
         unless ($repo_data) {
             log_info {"[$distribution] no repository data returned"};
             next RELEASE;
@@ -289,27 +291,52 @@ sub _github_dist_summary {
     return \%summary;
 }
 
-# Try (recursively) to find a github url in the resources hash.
-# FIXME: This should check bugtracker web exclusively, or at least first.
+# Extract a ( $user, $repo ) pair from a single github URL, or () if $url is
+# not a github repository URL.
+sub _github_user_repo_from_url {
+    my ( $self, $url ) = @_;
+    return ()
+        if is_ref($url)
+        || !defined $url
+        || $url
+        !~ m{^(?:https?|git)://github\.com/([^/]+)/([^/]+?)(?:\.git)?/?$};
+    return ( $1, $2 );
+}
+
+# Find a ( $user, $repo ) pair in the resources hash. The dist's declared
+# repository is preferred so star/watcher counts are attributed to the repo the
+# author actually named, rather than to whatever github url happens to come
+# first in hash order (an unrelated resource could otherwise hijack the count).
+# Falls back to a recursive scan of any remaining resource fields.
 sub github_user_repo_from_resources {
     my ( $self, $resources ) = @_;
-    my ( $user, $repo, $source );
+    return () unless is_hashref($resources);
 
-    for my $k ( keys %{$resources} ) {
-        my $v = $resources->{$k};
-
-        if ( !is_ref($v)
-            && $v
-            =~ /^(https?|git):\/\/github\.com\/([^\/]+)\/([^\/]+?)(\.git)?\/?$/
-            )
-        {
-            return ( $2, $3, $v );
+    if ( is_hashref( $resources->{repository} ) ) {
+        for my $field (qw( url web )) {
+            my ( $user, $repo )
+                = $self->_github_user_repo_from_url(
+                $resources->{repository}{$field} );
+            return ( $user, $repo ) if $user;
         }
+    }
 
-        ( $user, $repo, $source ) = $self->github_user_repo_from_resources($v)
-            if is_hashref($v);
+    return $self->_github_search_resources($resources);
+}
 
-        return ( $user, $repo, $source ) if $user;
+# Recursively walk the resources hash for any github url.
+sub _github_search_resources {
+    my ( $self, $resources ) = @_;
+
+    for my $v ( values %{$resources} ) {
+        if ( is_hashref($v) ) {
+            my ( $user, $repo ) = $self->_github_search_resources($v);
+            return ( $user, $repo ) if $user;
+        }
+        elsif ( !is_ref($v) ) {
+            my ( $user, $repo ) = $self->_github_user_repo_from_url($v);
+            return ( $user, $repo ) if $user;
+        }
     }
 
     return ();

--- a/lib/MetaCPAN/Script/Tickets.pm
+++ b/lib/MetaCPAN/Script/Tickets.pm
@@ -11,8 +11,9 @@ use MetaCPAN::Types       qw( Uri );
 use Net::GitHub::V4       ();
 use Ref::Util             qw( is_hashref is_ref );
 use Text::CSV_XS          ();
+use URI                   ();
 use URI::Escape           qw( uri_escape );
-use URI::Split            qw( uri_split );
+use URI::git ();    ## no perlimports (registers the git:// scheme with URI)
 
 with 'MetaCPAN::Role::Script', 'MooseX::Getopt';
 
@@ -133,13 +134,15 @@ sub index_github_bugs {
     my %summary;
 
 RELEASE: while ( my $release = $scroll->next ) {
-        my $resources = $release->{resources};
+        my $source       = $release->{_source};
+        my $distribution = $source->{distribution};
+        my $resources    = $source->{resources};
         my ( $user, $repo )
             = $self->github_user_repo_from_resources($resources);
         next unless $user;
         log_debug {"Retrieving issues from $user/$repo"};
 
-        my $dist_summary = $summary{ $release->{'distribution'} } ||= {};
+        my $dist_summary = $summary{$distribution} ||= {};
 
         my $vars = {
             user => $user,
@@ -170,8 +173,7 @@ END_QUERY
 
         if ( my $error = $data->{errors} ) {
             for my $error (@$error) {
-                my $log_message
-                    = "[$release->{distribution}] $error->{message}";
+                my $log_message = "[$distribution] $error->{message}";
                 if ( $error->{type} eq 'NOT_FOUND' ) {
                     delete $dist_summary->{'bugs'}{'github'};
                     delete $dist_summary->{'repo'}{'github'};
@@ -192,9 +194,7 @@ END_QUERY
         # that became private without an explicit NOT_FOUND error). Skip it
         # rather than dereferencing undef.
         unless ($repo_data) {
-            log_info {
-                "[$release->{distribution}] no repository data returned"
-            };
+            log_info {"[$distribution] no repository data returned"};
             next RELEASE;
         }
 
@@ -237,22 +237,16 @@ sub _github_release_query_filter {
     ];
 }
 
-# True if $url is an absolute URL whose host is github.com. Parsing out the
+# True if $url is an absolute URL whose host is github.com. Checking the parsed
 # host (rather than a prefix match) avoids misclassifying look-alike hosts such
-# as github.com.evil.com. uri_split handles git:// URLs, which URI->new treats
-# as foreign (host-less).
+# as github.com.evil.com. URI::git is loaded so git:// URLs parse to a host
+# rather than a host-less foreign URI.
 sub _is_github_url {
     my ( $self, $url ) = @_;
     return 0 if is_ref($url) || !defined $url || $url eq '';
 
-    my ( $scheme, $authority ) = uri_split($url);
-    return 0 unless defined $scheme && defined $authority;
-
-    # Strip any userinfo@ prefix and :port suffix to get the bare host.
-    ( my $host = $authority ) =~ s/^[^@]*@//;
-    $host =~ s/:[0-9]+\z//;
-
-    return lc($host) eq 'github.com' ? 1 : 0;
+    my $host = eval { URI->new($url)->host };
+    return defined $host && lc($host) eq 'github.com' ? 1 : 0;
 }
 
 # Given a release's resources and the GraphQL repository data, build the

--- a/precious.toml
+++ b/precious.toml
@@ -31,7 +31,6 @@ tidy-flags = [ "--backup-and-modify-in-place", "--backup-file-extension=/" ]
 ok-exit-codes = 0
 lint-failure-exit-codes = 2
 ignore-stderr = "Begin Error Output Stream"
-label = ["perltidy"]
 
 [commands.omegasort-gitignore]
 type = "both"

--- a/t/script/tickets.t
+++ b/t/script/tickets.t
@@ -34,6 +34,53 @@ subtest '_is_github_url' => sub {
     ok !$class->_is_github_url( { web => 'x' } ), 'ref is not a url';
 };
 
+subtest 'github_user_repo_from_resources prefers declared repository' => sub {
+    is_deeply [
+        $class->github_user_repo_from_resources( {
+            repository => { url => 'git://github.com/foo/bar.git' },
+            bugtracker => { web => 'https://github.com/evil/hijack' },
+        } )
+        ],
+        [ 'foo', 'bar' ],
+        'repository.url wins over a github bugtracker pointing elsewhere';
+
+    is_deeply [
+        $class->github_user_repo_from_resources(
+            { repository => { web => 'https://github.com/foo/bar' } }
+        )
+        ],
+        [ 'foo', 'bar' ],
+        'repository.web used when url is absent';
+
+    is_deeply [
+        $class->github_user_repo_from_resources(
+            { homepage => 'https://github.com/foo/bar' }
+        )
+        ],
+        [ 'foo', 'bar' ],
+        'falls back to scanning other resources when there is no repository';
+
+    is_deeply [
+        $class->github_user_repo_from_resources( {
+            repository => { url => 'https://gitlab.com/foo/bar' },
+            homepage   => 'https://github.com/foo/bar',
+        } )
+        ],
+        [ 'foo', 'bar' ],
+        'falls back to scanning when the repository is not on github';
+
+    is_deeply [
+        $class->github_user_repo_from_resources(
+            { homepage => 'https://example.com/' }
+        )
+        ],
+        [],
+        'no github url anywhere returns empty';
+
+    is_deeply [ $class->github_user_repo_from_resources(undef) ], [],
+        'undef resources returns empty';
+};
+
 subtest 'query filter covers repository as well as bugtracker' => sub {
     my $filter = $class->_github_release_query_filter;
 

--- a/t/script/tickets.t
+++ b/t/script/tickets.t
@@ -56,7 +56,9 @@ subtest 'query filter covers repository as well as bugtracker' => sub {
     is $fields{'resources.bugtracker.web'}, 2,
         'bugtracker matched on http(s)';
     is $fields{'resources.repository.url'}, 3,
-        'repository also matched on git://';
+        'repository url also matched on git://';
+    is $fields{'resources.repository.web'}, 3,
+        'repository web also matched on git://';
 
     ok $prefixes{'https://github.com/'}, 'matches https github prefix';
     ok $prefixes{'git://github.com/'},   'matches git github prefix';

--- a/t/script/tickets.t
+++ b/t/script/tickets.t
@@ -4,41 +4,62 @@ use lib 't/lib';
 
 use Test::More;
 
+## no perlimports (loaded for its methods, referenced by name below)
 use MetaCPAN::Script::Tickets ();
+## use perlimports
 
 # These helpers are pure (they don't touch instance state), so we can exercise
-# them as class methods without standing up a full Script object / ES.
+# them as class methods without standing up a full Script object / ES. This is
+# deliberately fragile: if any of these methods grows a dependency on a Moose
+# attribute, these class-method calls will start failing and the test should be
+# converted to use a constructed object.
 my $class = 'MetaCPAN::Script::Tickets';
 
 subtest '_is_github_url' => sub {
-    ok $class->_is_github_url('https://github.com/foo/bar'),     'https';
-    ok $class->_is_github_url('http://github.com/foo/bar'),      'http';
-    ok $class->_is_github_url('git://github.com/foo/bar.git'),   'git';
-    ok !$class->_is_github_url('https://rt.cpan.org/Public/x'),  'rt is not github';
-    ok !$class->_is_github_url('https://gitlab.com/foo/bar'),    'gitlab is not github';
-    ok !$class->_is_github_url(undef),                           'undef';
-    ok !$class->_is_github_url(''),                              'empty string';
-    ok !$class->_is_github_url( { web => 'x' } ),               'ref is not a url';
+    ok $class->_is_github_url('https://github.com/foo/bar'),   'https';
+    ok $class->_is_github_url('http://github.com/foo/bar'),    'http';
+    ok $class->_is_github_url('git://github.com/foo/bar.git'), 'git';
+    ok $class->_is_github_url('https://GitHub.com/foo/bar'),
+        'host is case-insensitive';
+    ok !$class->_is_github_url('https://rt.cpan.org/Public/x'),
+        'rt is not github';
+    ok !$class->_is_github_url('https://gitlab.com/foo/bar'),
+        'gitlab is not github';
+    ok !$class->_is_github_url('https://github.com.evil.com/x'),
+        'look-alike host rejected';
+    ok !$class->_is_github_url('https://www.github.com/foo'),
+        'subdomain is not github.com';
+    ok !$class->_is_github_url(undef),            'undef';
+    ok !$class->_is_github_url(''),               'empty string';
+    ok !$class->_is_github_url( { web => 'x' } ), 'ref is not a url';
 };
 
 subtest 'query filter covers repository as well as bugtracker' => sub {
     my $filter = $class->_github_release_query_filter;
 
     my %fields;
+    my %prefixes;
     for my $clause (@$filter) {
         my ($field) = keys %{ $clause->{prefix} };
         $fields{$field}++;
+        $prefixes{ $clause->{prefix}{$field} }++;
     }
 
     # The fix: star counts must be fetched for dists whose repository is on
     # GitHub even when their bug tracker is not, so the query must match the
     # repository resource fields, not just the bugtracker.
-    ok $fields{'resources.bugtracker.web'},  'matches bugtracker.web';
-    ok $fields{'resources.repository.url'},  'matches repository.url';
-    ok $fields{'resources.repository.web'},  'matches repository.web';
+    ok $fields{'resources.bugtracker.web'}, 'matches bugtracker.web';
+    ok $fields{'resources.repository.url'}, 'matches repository.url';
+    ok $fields{'resources.repository.web'}, 'matches repository.web';
 
-    # Each field is matched against http://, https:// and git:// prefixes.
-    is $fields{'resources.repository.url'}, 3, 'three url prefixes per field';
+    # Bug trackers are http(s) only; repository URLs may also be git://.
+    is $fields{'resources.bugtracker.web'}, 2,
+        'bugtracker matched on http(s)';
+    is $fields{'resources.repository.url'}, 3,
+        'repository also matched on git://';
+
+    ok $prefixes{'https://github.com/'}, 'matches https github prefix';
+    ok $prefixes{'git://github.com/'},   'matches git github prefix';
 };
 
 my $repo_data = {
@@ -61,8 +82,7 @@ subtest 'github bugtracker: stars and issue counts recorded' => sub {
     is_deeply $summary->{repo}{github}, { stars => 42, watchers => 10 },
         'stars and watchers recorded';
 
-    is_deeply $summary->{bugs}{github},
-        {
+    is_deeply $summary->{bugs}{github}, {
         active => 5,    # 3 open issues + 2 open PRs
         open   => 5,
         closed => 9,    # 5 closed issues + 4 closed/merged PRs
@@ -71,9 +91,12 @@ subtest 'github bugtracker: stars and issue counts recorded' => sub {
         'issue counts recorded with bugtracker as source';
 };
 
-subtest 'RT bugtracker + github repo: stars recorded, no github issues' => sub {
+subtest 'RT bugtracker + github repo: stars recorded, no github issues' =>
+    sub {
     my $resources = {
-        bugtracker => { web => 'https://rt.cpan.org/Public/Dist/Display.html?Name=Foo-Bar' },
+        bugtracker => {
+            web => 'https://rt.cpan.org/Public/Dist/Display.html?Name=Foo-Bar'
+        },
         repository => {
             url => 'git://github.com/foo/bar.git',
             web => 'https://github.com/foo/bar',
@@ -87,17 +110,17 @@ subtest 'RT bugtracker + github repo: stars recorded, no github issues' => sub {
 
     ok !exists $summary->{bugs},
         'no github issue counts when GitHub is not the bug tracker';
-};
+    };
 
 subtest 'no bugtracker: stars recorded, no github issues' => sub {
-    my $resources
-        = { repository => { web => 'https://github.com/foo/bar' } };
+    my $resources = { repository => { web => 'https://github.com/foo/bar' } };
 
     my $summary = $class->_github_dist_summary( $resources, $repo_data );
 
     is_deeply $summary->{repo}{github}, { stars => 42, watchers => 10 },
         'stars and watchers recorded';
-    ok !exists $summary->{bugs}, 'no github issue counts without a bug tracker';
+    ok !exists $summary->{bugs},
+        'no github issue counts without a bug tracker';
 };
 
 done_testing();

--- a/t/script/tickets.t
+++ b/t/script/tickets.t
@@ -1,0 +1,103 @@
+use strict;
+use warnings;
+use lib 't/lib';
+
+use Test::More;
+
+use MetaCPAN::Script::Tickets ();
+
+# These helpers are pure (they don't touch instance state), so we can exercise
+# them as class methods without standing up a full Script object / ES.
+my $class = 'MetaCPAN::Script::Tickets';
+
+subtest '_is_github_url' => sub {
+    ok $class->_is_github_url('https://github.com/foo/bar'),     'https';
+    ok $class->_is_github_url('http://github.com/foo/bar'),      'http';
+    ok $class->_is_github_url('git://github.com/foo/bar.git'),   'git';
+    ok !$class->_is_github_url('https://rt.cpan.org/Public/x'),  'rt is not github';
+    ok !$class->_is_github_url('https://gitlab.com/foo/bar'),    'gitlab is not github';
+    ok !$class->_is_github_url(undef),                           'undef';
+    ok !$class->_is_github_url(''),                              'empty string';
+    ok !$class->_is_github_url( { web => 'x' } ),               'ref is not a url';
+};
+
+subtest 'query filter covers repository as well as bugtracker' => sub {
+    my $filter = $class->_github_release_query_filter;
+
+    my %fields;
+    for my $clause (@$filter) {
+        my ($field) = keys %{ $clause->{prefix} };
+        $fields{$field}++;
+    }
+
+    # The fix: star counts must be fetched for dists whose repository is on
+    # GitHub even when their bug tracker is not, so the query must match the
+    # repository resource fields, not just the bugtracker.
+    ok $fields{'resources.bugtracker.web'},  'matches bugtracker.web';
+    ok $fields{'resources.repository.url'},  'matches repository.url';
+    ok $fields{'resources.repository.web'},  'matches repository.web';
+
+    # Each field is matched against http://, https:// and git:// prefixes.
+    is $fields{'resources.repository.url'}, 3, 'three url prefixes per field';
+};
+
+my $repo_data = {
+    openIssues         => { totalCount => 3 },
+    closedIssues       => { totalCount => 5 },
+    openPullRequests   => { totalCount => 2 },
+    closedPullRequests => { totalCount => 4 },
+    watchers           => { totalCount => 10 },
+    stargazerCount     => 42,
+};
+
+subtest 'github bugtracker: stars and issue counts recorded' => sub {
+    my $resources = {
+        bugtracker => { web => 'https://github.com/foo/bar/issues' },
+        repository => { web => 'https://github.com/foo/bar' },
+    };
+
+    my $summary = $class->_github_dist_summary( $resources, $repo_data );
+
+    is_deeply $summary->{repo}{github}, { stars => 42, watchers => 10 },
+        'stars and watchers recorded';
+
+    is_deeply $summary->{bugs}{github},
+        {
+        active => 5,    # 3 open issues + 2 open PRs
+        open   => 5,
+        closed => 9,    # 5 closed issues + 4 closed/merged PRs
+        source => 'https://github.com/foo/bar/issues',
+        },
+        'issue counts recorded with bugtracker as source';
+};
+
+subtest 'RT bugtracker + github repo: stars recorded, no github issues' => sub {
+    my $resources = {
+        bugtracker => { web => 'https://rt.cpan.org/Public/Dist/Display.html?Name=Foo-Bar' },
+        repository => {
+            url => 'git://github.com/foo/bar.git',
+            web => 'https://github.com/foo/bar',
+        },
+    };
+
+    my $summary = $class->_github_dist_summary( $resources, $repo_data );
+
+    is_deeply $summary->{repo}{github}, { stars => 42, watchers => 10 },
+        'stars and watchers recorded even though bug tracker is RT';
+
+    ok !exists $summary->{bugs},
+        'no github issue counts when GitHub is not the bug tracker';
+};
+
+subtest 'no bugtracker: stars recorded, no github issues' => sub {
+    my $resources
+        = { repository => { web => 'https://github.com/foo/bar' } };
+
+    my $summary = $class->_github_dist_summary( $resources, $repo_data );
+
+    is_deeply $summary->{repo}{github}, { stars => 42, watchers => 10 },
+        'stars and watchers recorded';
+    ok !exists $summary->{bugs}, 'no github issue counts without a bug tracker';
+};
+
+done_testing();


### PR DESCRIPTION
Closes #1477

## Problem

GitHub star/watcher counts were only fetched for distributions whose **bug tracker** was GitHub issues. A dist that uses RT (or any non-GitHub tracker) but hosts its code on GitHub never had its star count fetched.

While fixing this I found a deeper bug: `index_github_bugs` has been a **silent no-op since November 2024**. Commit 7c471c01 migrated the loop from a model scroll (`$release->resources`) to a raw Elasticsearch `scroll_helper` but kept top-level hash access (`$release->{resources}`, `$release->{distribution}`). Raw ES hits store fields under `_source`, so both reads returned `undef`, every release was skipped, and **no GitHub bug or star data was being updated at all**.

## Changes

- **Read release fields from `_source`** in `index_github_bugs`, matching `check_all_distributions` and every other script. This restores the feature.
- **Decouple star fetching from bug counting**: the release query now also matches `resources.repository.url` / `resources.repository.web`, and `_github_dist_summary` records stars/watchers for any dist with a GitHub repo while recording GitHub issue counts only when GitHub issues are the bug tracker.
- **`_is_github_url`** parses the URL and compares its host to `github.com` (via `URI->new->host`) instead of a prefix match, rejecting look-alike hosts such as `github.com.evil.com`. Adds `URI::git` (cpanfile + snapshot) so `git://` URLs resolve a host.
- The `git://` scheme is matched only against repository URL fields (bug trackers are always http(s)).
- Skip releases lacking a `distribution`, and skip a null `repository` in an otherwise-successful GraphQL response before dereferencing it.

## Testing

- New `t/script/tickets.t` unit tests for the host check, the query filter, and the star-vs-issue decision logic (including the RT-bugtracker-plus-GitHub-repo case that motivates the fix).
- `prove t/script/tickets.t t/script/load.t` passes; `precious lint` clean (perlimports/perlcritic/perltidy).
- Red-green verified: simulating the old coupled behavior makes the decoupling tests fail.
- `cpm install --resolver=snapshot URI::git` resolves from the new snapshot stanza.
- Not verified end-to-end: a live `index_github_bugs` run needs a GitHub token and ES release fixtures, which weren't available here. The `_source` fix is verified by consistency with the rest of the codebase rather than an integration test.
