### PR TITLE
Tidy lib/MetaCPAN/Query/File.pm with perltidy

### DIFF
--- a/lib/MetaCPAN/Query/File.pm
+++ b/lib/MetaCPAN/Query/File.pm
@@ -454,7 +454,7 @@ sub _autocomplete {
                $a_data->{deprecated} <=> $b_data->{deprecated}
             || $b_data->{favorites}  <=> $a_data->{favorites}
             || length($a)            <=> length($b)
-            || $a cmp $b
+            || $a                    cmp $b
         }
         keys %valid;
 


### PR DESCRIPTION
Runs `perltidy` (project `.perltidyrc`) on `lib/MetaCPAN/Query/File.pm`, which currently fails `precious lint --all` on `master`. The only change aligns the trailing `cmp` operator in the `_autocomplete` sort block — whitespace only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N6oJpF2cBxDcSPevtz6n6Z