### PR TITLE
use Pod::Simple to convert pod to text

### DIFF
--- a/lib/MetaCPAN/Util.pm
+++ b/lib/MetaCPAN/Util.pm
@@ -7,15 +7,16 @@ use warnings;
 use version;
 use warnings FATAL => 'utf8';
 
-use Cpanel::JSON::XS ();                           ## no perlimports
-use Cwd              ();
-use Digest::SHA      qw( sha1_base64 sha1_hex );
-use Unicode::UTF8    qw( decode_utf8 );
-use File::Basename   ();
-use File::Spec       ();
-use List::Util       qw( max min );
-use Types::Standard  qw( Int );
-use Ref::Util        qw(
+use Cpanel::JSON::XS         ();                           ## no perlimports
+use Cwd                      ();
+use Digest::SHA              qw( sha1_base64 sha1_hex );
+use Unicode::UTF8            qw( decode_utf8 );
+use File::Basename           ();
+use File::Spec               ();
+use List::Util               qw( max min );
+use Types::Standard          qw( Int );
+use Pod::Simple::TextContent ();
+use Ref::Util                qw(
     is_arrayref
     is_hashref
     is_plain_arrayref
@@ -169,12 +170,15 @@ sub simplify_total {
     return;
 }
 
-# TODO: E<escape>
 sub strip_pod {
     my $pod = shift;
-    $pod =~ s/L<([^\/]*?)\/([^\/]*?)>/$2 in $1/g;
-    $pod =~ s/\w<(.*?)(\|.*?)?>/$1/g;
-    return $pod;
+    my $output;
+    my $parser = Pod::Simple::TextContent->new;
+    $parser->output_string( \$output );
+    $parser->parse_string_document("=pod\n\n$pod");
+    $output =~ s/\A\n+//;
+    $output =~ s/\n+\z//;
+    return $output;
 }
 
 sub extract_section {

--- a/t/util.t
+++ b/t/util.t
@@ -60,7 +60,7 @@ is(
 );
 is(
     strip_pod('hello L<Module/section> foo'),
-    'hello section in Module foo',
+    'hello "section" in Module foo',
     'strip_pod strips internal links'
 );
 is(
@@ -72,6 +72,11 @@ is(
     strip_pod('without a leading C<$>.'),
     'without a leading $.',
     'strip_pod strips C<>'
+);
+is(
+    strip_pod('character E<gt> escape'),
+    'character > escape',
+    'strip_pod processes E<> escapes'
 );
 
 sub version {


### PR DESCRIPTION
Pod formatting codes are best handled by a real parser, not a regex. Using Pod::Simple for this causes slightly different formatting for section links, but also properly handles E<> escapes.